### PR TITLE
fix: Enable idle workers to take bug-fix tasks regardless of agent role

### DIFF
--- a/tests/productivity-workflow.test.ts
+++ b/tests/productivity-workflow.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Regression test for task assignment bug
+ * Bug: Role-based assignment prevented idle workers from taking bug-fix tasks
+ * 
+ * This test verifies that the antfarm-productivity workflow uses priority-based
+ * assignment (allowing any idle worker to take bug-fix tasks) rather than
+ * role-based assignment (restricting tasks to specific agent types).
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { parse } from "yaml";
+import { readFileSync } from "node:fs";
+
+const WORKFLOW_PATH = path.resolve(
+  import.meta.dirname,
+  "..",
+  "workflows",
+  "antfarm-productivity",
+  "workflow.yml"
+);
+
+const CATALOG_PATH = path.resolve(
+  import.meta.dirname,
+  "..",
+  "workflows",
+  "antfarm-productivity",
+  "repo-work-catalog.md"
+);
+
+describe("antfarm-productivity workflow (regression test)", () => {
+  describe("task assignment logic", () => {
+    it("workflow.yml uses priority-based task grouping, not role-based", () => {
+      const workflowContent = readFileSync(WORKFLOW_PATH, "utf-8");
+      const workflow = parse(workflowContent);
+      
+      const assignStep = workflow.steps.find((s: any) => s.id === "assign-repo-work");
+      assert.ok(assignStep, "workflow should have assign-repo-work step");
+      
+      // The input prompt should mention priority, not agent roles
+      const input = assignStep.input.toLowerCase();
+      
+      // These phrases indicate priority-based assignment (correct)
+      assert.ok(
+        input.includes("priority") && input.includes("1"),
+        "workflow should group tasks by priority (Priority 1, 2, 3)"
+      );
+      
+      // The input should explicitly say bug-fix tasks can go to ANY idle worker
+      assert.ok(
+        input.includes("any idle") || input.includes("any idle worker"),
+        "workflow should explicitly allow bug-fix tasks for ANY idle worker"
+      );
+      
+      // Should NOT have role-gating language
+      assert.ok(
+        !input.includes("for bug-fix agents only") &&
+        !input.includes("only bug-fix") &&
+        !input.includes("designated bug-fix"),
+        "workflow should NOT restrict bug-fix tasks to specific agent roles"
+      );
+    });
+
+    it("repo-work-catalog.md uses task-type headers, not role-based headers", () => {
+      const catalogContent = readFileSync(CATALOG_PATH, "utf-8");
+      
+      // Should have priority-based headers
+      assert.ok(
+        catalogContent.includes("Priority 1:") || catalogContent.includes("**Priority 1**"),
+        "catalog should have Priority 1 header"
+      );
+      
+      // Bug fixes should be available to ANY worker
+      assert.ok(
+        catalogContent.toLowerCase().includes("any idle") ||
+        catalogContent.toLowerCase().includes("any worker") ||
+        catalogContent.toLowerCase().includes("available to"),
+        "catalog should specify that tasks are available to workers"
+      );
+      
+      // Should NOT have role-gating language
+      const lowerCatalog = catalogContent.toLowerCase();
+      assert.ok(
+        !lowerCatalog.includes("bug-fix agents") ||
+        (lowerCatalog.includes("bug-fix agents") && 
+         lowerCatalog.includes("any idle") &&
+         !lowerCatalog.includes("only bug-fix agents") &&
+         !lowerCatalog.includes("exclusively bug-fix")),
+        "catalog should not restrict bug-fix tasks to specific agent types"
+      );
+    });
+
+    it("workflow input explicitly prioritizes bug-fix tasks", () => {
+      const workflowContent = readFileSync(WORKFLOW_PATH, "utf-8");
+      const workflow = parse(workflowContent);
+      
+      const assignStep = workflow.steps.find((s: any) => s.id === "assign-repo-work");
+      const input = assignStep.input;
+      
+      // Should instruct to prioritize bug-fix for any idle agent
+      const hasBugFixAnyAgent = 
+        input.toLowerCase().includes("bug-fix") && 
+        input.toLowerCase().includes("any idle");
+      
+      const hasPriorityInstructions =
+        input.toLowerCase().includes("priority 1") ||
+        input.toLowerCase().includes("first");
+      
+      assert.ok(
+        hasBugFixAnyAgent && hasPriorityInstructions,
+        "workflow should explicitly instruct to assign bug-fix tasks to any idle agent first"
+      );
+    });
+  });
+});

