### PR TITLE
fix: datetime format mismatch in cleanupAbandonedSteps causes immediate step abandonment

### DIFF
--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -202,7 +202,8 @@ const ABANDONED_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
  */
 function cleanupAbandonedSteps(): void {
   const db = getDb();
-  const cutoff = new Date(Date.now() - ABANDONED_THRESHOLD_MS).toISOString();
+  // Use SQLite-compatible datetime format (space separator, no T/Z) to match datetime('now') output
+  const cutoff = new Date(Date.now() - ABANDONED_THRESHOLD_MS).toISOString().replace("T", " ").replace(/\.\d{3}Z$/, "");
 
   // Find running steps that haven't been updated recently
   const abandonedSteps = db.prepare(


### PR DESCRIPTION
## Bug

`cleanupAbandonedSteps()` compares a JavaScript `toISOString()` cutoff timestamp against SQLite `datetime('now')`-formatted `updated_at` values. 

- JS: `2026-02-11T09:24:21.000Z` (with `T` separator)
- SQLite: `2026-02-11 09:24:21` (with space separator)

Because `'T'` (ASCII 84) > `' '` (ASCII 32), the SQL comparison `updated_at < cutoff` is **always true**, regardless of the 15-minute threshold. Every running step is immediately flagged as abandoned.

## Impact

All workflows fail within seconds of starting. Loop steps (like `implement` with `verify_each`) are especially affected because they stay in `running` state while waiting for verification — cleanup kills them before the verifier can even poll.

## Fix

Convert the JS cutoff timestamp to SQLite-compatible format by replacing `T` with a space and stripping the `.000Z` suffix.

## Testing

Before fix: feature-dev and security-audit workflows failed 4 consecutive times, with steps being abandoned 25-44 seconds after completion.

After fix: workflows advance through stories correctly with the 15-minute threshold working as intended.