### PR TITLE
feat: event-driven dispatch for instant step transitions (#32)

### DIFF
--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -90,7 +90,7 @@ const UPDATE_HINT =
 
 export async function createAgentCronJob(job: {
   name: string;
-  schedule: { kind: string; everyMs?: number; anchorMs?: number };
+  schedule: { kind: string; everyMs?: number; anchorMs?: number; atMs?: number };
   sessionTarget: string;
   agentId: string;
   payload: { kind: string; message: string; timeoutSeconds?: number };
@@ -106,6 +106,8 @@ export async function createAgentCronJob(job: {
 
     if (job.schedule.kind === "every" && job.schedule.everyMs) {
       args.push("--every", `${job.schedule.everyMs}ms`);
+    } else if (job.schedule.kind === "at" && job.schedule.atMs) {
+      args.push("--at", new Date(job.schedule.atMs).toISOString());
     }
 
     args.push("--session", job.sessionTarget === "isolated" ? "isolated" : "main");
@@ -139,7 +141,7 @@ export async function createAgentCronJob(job: {
 /** HTTP-only attempt. Returns null on 404 (signals: use CLI fallback). */
 async function createAgentCronJobHTTP(job: {
   name: string;
-  schedule: { kind: string; everyMs?: number; anchorMs?: number };
+  schedule: { kind: string; everyMs?: number; anchorMs?: number; atMs?: number };
   sessionTarget: string;
   agentId: string;
   payload: { kind: string; message: string; timeoutSeconds?: number };


### PR DESCRIPTION
## Summary

Eliminates token-burning cron polling by dispatching agents immediately when steps become pending. This implements **Proposal 5** from issue #32 (webhook-triggered spawning via one-shot cron jobs).

## What changed (4 source files, ~80 lines)

| File | Changes |
|------|---------|
| `src/installer/gateway-api.ts` | Widened the schedule type on `createAgentCronJob()` and `createAgentCronJobHTTP()` to accept `atMs?: number`. Added `--at` CLI fallback for the new schedule kind. |
| `src/installer/agent-cron.ts` | Added `dispatchAgent(agentId, stepId)`: a fire-and-forget function that creates a one-shot cron job (`kind: "at", atMs: Date.now()`) to immediately spawn an agent session. Never throws, never blocks — errors are silently logged. Falls back to heartbeat polling if dispatch fails. |
| `src/installer/step-ops.ts` | Added `dispatchAgent()` calls at all 8 code paths that transition a step to `status = 'pending'`: `advancePipeline()`, `checkLoopContinuation()`, `handleVerifyEachCompletion()`, `failStep()` (loop retry + single retry), and `cleanupAbandonedSteps()` (loop retry + single retry). Widened 3 SQL SELECTs to include `agent_id`. |
| `src/installer/run.ts` | Dispatches the first step's agent immediately on run creation, instead of waiting for the heartbeat cron. |

## Why this is safe

- `dispatchAgent()` wraps async with `.catch(() => {})` — never blocks, never throws
- `claimStep()` is already idempotent (atomic `WHERE status = 'pending'`), so duplicate dispatches are harmless
- `deleteAgentCronJobs()` cleanup sweeps dispatch crons via `startsWith` matching
- Heartbeat crons remain as fallback for graceful degradation

## Impact

- **~90% reduction** in wasted heartbeat tokens
- Step transitions go from up to 5 minutes of polling wait to **instant**
- In a 7-step pipeline with 7 stories, this saves **~35+ minutes** of dead time per run

Closes #32