### PR TITLE
Add planning gate - require plan approval before workflow execution

### DIFF
--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -53,7 +53,7 @@ export type WorkflowRunRecord = {
   workflowId: string;
   workflowName?: string;
   taskTitle: string;
-  status: "running" | "paused" | "blocked" | "completed" | "canceled";
+  status: "pending_plan" | "running" | "paused" | "blocked" | "completed" | "canceled";
   leadAgentId: string;
   leadSessionLabel: string;
   currentStepIndex: number;
@@ -61,6 +61,13 @@ export type WorkflowRunRecord = {
   stepResults: StepResult[];
   retryCount: number;
   context: Record<string, string>;
+  // Planning fields - required before execution
+  plan?: string;
+  acceptanceCriteria?: string[];
+  plannedAt?: string;
+  plannedBy?: string;
+  // Tracking for planning pings
+  lastPlanPingAt?: string;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## Summary

Workflows now require planning approval before agents execute. This ensures the main agent discusses requirements with the human before kicking off work.

## Changes

- `workflow run` creates runs with `pending_plan` status (not `running`)
- Orchestrator writes pending_plan runs to `~/.openclaw/antfarm/planning-queue/`
- New CLI command: `antfarm planning` - lists runs waiting for planning
- New CLI command: `antfarm workflow plan <task>` - approves plan with JSON from stdin
- Plan and acceptance criteria stored in run context for agents to use
- Automatically removes from planning queue on approval

## Flow

1. User requests workflow → `antfarm workflow run feature-dev "build X"`
2. Run created with `pending_plan` status
3. Orchestrator writes to planning queue
4. Main agent checks queue, discusses with human
5. Main agent approves: `echo '{"plan": "...", "acceptanceCriteria": [...]}' | antfarm workflow plan "build X"`
6. Run status → `running`, orchestrator spawns agents