### PR TITLE
feat: human gate steps with delivery instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## v0.3.0 — 2026-02-11
+
+### Added
+- **Human gate steps** — workflows can now include `gate: true` steps that pause execution and wait for human approval before advancing. This lets you insert review checkpoints into any pipeline (e.g. approve a spec before planning begins).
+- **Delivery instructions** — `workflow run --delivery <json>` tells the main agent how and where to surface gate notifications (Slack thread, terminal, etc.). Antfarm is transport-agnostic; delivery logic lives in agent guidance, not in core.
+- **Gate codes** — notifications include a two-word code (e.g. `bold-falcon`) the human uses to discuss or approve a gate inline, without leaving their current context. Gate codes are a workaround for an OpenClaw bug where `sessions_send` strips channel identity; once that's fixed, gates will notify the thread directly.
+- **`on_gate` directive** — workflow steps can specify custom notification instructions in YAML, giving workflow authors control over what the human sees at each gate.
+- **`spec-review` workflow** — new bundled workflow: spec → gate (human approval) → plan. First workflow to use gating.
+- **`antfarm step approve <gate-code>`** — CLI command to approve a pending gate step and advance the pipeline.
+- Dedicated `gates.md` skill documentation covering delivery, gate codes, discussion flow, and editable artifacts.
+
 ## v0.2.2 — 2026-02-11
 
 ### Fixed

