### PR TITLE
fix: add active agent indicator and faster polling to dashboard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antfarm",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antfarm",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "dependencies": {
         "json5": "^2.2.3",
         "yaml": "^2.4.5"

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -157,7 +157,8 @@ select:focus{outline:none;border-color:#8ECFC0}
 .step-row{display:flex;align-items:center;gap:12px;padding:10px 12px;background:var(--bg-surface-alt);border:1px solid var(--border);border-radius:6px}
 .step-icon{width:24px;height:24px;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;flex-shrink:0}
 .step-icon.done{background:var(--accent-green-subtle);color:var(--accent-green)}
-.step-icon.running{background:var(--accent-teal-subtle);color:var(--accent-teal)}
+.step-icon.running{background:var(--accent-teal-subtle);color:var(--accent-teal);animation:pulse 1.5s ease-in-out infinite}
+@keyframes pulse{0%,100%{opacity:1;transform:scale(1)}50%{opacity:.7;transform:scale(1.1)}}
 .step-icon.pending{background:var(--accent-muted);color:var(--text-secondary)}
 .step-icon.waiting{background:var(--accent-muted);color:var(--text-secondary)}
 .step-icon.failed,.step-icon.error{background:var(--accent-orange-subtle);color:var(--accent-orange)}
@@ -167,7 +168,8 @@ select:focus{outline:none;border-color:#8ECFC0}
 
 /* ── Badges ────────────────────────────────────────────────────── */
 .badge{font-size:10px;font-weight:600;padding:2px 6px;border-radius:4px;text-transform:uppercase}
-.badge-running{background:var(--accent-teal-subtle);color:var(--accent-teal)}
+.badge-running{background:var(--accent-teal-subtle);color:var(--accent-teal);animation:pulse-badge 1.5s ease-in-out infinite}
+@keyframes pulse-badge{0%,100%{opacity:1}50%{opacity:.6}}
 .badge-done,.badge-completed{background:var(--accent-green-subtle);color:var(--accent-green)}
 .badge-failed,.badge-error{background:var(--accent-orange-subtle);color:var(--accent-orange)}
 .badge-waiting{background:var(--accent-muted);color:var(--text-secondary)}
@@ -187,7 +189,7 @@ select:focus{outline:none;border-color:#8ECFC0}
   <h1><span>antfarm</span> dashboard</h1>
   <select id="wf-select"><option value="">Loading...</option></select>
   <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode">☀️</button>
-  <span class="refresh-note" id="refresh-note">Auto-refresh: 30s</span>
+  <span class="refresh-note" id="refresh-note">Auto-refresh: 5s</span>
 </header>
 <div class="board" id="board"><div class="empty" style="margin:auto">Select a workflow</div></div>
 <div class="overlay" id="overlay" onclick="if(event.target===this)closePanel()">
@@ -410,7 +412,7 @@ async function loadStories(runId) {
 
 document.getElementById('wf-select').addEventListener('change', e => selectWorkflow(e.target.value));
 loadWorkflows();
-setInterval(() => { if (currentWf) loadRuns(); }, 30000);
+setInterval(() => { if (currentWf) loadRuns(); }, 5000);
 
 // ── Theme toggle ──────────────────────────────────────────────────
 (function initTheme() {

--- a/tests/dashboard-active-indicator.test.ts
+++ b/tests/dashboard-active-indicator.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for dashboard active agent indicator.
+ * Bug: Dashboard was not showing when agents were actively working
+ * because polling was too slow (30s) and there was no visual indicator.
+ * Fix: Reduced polling to 5s and added pulse animation for running state.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+
+const DASHBOARD_HTML = path.resolve(
+  import.meta.dirname,
+  "..",
+  "src",
+  "server",
+  "index.html"
+);
+
+describe("dashboard active agent indicator", () => {
+  const html = fs.readFileSync(DASHBOARD_HTML, "utf-8");
+
+  it("should use 5-second polling interval for responsive updates", () => {
+    // The bug was 30-second polling which missed short-lived running states
+    assert.ok(
+      html.includes("setInterval(() => { if (currentWf) loadRuns(); }, 5000)"),
+      "polling interval should be 5000ms (5 seconds), not 30000ms"
+    );
+    assert.ok(
+      !html.includes("setInterval(() => { if (currentWf) loadRuns(); }, 30000)"),
+      "should not use the old 30-second polling interval"
+    );
+  });
+
+  it("should have pulse animation for running step icons", () => {
+    // Running steps need visual feedback so users can see active agents
+    assert.ok(
+      html.includes(".step-icon.running") && html.includes("animation:pulse"),
+      "running step icon should have pulse animation"
+    );
+  });
+
+  it("should have pulse animation for running badges", () => {
+    // Running badges on cards also need visual feedback
+    assert.ok(
+      html.includes(".badge-running") && html.includes("animation:pulse-badge"),
+      "running badge should have pulse-badge animation"
+    );
+  });
+
+  it("should display correct refresh interval in UI", () => {
+    // UI should accurately reflect the polling interval
+    assert.ok(
+      html.includes("Auto-refresh: 5s"),
+      "refresh note should say 5s, not 30s"
+    );
+  });
+});


### PR DESCRIPTION
## Bug Description
The antfarm dashboard (likely what the user calls "mission control") uses 30-second HTTP polling to fetch run/step statuses. When an agent claims and completes work quickly, users may never see the "running" state. There is no real-time feedback mechanism (WebSocket, SSE) and no dedicated "agent is active" indicator beyond the step status badge. The dashboard shows step status as "running" when claimed, but lacks: (1) shorter polling interval or real-time updates, (2) visual pulse/animation on active steps, (3) dedicated agent activity/presence indicator. The Activity panel shows events retroactively but doesn't provide live feedback during execution.

**Severity:** medium

## Root Cause
The dashboard at src/server/index.html has two compounding issues:

## Fix
Modified src/server/index.html: (1) Reduced polling interval from 30s to 5s for faster feedback on agent activity, (2) Added CSS pulse animation to .step-icon.running for visual indication of active steps, (3) Added CSS pulse-badge animation to .badge-running for visual indication on cards, (4) Updated refresh note text from "30s" to "5s"

## Regression Test
Added tests/dashboard-active-indicator.test.ts with 4 test cases: verifies 5-second polling interval, pulse animation on running step icons, pulse animation on running badges, and correct refresh interval display in UI

## Verification
[missing: verified]
