### PR TITLE
fix: use consistent step names (not UUIDs) in emitted events

### DIFF
--- a/src/installer/events.ts
+++ b/src/installer/events.ts
@@ -18,6 +18,7 @@ export interface AntfarmEvent {
   event: EventType;
   runId: string;
   workflowId?: string;
+  /** Human-readable step name (e.g. "plan", "implement"), NOT the internal UUID. */
   stepId?: string;
   agentId?: string;
   storyId?: string;


### PR DESCRIPTION
## Problem

`stepId` in `AntfarmEvent` was inconsistent — some code paths in `step-ops.ts` passed `step.id` (internal UUID primary key) while others passed `step.step_id` (the human-readable name from workflow YAML like `plan`, `implement`, `review`).

This affects all event consumers — the `events.jsonl` log, the Antfarm dashboard (`getRunEvents()`), and any webhook subscriber. Any consumer relying on `stepId` being a stable, meaningful identifier would get unpredictable UUIDs for some events and names for others.

## Changes

- All `emitEvent()` calls now consistently use `step.step_id` (name)
- Updated `claimStep` and `advancePipeline` queries to `SELECT step_id`
- Documented the `stepId` contract on the `AntfarmEvent` interface

## Affected events

`step.running`, `step.done`, `story.started`, `story.done`, `story.verified`, `story.failed`, `story.retry`, `pipeline.advanced`, `step.pending`

The error-path events (`step.timeout`, `step.failed` with retries exhausted) were already correct.