### PR TITLE
feat: per-agent model routing with workflow-level role defaults

### DIFF
--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -16,12 +16,22 @@ export type WorkflowAgentFiles = {
  */
 export type AgentRole = "analysis" | "coding" | "verification" | "testing" | "pr" | "scanning";
 
+/**
+ * Model config: either a plain string (`"anthropic/claude-sonnet-4-5"`)
+ * or an object with primary + optional fallbacks.
+ * When written to openclaw.json, always normalized to object form.
+ */
+export type ModelConfig = string | {
+  primary: string;
+  fallbacks?: string[];
+};
+
 export type WorkflowAgent = {
   id: string;
   name?: string;
   description?: string;
   role?: AgentRole;
-  model?: string;
+  model?: ModelConfig;
   timeoutSeconds?: number;
   workspace: WorkflowAgentFiles;
 };
@@ -70,6 +80,18 @@ export type WorkflowSpec = {
   id: string;
   name?: string;
   version?: number;
+  /**
+   * Role-based model defaults.  Keys are AgentRole values (e.g. "coding",
+   * "analysis").  Per-agent `model` overrides these.
+   *
+   * Example in workflow.yml:
+   *   models:
+   *     coding: anthropic/claude-sonnet-4-5
+   *     analysis:
+   *       primary: openai/gpt-4o
+   *       fallbacks: [anthropic/claude-haiku-4-5]
+   */
+  models?: Partial<Record<AgentRole, ModelConfig>>;
   agents: WorkflowAgent[];
   steps: WorkflowStep[];
   context?: Record<string, string>;


### PR DESCRIPTION
## Summary

- Adds `ModelConfig` type supporting both string (`"anthropic/claude-sonnet-4-5"`) and object (`{ primary, fallbacks }`) formats
- Adds optional `models` map to `WorkflowSpec` for role-based model defaults — set once per workflow, applies to all agents of that role
- Per-agent `model` overrides take precedence over workflow-level defaults
- All model configs are normalized to OpenClaw's object format (`{ "primary": "..." }`) during install
- Full validation for `models` config in workflow YAML (role names, model format, fallbacks)

## Usage

**Workflow-level role defaults** (new):
```yaml
# workflow.yml
models:
  coding: anthropic/claude-sonnet-4-5
  analysis:
    primary: openai/gpt-4o
    fallbacks: [anthropic/claude-haiku-4-5]
```

**Per-agent override** (existing, now accepts object format too):
```yaml
agents:
  - id: developer
    role: coding
    model:
      primary: anthropic/claude-sonnet-4-5
      fallbacks: [openai/gpt-4o]
    workspace: ...
```

**Resolution priority**: per-agent model > workflow role default > no model (uses OpenClaw default)

## Files changed

| File | Change |
|------|--------|
| `src/installer/types.ts` | Add `ModelConfig` type, add `models` to `WorkflowSpec` |
| `src/installer/agent-provision.ts` | Resolve model from agent or workflow role defaults |
| `src/installer/install.ts` | Normalize `ModelConfig` to OpenClaw object format |
| `src/installer/workflow-spec.ts` | Validate `models` map and per-agent model configs |

## Test plan

- [ ] TypeScript compiles with zero errors
- [ ] Existing workflows without `models` key install unchanged (backward compatible)
- [ ] Workflow with `models` map correctly assigns models to agents by role
- [ ] Per-agent model overrides workflow-level default
- [ ] String model format normalized to `{ "primary": "..." }` in openclaw.json
- [ ] Object model format with fallbacks preserved in openclaw.json
- [ ] Invalid role names in `models` rejected with clear error
- [ ] Empty model strings rejected with clear error

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)