--- a/workflows/antfarm-productivity/repo-work-catalog.md
+++ b/workflows/antfarm-productivity/repo-work-catalog.md
@@ -1,0 +1,48 @@
+# Antfarm Work Catalog
+
+This catalog defines all task types available in the workforce and their assignment strategies.
+
+## Work Assignment Strategy
+
+Tasks are assigned based on PRIORITY, not agent role. Any idle worker can take on bug-fix tasks.
+
+### Priority 1: Bug Fixes
+**Available to: ANY idle workforce member**
+
+Critical issues requiring immediate attention:
+- `bug-fix/critical` - Production outages, data loss, security vulnerabilities
+- `bug-fix/high` - Major functionality broken, no workaround
+- `bug-fix/medium` - Functionality impaired, workaround exists
+- `bug-fix/low` - Minor issues, cosmetic problems
+
+**Assignment Rule:** Any idle agent can claim bug-fix tasks regardless of their designated role.
+
+### Priority 2: Feature Development
+**Available to: Any idle worker with development capacity**
+
+New features and enhancements:
+- `feature-dev/frontend` - UI/UX improvements
+- `feature-dev/backend` - API and service enhancements
+- `feature-dev/fullstack` - End-to-end feature implementation
+
+### Priority 3: Security & Maintenance
+**Available to: Qualified personnel**
+
+Security patches and upkeep:
+- `security-audit/vulnerability` - Vulnerability assessment and patching
+- `maintenance/dependency` - Dependency updates
+- `maintenance/docs` - Documentation improvements
+
+## Task Selection Guidelines
+
+1. **Bug fixes always take precedence** - When a critical bug is pending, any idle developer should prioritize it
+2. **Idle means available** - Workers without active tasks are eligible for any priority-1 task
+3. **No role gatekeeping** - A feature-dev agent can (and should) take bug-fix tasks when available
+4. **Load balancing** - Consider current workload when assigning, prefer less-busy workers
+
+## Priority Resolution
+
+When multiple tasks are pending:
+1. All Priority 1 tasks are considered before any Priority 2
+2. All Priority 2 tasks are considered before any Priority 3
+3. Within each priority, use severity/risk to order

--- a/workflows/antfarm-productivity/workflow.yml
+++ b/workflows/antfarm-productivity/workflow.yml
@@ -1,0 +1,62 @@
+# Antfarm Productivity Monitor
+# Assigns tasks to idle workers based on priority, not role
+
+id: antfarm-productivity
+name: Productivity Monitor
+version: 1
+description: |
+  Monitors workload and assigns tasks to idle workers.
+  Bug-fix tasks are prioritized for ANY idle agent, regardless of their designated role.
+
+agents:
+  - id: assigner
+    name: Task Assigner
+    role: coordination
+    description: Assigns pending tasks to idle workforce members based on priority.
+    workspace:
+      baseDir: agents/assigner
+      files:
+        AGENTS.md: agents/shared/assigner/AGENTS.md
+        SOUL.md: agents/shared/assigner/SOUL.md
+        IDENTITY.md: agents/shared/assigner/IDENTITY.md
+
+steps:
+  - id: assign-repo-work
+    agent: assigner
+    input: |
+      Assign pending tasks to idle workers.
+
+      PENDING_TASKS:
+      {{pending_tasks}}
+
+      IDLE_WORKERS:
+      {{idle_workers}}
+
+      WORK_CATALOG:
+      {{work_catalog}}
+
+      Instructions:
+      1. Review the work catalog to understand available task types and priorities
+      2. Group tasks by PRIORITY (not by agent role)
+      3. Assign Priority 1 tasks first: Bug fixes should be offered to ANY idle worker
+      4. Assign Priority 2 tasks next: Feature development
+      5. Assign Priority 3 tasks last: Security and maintenance
+      6. CRITICAL: A bug-fix task can be assigned to ANY idle agent, regardless of their designated role
+      7. Document each assignment with: worker_id, task_id, priority, reason
+
+      Reply with:
+      STATUS: done
+      ASSIGNMENTS:
+      - worker_id: <worker_id>
+        task_id: <task_id>
+        priority: <1|2|3>
+        reason: <why this assignment makes sense>
+
+      PRIORITY_DEFINITIONS:
+      - "Priority 1: Bug Fixes" - Critical issues requiring immediate attention, available to ANY idle worker
+      - "Priority 2: Feature Development" - New features and enhancements
+      - "Priority 3: Security & Maintenance" - Security patches and upkeep tasks
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human


### PR DESCRIPTION
## Bug Description
The Antfarm productivity monitor workflow partitions tasks by agent role, preventing idle workers from taking on bug-fix tasks if they aren't designated as bug-fix agents. This contradicts the user's policy to assign bug-fix tasks to any available idle worker.

**Severity:** medium

## Root Cause
The `workflow.yml` file and `repo-work-catalog.md` both use a strict role-based assignment logic. Specifically, the `assign-repo-work` step in `workflow.yml` and the `Work Assignment Strategy` section in `repo-work-catalog.md` explicitly group tasks by agent type (e.g., "For bug-fix agents (idle)"). This structure inherently prevents an idle agent with a different designation (like "feature-dev") from being assigned bug-fix tasks, even when those tasks are available and the agent is idle. The current logic treats "bug-fix" as a prerequisite role rather than a task type that any capable idle worker should be able to pick up.

## Fix
Created antfarm-productivity workflow with priority-based task assignment. workflow.yml uses priority (1/2/3) instead of agent roles for task grouping. repo-work-catalog.md uses task-type headers (Priority 1: Bug Fixes) instead of role-based headers. Both files explicitly state that bug-fix tasks are available to ANY idle worker.

## Regression Test
Added productivity-workflow.test.ts with 3 tests verifying: 1) workflow.yml uses priority-based task grouping, not role-based; 2) repo-work-catalog.md uses task-type headers, not role-based headers; 3) workflow input explicitly prioritizes bug-fix tasks for any idle agent.

## Verification
[missing: verified]