### PR TITLE
feat: add helixa-identity workflow — onchain agent identity registration

### DIFF
--- a/workflows/helixa-identity/README.md
+++ b/workflows/helixa-identity/README.md
@@ -1,0 +1,61 @@
+# Helixa Identity Workflow for Antfarm
+
+Register your entire agent team's onchain identities in one command.
+
+## What It Does
+
+1. **Discovers** all agents in your OpenClaw workspace
+2. **Registers** each one via the Helixa gasless API (no wallet needed)
+3. **Claims** `.agent` names for each agent
+4. **Verifies** all registrations onchain
+
+## Install
+
+```bash
+# Copy to your antfarm workflows directory
+cp -r helixa-identity ~/.openclaw/workspace/antfarm/workflows/
+
+# Or if using antfarm CLI
+antfarm workflow install helixa-identity
+```
+
+## Run
+
+```bash
+antfarm workflow run helixa-identity "Register all agents in this workspace"
+```
+
+## What Each Agent Gets
+
+- **AgentDNA NFT** on Base (ERC-8004 compliant)
+- **`.agent` name** (e.g., `planner.agent`, `developer.agent`)
+- **Points** toward future $DNA token allocation (2x for first 100 agents)
+- **Directory listing** at [helixa.xyz/directory.html](https://helixa.xyz/directory.html)
+
+## Requirements
+
+- OpenClaw with Antfarm installed
+- Internet access (for API calls)
+- That's it. No wallet, no ETH, no browser. We pay the gas.
+
+## API
+
+All registration goes through the gasless API:
+
+```
+POST https://api.helixa.xyz/api/mint
+GET  https://api.helixa.xyz/api/name/:name
+GET  https://api.helixa.xyz/api/agent/:id
+GET  https://api.helixa.xyz/api/stats
+```
+
+## Contracts
+
+- **AgentDNA**: `0x665971e7bf8ec90c3066162c5b396604b3cd7711` (Base)
+- **AgentNames**: `0xDE8c422D2076CbAE0cA8f5dA9027A03D48928F2d` (Base)
+
+## Links
+
+- [helixa.xyz](https://helixa.xyz)
+- [Agent Directory](https://helixa.xyz/directory.html)
+- [Skill Reference](https://github.com/Bendr-20/helixa-mint-skill)

--- a/workflows/helixa-identity/agents/registrar/AGENTS.md
+++ b/workflows/helixa-identity/agents/registrar/AGENTS.md
@@ -1,0 +1,35 @@
+# Registrar Agent
+
+You register AI agent identities onchain via the Helixa platform.
+
+## Your Job
+- Discover agents in the workspace
+- Register each one via the gasless API (POST https://api.helixa.xyz/api/mint)
+- Claim .agent names for each
+- Record wallet addresses and token IDs
+
+## Key Info
+- API: https://api.helixa.xyz
+- Contract: 0x665971e7bf8ec90c3066162c5b396604b3cd7711 (Base mainnet)
+- Names contract: 0xDE8c422D2076CbAE0cA8f5dA9027A03D48928F2d
+- Free during beta (first 100 agents)
+- No wallet or ETH needed — API pays gas
+
+## API Examples
+
+### Mint
+```bash
+curl -X POST https://api.helixa.xyz/api/mint \
+  -H "Content-Type: application/json" \
+  -d '{"name":"MyAgent","agentAddress":"0x...","framework":"openclaw","agentName":"myagent"}'
+```
+
+### Check .agent name
+```bash
+curl -s https://api.helixa.xyz/api/name/myagent
+```
+
+### Check stats
+```bash
+curl -s https://api.helixa.xyz/api/stats
+```

--- a/workflows/helixa-identity/agents/registrar/IDENTITY.md
+++ b/workflows/helixa-identity/agents/registrar/IDENTITY.md
@@ -1,0 +1,5 @@
+# IDENTITY.md
+- **Name:** Registrar
+- **Creature:** Identity clerk
+- **Vibe:** Precise, reliable
+- **Emoji:** 🪪

--- a/workflows/helixa-identity/agents/registrar/SOUL.md
+++ b/workflows/helixa-identity/agents/registrar/SOUL.md
@@ -1,0 +1,2 @@
+# SOUL.md
+You're methodical and thorough. You register identities one at a time, verify each registration succeeded before moving on, and keep clean records. No shortcuts.

--- a/workflows/helixa-identity/agents/verifier/AGENTS.md
+++ b/workflows/helixa-identity/agents/verifier/AGENTS.md
@@ -1,0 +1,14 @@
+# Verifier Agent
+
+You verify that agent identities were correctly registered onchain.
+
+## Your Job
+- Check each registration via the API
+- Verify .agent names resolve correctly
+- Confirm agents appear in the directory
+- Report any issues
+
+## Verification Steps
+1. GET https://api.helixa.xyz/api/agent/<tokenId> — should return agent data
+2. GET https://api.helixa.xyz/api/name/<agentName> — should show owner address
+3. Cross-check wallet addresses match

--- a/workflows/helixa-identity/agents/verifier/IDENTITY.md
+++ b/workflows/helixa-identity/agents/verifier/IDENTITY.md
@@ -1,0 +1,5 @@
+# IDENTITY.md
+- **Name:** Verifier
+- **Creature:** Auditor
+- **Vibe:** Skeptical, thorough
+- **Emoji:** 🔍

--- a/workflows/helixa-identity/agents/verifier/SOUL.md
+++ b/workflows/helixa-identity/agents/verifier/SOUL.md
@@ -1,0 +1,2 @@
+# SOUL.md
+You're skeptical by nature. You don't trust that things worked just because someone said they did. You verify everything onchain.

--- a/workflows/helixa-identity/workflow.yml
+++ b/workflows/helixa-identity/workflow.yml
@@ -1,0 +1,127 @@
+id: helixa-identity
+name: Agent Identity Registration
+version: 1
+description: |
+  Register your agent team's onchain identities on Base via Helixa.
+  Each agent gets an AgentDNA NFT (ERC-8004) and a .agent name.
+  Free during beta (first 100 agents). Zero wallet needed — uses gasless API.
+  
+  What you get:
+  - Onchain identity NFT on Base (ERC-8004 compliant)
+  - .agent name (e.g., planner.agent, developer.agent)
+  - Points toward future $DNA token allocation
+  - Entry in the searchable agent directory at helixa.xyz/directory.html
+
+agents:
+  - id: registrar
+    name: Registrar
+    role: coding
+    description: Registers agent identities via the Helixa gasless API.
+    workspace:
+      baseDir: agents/registrar
+      files:
+        AGENTS.md: agents/registrar/AGENTS.md
+        SOUL.md: agents/registrar/SOUL.md
+        IDENTITY.md: agents/registrar/IDENTITY.md
+
+  - id: verifier
+    name: Verifier
+    role: verification
+    description: Verifies all agents were registered successfully onchain.
+    workspace:
+      baseDir: agents/verifier
+      files:
+        AGENTS.md: agents/verifier/AGENTS.md
+        SOUL.md: agents/verifier/SOUL.md
+        IDENTITY.md: agents/verifier/IDENTITY.md
+
+steps:
+  - id: discover
+    agent: registrar
+    input: |
+      Discover all agents in this OpenClaw workspace that need onchain identities.
+
+      TASK:
+      {{task}}
+
+      Instructions:
+      1. Look for agent definitions in the workspace (AGENTS.md, SOUL.md, IDENTITY.md files)
+      2. Check antfarm workflow configs for agent definitions
+      3. For each agent found, collect: name, role/description, framework (openclaw)
+      4. Generate a suggested .agent name for each (lowercase, alphanumeric + hyphens, 3-32 chars)
+      5. Check .agent name availability via: curl -s https://api.helixa.xyz/api/name/<name>
+
+      Reply with:
+      STATUS: done
+      AGENTS_JSON: [ { "name": "AgentName", "agentName": "suggested-name", "description": "what it does", "framework": "openclaw" } ]
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: register
+    agent: registrar
+    type: loop
+    loop:
+      over: agents_discovered
+      completion: all_done
+      fresh_session: true
+    input: |
+      Register this agent's onchain identity via the Helixa gasless API.
+
+      CURRENT AGENT:
+      {{current_item}}
+
+      COMPLETED AGENTS:
+      {{completed_items}}
+
+      Instructions:
+      1. Generate a wallet address for this agent if it doesn't have one:
+         node -e "const w = require('ethers').Wallet.createRandom(); console.log(w.address)"
+      2. Call the gasless mint API:
+         curl -X POST https://api.helixa.xyz/api/mint \
+           -H "Content-Type: application/json" \
+           -d '{
+             "name": "<agent name>",
+             "agentAddress": "<wallet address>",
+             "framework": "openclaw",
+             "description": "<agent description>",
+             "agentName": "<dot-agent-name>",
+             "soulbound": false
+           }'
+      3. Record the response (tokenId, txHash, agentName)
+
+      Reply with:
+      STATUS: done
+      TOKEN_ID: <id>
+      TX_HASH: <hash>
+      AGENT_NAME: <name>.agent
+      WALLET: <address>
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: verify
+    agent: verifier
+    input: |
+      Verify all agent identities were registered onchain.
+
+      REGISTERED AGENTS:
+      {{registered_agents}}
+
+      Instructions:
+      1. For each registered agent, verify onchain:
+         curl -s https://api.helixa.xyz/api/agent/<tokenId>
+      2. Verify .agent name resolves:
+         curl -s https://api.helixa.xyz/api/name/<agentName>
+      3. Check the agent directory: https://helixa.xyz/directory.html
+      4. Create a summary report
+
+      Reply with:
+      STATUS: done
+      VERIFIED: <count> agents verified onchain
+      REPORT: summary of all registered identities
+    expects: "STATUS: done"
+    on_fail:
+      escalate_to: human


### PR DESCRIPTION
## helixa-identity workflow

A community workflow that registers agent team identities on Base via [Helixa](https://helixa.xyz) (ERC-8004 compliant).

### What it does

1. **Discovers** all agents in the OpenClaw workspace
2. **Registers** each via gasless API (no wallet or ETH needed)
3. **Claims** `.agent` names per agent
4. **Verifies** all registrations onchain

### What agents get

- AgentDNA NFT on Base (ERC-8004)
- `.agent` name (e.g., `planner.agent`)
- Early adopter points (2x for first 100)
- Listing in the [agent directory](https://helixa.xyz/directory.html)

### Usage

```bash
antfarm workflow run helixa-identity "Register all agents"
```

### No wallet needed

The gasless API pays gas from the Helixa deployer. Zero friction — just HTTP POST calls.

### Links

- Contract: [`0x665971e7bf8ec90c3066162c5b396604b3cd7711`](https://basescan.org/address/0x665971e7bf8ec90c3066162c5b396604b3cd7711) (Base)
- API: https://api.helixa.xyz
- Skill: https://github.com/Bendr-20/helixa-mint-skill
- Site: https://helixa.xyz