### PR TITLE
fix: abandoned step threshold too aggressive, causing premature run failures

### DIFF
--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -174,7 +174,7 @@ function parseAndInsertStories(output: string, runId: string): void {
   const db = getDb();
   const now = new Date().toISOString();
   const insert = db.prepare(
-    "INSERT INTO stories (id, run_id, story_index, story_id, title, description, acceptance_criteria, status, retry_count, max_retries, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, 2, ?, ?)"
+    "INSERT INTO stories (id, run_id, story_index, story_id, title, description, acceptance_criteria, status, retry_count, max_retries, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, 3, ?, ?)"
   );
 
   const seenIds = new Set<string>();
@@ -195,7 +195,7 @@ function parseAndInsertStories(output: string, runId: string): void {
 
 // ── Abandoned Step Cleanup ──────────────────────────────────────────
 
-const ABANDONED_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+const ABANDONED_THRESHOLD_MS = 35 * 60 * 1000; // 35 minutes (must exceed agent session timeout of 30 min)
 
 /**
  * Find steps that have been "running" for too long and reset them to pending.


### PR DESCRIPTION
## Problem

Feature-dev workflow runs consistently fail at the `implement` (loop) step with `Agent abandoned step without completing`. The agent is still actively working when the cleanup routine marks the step as abandoned.

## Root Cause

`ABANDONED_THRESHOLD_MS` in `step-ops.ts` is set to **15 minutes**, but the default agent session timeout (`DEFAULT_AGENT_TIMEOUT_SECONDS`) is **30 minutes**. This means:

1. Agent claims a story and starts coding (takes 10-20 min for complex stories)
2. After 15 min, `cleanupAbandonedSteps()` fires and marks the step as `failed`/`pending`
3. Story retry count increments
4. After 2 retries (default `max_retries`), the entire run fails

This is especially common with `loop`-type implement steps where each user story involves significant coding work.

## Reproduction

1. `antfarm workflow run feature-dev "Build a SaaS app with auth, dashboard, billing"`
2. Planner creates 10-20 stories
3. First few stories complete (quick ones)
4. Complex stories that take >15 min get abandoned mid-work
5. After 2 abandoned retries per story, run fails

## Fix

- **Increase `ABANDONED_THRESHOLD_MS`** from 15 min → 35 min (exceeds the 30-min default agent timeout with a 5-min buffer)
- **Increase default story `max_retries`** from 2 → 3 for loop steps, giving complex stories more chances

## Ideal Future Fix

The abandoned threshold should be dynamically derived from the workflow's agent `timeoutSeconds` config rather than using a static value. This PR fixes the immediate issue; a follow-up could make it configurable per-workflow.

## Testing

- Verified build passes (`npm run build`)
- Tested with 3 feature-dev runs that previously failed at implement step