--- a/skills/antfarm-workflows/SKILL.md
+++ b/skills/antfarm-workflows/SKILL.md
@@ -23,6 +23,7 @@ Shorthand used below: `antfarm-cli` means `node ~/.openclaw/workspace/antfarm/di
 | `feature-dev` | plan -> setup -> develop (stories) -> verify -> test -> PR -> review | New features, refactors |
 | `bug-fix` | triage -> investigate -> setup -> fix -> verify -> PR | Bug reports with reproduction steps |
 | `security-audit` | scan -> prioritize -> setup -> fix -> verify -> test -> PR | Codebase security review |
+| `spec-review` | spec -> **gate** (human approval) -> plan | Spec-first planning with human review |
 
 ## Core Commands
 
@@ -33,8 +34,8 @@ node ~/.openclaw/workspace/antfarm/dist/cli/cli.js install
 # Full uninstall (workflows, agents, crons, DB, dashboard)
 node ~/.openclaw/workspace/antfarm/dist/cli/cli.js uninstall [--force]
 
-# Start a run
-node ~/.openclaw/workspace/antfarm/dist/cli/cli.js workflow run <workflow-id> "<detailed task with acceptance criteria>"
+# Start a run (with delivery instructions for notifications)
+node ~/.openclaw/workspace/antfarm/dist/cli/cli.js workflow run <workflow-id> "<detailed task>" [--delivery "<instructions>"]
 
 # Check a run
 node ~/.openclaw/workspace/antfarm/dist/cli/cli.js workflow status "<task or run-id prefix>"
@@ -90,6 +91,10 @@ node ~/.openclaw/workspace/antfarm/dist/cli/cli.js workflow uninstall --all [--f
 ## Creating Custom Workflows
 
 See `{baseDir}/../../docs/creating-workflows.md` for the full guide on writing workflow YAML, agent workspaces, step templates, and verification loops.
+
+## Human Gate Steps
+
+Workflows can include `gate: true` steps that pause for human approval. **Read [`gates.md`](gates.md) for full gate instructions** — delivery, gate codes, discussion flow, and editable artifacts.
 
 ## Agent Step Operations (used by agent cron jobs, not typically manual)
 

--- a/skills/antfarm-workflows/gates.md
+++ b/skills/antfarm-workflows/gates.md
@@ -1,0 +1,51 @@
+# Human Gate Steps
+
+Workflows can include `gate: true` steps that pause execution until a human approves. When a gate step is reached, the pipeline stops and a notification is sent. The step enters `gate` status until approved.
+
+```bash
+# Approve a pending gate step to resume the pipeline
+antfarm step approve <gate-code>
+```
+
+## Delivery Instructions — CRITICAL
+
+**You MUST include delivery instructions when starting a workflow run.** These tell the main agent how to deliver gate notifications and other messages to the user. Without them, notifications go nowhere.
+
+Delivery instructions are natural-language prose that tell the receiving agent exactly how to deliver a message. You construct them based on your current context (what channel you're in, what tools are available).
+
+Gate notifications fire via cron into the main session. The main agent reads the delivery instructions and follows them.
+
+**Construct delivery instructions that tell the main agent:**
+1. How to send a message to the user (use the `message` tool with whatever channel/target params match your current context)
+2. What to include in the message (gate summary + gate code)
+
+**⚠️ DO NOT use `sessions_send` for gate notifications.** It injects into the wrong transcript due to channel identity being stripped. Use the `message` tool only.
+
+## Gate Codes
+
+The message posted via the `message` tool is visible to the human but NOT to the thread/session agent. So the notification must give the human a **gate code** — a two-word phrase like `bold-falcon` — they include in their reply to prime the agent.
+
+Gate codes are derived deterministically from the step UUID (no extra DB column). They exist as a workaround for an OpenClaw bug where `sessions_send` strips channel identity, preventing inline notification delivery. Once that's fixed, gate codes will be replaced by direct thread notifications.
+
+The notification MUST include:
+1. A summary of what's being gated (spec, plan, etc.)
+2. The gate code (e.g. `bold-falcon`)
+3. Instructions:
+   - To **discuss** this gate, include the code in your message (the agent will look up the gate context from the DB)
+   - To **approve**, say `approve <code>` (this advances the pipeline immediately)
+
+### How it works
+
+1. Human sees the gate notification (via `message` tool)
+2. Human replies with just the code (e.g. "bold-falcon — I have questions about the error handling") → agent looks up the gate in the antfarm DB, pulls context (spec/plan output + artifact paths), discusses
+3. Human replies with `approve bold-falcon` → agent approves and advances the pipeline
+
+## Editable Artifacts
+
+When a user includes the gate code to discuss, look up the step output in the DB — it often contains file paths (e.g. `SPEC_PATH`, `PLAN_PATH`) pointing to artifacts on disk. Read those files and help the user review/edit them before approval. The downstream steps will pick up the edited files when the pipeline advances.
+
+## Delivery Example
+
+```bash
+--delivery '{"instructions": "Use the message tool to post a gate notification to the user. Include a summary of the gated content and the gate code. Tell the user: to discuss, include the code in your message. To approve, say: approve <GATE_CODE>."}'
+```

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -23,7 +23,8 @@ import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
 import { getRecentEvents, getRunEvents, type AntfarmEvent } from "../installer/events.js";
 import { startDaemon, stopDaemon, getDaemonStatus, isRunning } from "../server/daemonctl.js";
-import { claimStep, completeStep, failStep, getStories } from "../installer/step-ops.js";
+import { claimStep, completeStep, failStep, approveGate, getStories } from "../installer/step-ops.js";
+import { getDb } from "../db.js";
 import { ensureCliSymlink } from "../installer/symlink.js";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -91,7 +92,7 @@ function printUsage() {
       "antfarm workflow install <name>      Install a workflow",
       "antfarm workflow uninstall <name>    Uninstall a workflow (blocked if runs active)",
       "antfarm workflow uninstall --all     Uninstall all workflows (--force to override)",
-      "antfarm workflow run <name> <task>   Start a workflow run",
+      "antfarm workflow run <name> <task>   Start a workflow run [--delivery <instructions>]",
       "antfarm workflow status <query>      Check run status (task substring, run ID prefix)",
       "antfarm workflow runs                List all workflow runs",
       "antfarm workflow resume <run-id>     Resume a failed run from where it left off",
@@ -103,6 +104,7 @@ function printUsage() {
       "antfarm step claim <agent-id>       Claim pending step, output resolved input as JSON",
       "antfarm step complete <step-id>      Complete step (reads output from stdin)",
       "antfarm step fail <step-id> <error>  Fail step with retry logic",
+      "antfarm step approve <step-id>       Approve a human gate step",
       "antfarm step stories <run-id>       List stories for a run",
       "",
       "antfarm logs [<lines>]               Show recent activity (from events)",
@@ -260,6 +262,16 @@ async function main() {
     return;
   }
 
+  // Internal command: notify-gate (called by detached spawn from advancePipeline)
+  if (group === "notify-gate") {
+    const stepId = action; // arg positions shift: notify-gate <stepId> <runId>
+    const notifyRunId = target;
+    if (!stepId || !notifyRunId) { process.exit(1); }
+    const { notifyGate } = await import("../installer/gateway-api.js");
+    await notifyGate(stepId, notifyRunId).catch(() => {});
+    process.exit(0);
+  }
+
   if (group === "step") {
     if (action === "claim") {
       if (!target) { process.stderr.write("Missing agent-id.\n"); process.exit(1); }
@@ -291,6 +303,16 @@ async function main() {
       if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
       const error = args.slice(3).join(" ").trim() || "Unknown error";
       const result = failStep(target, error);
+      process.stdout.write(JSON.stringify(result) + "\n");
+      return;
+    }
+    if (action === "approve") {
+      if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
+      const result = approveGate(target);
+      if (!result.ok) {
+        process.stderr.write(`${result.error}\n`);
+        process.exit(1);
+      }
       process.stdout.write(JSON.stringify(result) + "\n");
       return;
     }
@@ -513,15 +535,20 @@ async function main() {
 
   if (action === "run") {
     let notifyUrl: string | undefined;
+    let delivery: string | undefined;
     const runArgs = args.slice(3);
-    const nuIdx = runArgs.indexOf("--notify-url");
-    if (nuIdx !== -1) {
-      notifyUrl = runArgs[nuIdx + 1];
-      runArgs.splice(nuIdx, 2);
+    for (const flag of ["--notify-url", "--delivery"] as const) {
+      const idx = runArgs.indexOf(flag);
+      if (idx !== -1) {
+        const val = runArgs[idx + 1];
+        runArgs.splice(idx, 2);
+        if (flag === "--notify-url") notifyUrl = val;
+        else if (flag === "--delivery") delivery = val;
+      }
     }
     const taskTitle = runArgs.join(" ").trim();
     if (!taskTitle) { process.stderr.write("Missing task title.\n"); printUsage(); process.exit(1); }
-    const run = await runWorkflow({ workflowId: target, taskTitle, notifyUrl });
+    const run = await runWorkflow({ workflowId: target, taskTitle, notifyUrl, delivery });
     process.stdout.write(
       [`Run: ${run.id}`, `Workflow: ${run.workflowId}`, `Task: ${run.task}`, `Status: ${run.status}`].join("\n") + "\n",
     );

--- a/src/db.ts
+++ b/src/db.ts
@@ -69,7 +69,7 @@ function migrate(db: DatabaseSync): void {
     );
   `);
 
