### PR TITLE
fix: validate TypeScript files with tsc instead of node -c

### DIFF
--- a/tests/typescript-syntax.test.ts
+++ b/tests/typescript-syntax.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Regression test for TypeScript syntax checking bug.
+ * 
+ * Bug: Using `node -c` to check TypeScript files produces false positive
+ * syntax errors because `node -c` validates JavaScript syntax, not TypeScript.
+ * 
+ * This test ensures:
+ * 1. TypeScript files compile successfully with TypeScript compiler
+ * 2. We don't accidentally use `node -c` for TypeScript syntax checking
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execSync } from "node:child_process";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+function findAllTypeScriptFiles(dir: string): string[] {
+  const files: string[] = [];
+  const entries = readdirSync(dir);
+  
+  for (const entry of entries) {
+    // Skip node_modules and dist directories
+    if (entry === "node_modules" || entry === "dist") {
+      continue;
+    }
+    
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    
+    if (stat.isDirectory()) {
+      files.push(...findAllTypeScriptFiles(fullPath));
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".d.ts")) {
+      files.push(fullPath);
+    }
+  }
+  
+  return files;
+}
+
+describe("TypeScript syntax checking", () => {
+  it("all TypeScript files compile successfully with tsc --noEmit", () => {
+    const tsFiles = findAllTypeScriptFiles(join(import.meta.dirname, ".."));
+    
+    // Skip if no TypeScript files found (shouldn't happen)
+    if (tsFiles.length === 0) {
+      console.warn("No TypeScript files found to test");
+      return;
+    }
+    
+    console.log(`Checking ${tsFiles.length} TypeScript files with tsc --noEmit...`);
+    
+    try {
+      // Run tsc --noEmit on all TypeScript files
+      execSync("npx tsc --noEmit", {
+        cwd: join(import.meta.dirname, ".."),
+        stdio: "inherit"
+      });
+    } catch (error) {
+      // If tsc fails, provide helpful error message
+      console.error("\n❌ TypeScript compilation failed!");
+      console.error("This means there are actual syntax errors in TypeScript files.");
+      console.error("Note: Do not use `node -c` to check TypeScript syntax.");
+      console.error("Use `tsc --noEmit` or `npm run build` instead.\n");
+      throw error;
+    }
+    
+    console.log("✅ All TypeScript files compile successfully with tsc --noEmit");
+  });
+
+  it("demonstrates that node -c fails on TypeScript files (expected)", () => {
+    // Find a TypeScript file with TypeScript-specific syntax
+    const sampleFile = join(import.meta.dirname, "..", "src", "installer", "subagent-allowlist.ts");
+    
+    try {
+      // Try to check it with node -c (should fail)
+      execSync(`node -c "${sampleFile}"`, { stdio: "pipe" });
+      
+      // If we get here, node -c succeeded, which is actually a problem!
+      // It means the TypeScript file doesn't contain TypeScript-specific syntax
+      // and could be valid JavaScript, which is unexpected for a .ts file.
+      console.warn(`⚠️  WARNING: ${sampleFile} passed node -c syntax check`);
+      console.warn("This TypeScript file might not contain TypeScript-specific syntax.");
+      console.warn("While not necessarily wrong, it's unusual for a .ts file.");
+      
+      // We don't fail the test because this isn't necessarily an error,
+      // but we log it as a warning.
+    } catch (error) {
+      // Expected: node -c should fail on TypeScript files
+      console.log("✅ As expected, node -c fails on TypeScript files");
+      console.log("   This demonstrates why tsc --noEmit should be used instead.");
+    }
+  });
+});


### PR DESCRIPTION
# Bug Description
The bug report claims there are syntax errors in example code. Running `node -c` on TypeScript source files produces syntax error warnings, but these are expected since `node -c` validates JavaScript syntax, not TypeScript. The actual TypeScript compilation passes, built code works correctly, and no runtime errors exist.

**Severity:** low

## Root Cause
The issue is not with the Antfarm TypeScript source code, which is syntactically correct and compiles successfully with TypeScript compiler (tsc). The problem is that `node -c` is being used to check TypeScript files, but `node -c` validates JavaScript syntax, not TypeScript syntax. TypeScript files contain TypeScript-specific constructs (type annotations, interfaces, etc.) that Node.js's JavaScript parser doesn't understand, causing false positive syntax errors. For example, `src/installer/subagent-allowlist.ts` contains `type AgentToAgentConfig = {` which is valid TypeScript but invalid JavaScript syntax.

## Fix
Added regression test tests/typescript-syntax.test.ts that validates TypeScript files should be checked with tsc --noEmit instead of node -c. The test demonstrates that node -c fails on TypeScript files (as expected since TypeScript contains type annotations invalid in JavaScript) while tsc --noEmit succeeds.

## Regression Test
[missing: regression_test]

## Verification
