### PR TITLE
fix: set delivery mode to none for agent cron jobs

### DIFF
--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -68,6 +68,7 @@ export async function setupAgentCrons(workflow: WorkflowSpec): Promise<void> {
       sessionTarget: "isolated",
       agentId,
       payload: { kind: "agentTurn", message: prompt, timeoutSeconds },
+      delivery: { mode: "none" },
       enabled: true,
     });
 

--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -94,6 +94,7 @@ export async function createAgentCronJob(job: {
   sessionTarget: string;
   agentId: string;
   payload: { kind: string; message: string; timeoutSeconds?: number };
+  delivery?: { mode: "none" | "announce"; channel?: string; to?: string };
   enabled: boolean;
 }): Promise<{ ok: boolean; error?: string; id?: string }> {
   // --- Try HTTP first ---
@@ -143,6 +144,7 @@ async function createAgentCronJobHTTP(job: {
   sessionTarget: string;
   agentId: string;
   payload: { kind: string; message: string; timeoutSeconds?: number };
+  delivery?: { mode: "none" | "announce"; channel?: string; to?: string };
   enabled: boolean;
 }): Promise<{ ok: boolean; error?: string; id?: string } | null> {
   const gateway = await getGatewayConfig();


### PR DESCRIPTION
## Problem

When antfarm installs agent cron jobs via `setupAgentCrons()`, it doesn't specify a `delivery` config. OpenClaw defaults isolated `agentTurn` jobs to `delivery.mode='announce'`, which requires `channel` and `to` fields.

Without explicit delivery config, agent crons fail with:
```
cron delivery target is missing
```

## Solution

Explicitly set `delivery: { mode: "none" }` when creating agent cron jobs.

Since antfarm agents handle their own output via `step complete` / `step fail`, they don't need cron-level delivery—the cron system should simply run the agent and not attempt to deliver output.

## Changes

- `agent-cron.ts`: Add `delivery: { mode: "none" }` to job creation
- `gateway-api.ts`: Add `delivery` to type signatures for `createAgentCronJob` and `createAgentCronJobHTTP`

## Testing

- Built successfully with `npm run build`
- Verified fix resolves the issue on a live OpenClaw installation