-  // Add columns to steps table for backwards compat
+  // Migrations
   const cols = db.prepare("PRAGMA table_info(steps)").all() as Array<{ name: string }>;
   const colNames = new Set(cols.map((c) => c.name));
 
@@ -82,12 +82,17 @@ function migrate(db: DatabaseSync): void {
   if (!colNames.has("current_story_id")) {
     db.exec("ALTER TABLE steps ADD COLUMN current_story_id TEXT");
   }
+  if (!colNames.has("on_gate")) {
+    db.exec("ALTER TABLE steps ADD COLUMN on_gate TEXT");
+  }
 
-  // Add columns to runs table for backwards compat
   const runCols = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
   const runColNames = new Set(runCols.map((c) => c.name));
   if (!runColNames.has("notify_url")) {
     db.exec("ALTER TABLE runs ADD COLUMN notify_url TEXT");
+  }
+  if (!runColNames.has("delivery")) {
+    db.exec("ALTER TABLE runs ADD COLUMN delivery TEXT");
   }
 }
 

--- a/src/installer/events.ts
+++ b/src/installer/events.ts
@@ -9,7 +9,7 @@ const MAX_EVENTS_SIZE = 10 * 1024 * 1024; // 10MB
 
 export type EventType =
   | "run.started" | "run.completed" | "run.failed"
