### PR TITLE
fix: separate abandoned step tracking from explicit failures

### DIFF
--- a/src/db.ts
+++ b/src/db.ts
@@ -82,6 +82,9 @@ function migrate(db: DatabaseSync): void {
   if (!colNames.has("current_story_id")) {
     db.exec("ALTER TABLE steps ADD COLUMN current_story_id TEXT");
   }
+  if (!colNames.has("abandoned_count")) {
+    db.exec("ALTER TABLE steps ADD COLUMN abandoned_count INTEGER DEFAULT 0");
+  }
 
   // Add columns to runs table for backwards compat
   const runCols = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;


### PR DESCRIPTION
Agents sometimes complete work but fail to call 'step complete' before their session ends. Previously this was treated identically to explicit failures, burning through max_retries (default 2) quickly and failing the entire run — even though the work was done.

Changes:
- Track abandoned_count separately from retry_count
- Abandoned steps get 5 resets before failing (MAX_ABANDON_RESETS)
- Only explicit failStep() calls count against retry_count/max_retries
- Abandoned stories reset to pending without incrementing retry_count
- Done stories are never touched during cleanup
- Increased ABANDONED_THRESHOLD_MS from 15 to 20 minutes