### PR TITLE
feat: add multiply() helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,14 @@ Steps:
   [pending] review (reviewer)
 ```
 
+### Library usage
+
+```ts
+import { multiply } from "antfarm";
+
+console.log(multiply(2, 3)); // 6
+```
+
 ---
 
 ## Build Your Own

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/server/index.html dist/server/index.html && chmod +x dist/cli/cli.js",
-    "start": "node dist/cli/cli.js"
+    "start": "node dist/cli/cli.js",
+    "test": "npm run build && node --test dist/**/*.test.js"
   },
   "dependencies": {
     "json5": "^2.2.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./installer/install.js";
 export * from "./db.js";
+export * from "./lib/multiply.js";

--- a/src/lib/multiply.test.ts
+++ b/src/lib/multiply.test.ts
@@ -1,0 +1,22 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { multiply } from "./multiply.js";
+
+describe("multiply", () => {
+  it("multiplies positive integers", () => {
+    assert.equal(multiply(2, 3), 6);
+  });
+
+  it("multiplies with negatives", () => {
+    assert.equal(multiply(-2, 3), -6);
+  });
+
+  it("multiplies by zero", () => {
+    assert.equal(multiply(0, 5), 0);
+  });
+
+  it("multiplies decimals", () => {
+    assert.equal(multiply(2.5, 2), 5);
+  });
+});

--- a/src/lib/multiply.ts
+++ b/src/lib/multiply.ts
@@ -1,0 +1,6 @@
+/**
+ * Multiply two numbers.
+ */
+export function multiply(a: number, b: number): number {
+  return a * b;
+}


### PR DESCRIPTION
Adds a typed multiply(a,b) helper exported from the package.

Why:
- Provides a small utility and a clear example of how to add library code + tests.

Tests:
- npm test