-  | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout"
+  | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout" | "step.gate" | "step.approved"
   | "story.started" | "story.done" | "story.verified" | "story.retry" | "story.failed"
   | "pipeline.advanced";
 

--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -43,13 +43,15 @@ export type LoopConfig = {
 
 export type WorkflowStep = {
   id: string;
-  agent: string;
-  type?: "single" | "loop";
+  agent?: string;
+  gate?: boolean;
+  type?: "single" | "loop" | "gate";
   loop?: LoopConfig;
-  input: string;
-  expects: string;
+  input?: string;
+  expects?: string;
   max_retries?: number;
   on_fail?: WorkflowStepFailure;
+  on_gate?: string;
 };
 
 export type Story = {

--- a/src/installer/workflow-spec.ts
+++ b/src/installer/workflow-spec.ts
@@ -76,6 +76,10 @@ function validateSteps(steps: WorkflowStep[], workflowDir: string) {
       throw new Error(`workflow.yml has duplicate step id "${step.id}" in ${workflowDir}`);
     }
     ids.add(step.id);
+    // Gate steps don't need agent, input, or expects
+    if (step.gate) {
+      continue;
+    }
     if (!step.agent?.trim()) {
       throw new Error(`workflow.yml missing step.agent for step "${step.id}"`);
     }

--- a/workflows/spec-review/agents/planner/AGENTS.md
+++ b/workflows/spec-review/agents/planner/AGENTS.md
@@ -1,0 +1,51 @@
+# Planner Agent
+
+You decompose a task into ordered user stories for autonomous execution by a developer agent. Each story is implemented in a fresh session with no memory beyond a progress log.
+
+## Your Process
+
+1. **Explore the codebase** — Read key files, understand the stack, find conventions
+2. **Identify the work** — Break the task into logical units
+3. **Order by dependency** — Schema/DB first, then backend, then frontend, then integration
+4. **Size each story** — Must fit in ONE context window (one agent session)
+5. **Write acceptance criteria** — Every criterion must be mechanically verifiable
+6. **Output the plan** — Structured JSON that the pipeline consumes
+
+## Story Sizing
+
+**Each story must be completable in ONE developer session (one context window).**
+
+Right-sized: Add a DB column, add a UI component, wire up an endpoint.
+Too big: "Build the entire dashboard", "Add authentication" — split these.
+
+**Rule of thumb:** If you cannot describe the change in 2-3 sentences, it is too big.
+
+## Output Format
+
+Your output MUST include these KEY: VALUE lines:
+
+```
+STATUS: done
+BRANCH: feature-branch-name
+PLAN: <the full plan text>
+STORIES_JSON: [
+  {
+    "id": "US-001",
+    "title": "Short descriptive title",
+    "description": "As a developer, I need to...",
+    "acceptanceCriteria": [
+      "Specific verifiable criterion",
+      "Tests for [feature] pass",
+      "Typecheck passes"
+    ]
+  }
+]
+```
+
+## What NOT To Do
+
+- Don't write code — you're a planner, not a developer
+- Don't produce vague stories — every story must be concrete
+- Don't create dependencies on later stories — order matters
+- Don't skip exploring the codebase — you need to understand the patterns
+- Don't exceed 20 stories — if you need more, the task is too big

--- a/workflows/spec-review/agents/planner/IDENTITY.md
+++ b/workflows/spec-review/agents/planner/IDENTITY.md
@@ -1,0 +1,4 @@
+# Identity
+
+Name: Planner
+Role: Decomposes tasks into ordered user stories for autonomous execution

--- a/workflows/spec-review/agents/planner/SOUL.md
+++ b/workflows/spec-review/agents/planner/SOUL.md
@@ -1,0 +1,9 @@
+# Soul
+
+You are analytical, thorough, and methodical. You take time to understand a codebase before decomposing work. You think in terms of dependencies, risk, and incremental delivery.
+
+You are NOT a coder — you are a planner. Your output is a sequence of small, well-ordered user stories that a developer can execute one at a time in isolated sessions. Each story must be completable in a single context window with no memory of previous work beyond a progress log.
+
+You are cautious about story sizing: when in doubt, split smaller. You are rigorous about acceptance criteria: every criterion must be mechanically verifiable. You never produce vague stories like "make it work" or "handle edge cases."
+
+You value clarity over cleverness. A good plan is one where a developer can pick up any story, read it, and know exactly what to build and how to verify it's done.

--- a/workflows/spec-review/agents/specwriter/AGENTS.md
+++ b/workflows/spec-review/agents/specwriter/AGENTS.md
@@ -1,0 +1,27 @@
+# Specwriter Agent
+
+You write formal specifications from task descriptions. Your output is reviewed by a human before planning begins.
+
+## Your Process
+
+1. **Explore the codebase** — Read key files, understand the stack, find conventions and patterns
+2. **Understand the task** — What is being asked? What problem does it solve?
+3. **Write the spec** — Problem statement, proposed solution, scope, acceptance criteria, constraints
+4. **Stay high-level** — Describe *what*, not *how*. The planner handles decomposition.
+
+## Output Format
+
+Your output MUST include these KEY: VALUE lines:
+
+```
+STATUS: done
+REPO: /path/to/repo
+SPEC: <the full spec text>
+```
+
+## What NOT To Do
+
+- Don't design the implementation — that's the planner's job
+- Don't write code or pseudocode
+- Don't be vague — every acceptance criterion must be mechanically verifiable
+- Don't skip exploring the codebase — you need to understand existing patterns

--- a/workflows/spec-review/agents/specwriter/IDENTITY.md
+++ b/workflows/spec-review/agents/specwriter/IDENTITY.md
@@ -1,0 +1,4 @@
+# Identity
+
+Name: Specwriter
+Role: Explores a codebase and writes a formal specification from a task description

--- a/workflows/spec-review/agents/specwriter/SOUL.md
+++ b/workflows/spec-review/agents/specwriter/SOUL.md
@@ -1,0 +1,5 @@
+# Soul
+
+You are thorough and precise. You explore a codebase deeply before writing anything. Your specs are clear, concise, and grounded in what actually exists in the code — not hypotheticals.
+
+You focus on *what* needs to happen, not *how*. You leave implementation details to the planner. Your acceptance criteria are always mechanically verifiable.

--- a/workflows/spec-review/workflow.yml
+++ b/workflows/spec-review/workflow.yml
@@ -1,0 +1,107 @@
+id: spec-review
+name: Spec Review
+version: 1
+description: |
+  Spec-first planning with a human approval gate.
+  A specwriter explores the codebase and writes a specification, a human
+  reviews and approves it, then a planner turns it into ordered stories.
+
+agents:
+  - id: specwriter
+    name: Specwriter
+    role: analysis
+    description: Explores codebase and writes a formal spec from a task description.
+    workspace:
+      baseDir: agents/specwriter
+      files:
+        AGENTS.md: agents/specwriter/AGENTS.md
+        SOUL.md: agents/specwriter/SOUL.md
+        IDENTITY.md: agents/specwriter/IDENTITY.md
+
+  - id: planner
+    name: Planner
+    role: analysis
+    description: Turns an approved spec into an ordered plan with stories.
+    workspace:
+      baseDir: agents/planner
+      files:
+        AGENTS.md: agents/planner/AGENTS.md
+        SOUL.md: agents/planner/SOUL.md
+        IDENTITY.md: agents/planner/IDENTITY.md
+
+steps:
+  # Step 1: Write a spec from the task description
+  - id: spec
+    agent: specwriter
+    input: |
+      Explore the codebase and write a formal specification for the following task.
+
+      TASK:
+      {{task}}
+
+      Instructions:
+      1. Explore the codebase — read key files, understand the stack, conventions, patterns
+      2. Write a clear, concise spec covering:
+         - Problem statement / motivation
+         - Proposed solution (what, not how)
+         - Scope: what's in, what's explicitly out
+         - Acceptance criteria (mechanically verifiable)
+         - Key technical constraints or dependencies
+      3. Do NOT design the implementation — that's the planner's job
+      4. Be specific enough that a planner can decompose this into stories
+
+      5. Save the spec as markdown to docs/plans/<spec_name>-<iso8601>.md where
+         <spec_name> is a slugified version of the task and <iso8601> is the current timestamp.
+         Create the docs/plans/ directory if it doesn't exist.
+
+      Reply with:
+      STATUS: done
+      REPO: /path/to/repo
+      SPEC_PATH: docs/plans/<the file you wrote>
+      SPEC: <the full spec text>
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  # Step 2: Human reviews the spec before planning proceeds
+  - id: spec-approval
+    gate: true
+    on_gate: |
+      Render the spec to HTML for human review.
+      1. Read the spec markdown from {{spec_path}}
+      2. Use Pandoc to convert it: pandoc {{spec_path}} -f markdown -t html --standalone -o /var/www/plans/<matching-name>.html
+      3. Send the review URL (http://<hostname>/plans/<filename>) to the bound session
+      4. Ask the user to review and approve
+
+  # Step 3: Turn the approved spec into an implementation plan
+  - id: plan
+    agent: planner
+    input: |
+      Turn this approved spec into an ordered implementation plan with user stories.
+
+      REPO: {{repo}}
+      SPEC:
+      {{spec}}
+
+      ORIGINAL TASK:
+      {{task}}
+
+      Instructions:
+      1. Re-explore the codebase with the spec in mind
+      2. Break the spec into small, ordered user stories (max 20)
+      3. Order by dependency: schema/DB first, backend, frontend, integration
+      4. Each story must fit in ONE developer session (one context window)
+      5. Every acceptance criterion must be mechanically verifiable
+      6. Always include "Typecheck passes" as the last criterion in every story
+      7. Every story MUST include test criteria
+
+      Reply with:
+      STATUS: done
+      BRANCH: feature-branch-name
+      PLAN: <the full plan text>
+      STORIES_JSON: [ ... array of story objects ... ]
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human


### PR DESCRIPTION
## Summary
- Add `gate: true` workflow steps that pause execution for human approval before advancing
- Gate notifications routed via delivery instructions (`--delivery` flag) and cron — antfarm stays transport-agnostic
- Human-friendly two-word gate codes (e.g. `bold-falcon`) instead of hex IDs, derived deterministically from step UUIDs
- `on_gate` directive for custom notification instructions per step
- New `spec-review` workflow: spec → gate (human approval) → plan
- `antfarm step approve <gate-code>` CLI command
- Dedicated `gates.md` skill documentation

## Test plan
- [ ] Run `spec-review` workflow with `--delivery` instructions and verify gate notification appears
- [ ] Verify two-word gate code is included in notification
- [ ] Approve gate with `antfarm step approve <gate-code>` and confirm pipeline advances
- [ ] Verify existing workflows (feature-dev, bug-fix, security-audit) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)