### PR TITLE
fix(security): audit and remediation 2026-02-13

### DIFF
--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -48,6 +48,16 @@ export function resolveTemplate(template: string, context: Record<string, string
 }
 
 /**
+ * Validate that a resolved workspace path stays within the user's home directory.
+ * Prevents path traversal via crafted openclaw.json workspace values.
+ */
+function isWorkspaceSafe(workspace: string): boolean {
+  const resolved = path.resolve(workspace);
+  const homeDir = os.homedir();
+  return resolved.startsWith(homeDir + path.sep) || resolved === homeDir;
+}
+
+/**
  * Get the workspace path for an OpenClaw agent by its id.
  */
 function getAgentWorkspacePath(agentId: string): string | null {
@@ -55,7 +65,9 @@ function getAgentWorkspacePath(agentId: string): string | null {
     const configPath = path.join(os.homedir(), ".openclaw", "openclaw.json");
     const config = JSON.parse(fs.readFileSync(configPath, "utf-8"));
     const agent = config.agents?.list?.find((a: any) => a.id === agentId);
-    return agent?.workspace ?? null;
+    const workspace = agent?.workspace ?? null;
+    if (workspace && !isWorkspaceSafe(workspace)) return null;
+    return workspace;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Security Audit Summary

**Scan Date**: 2026-02-13
**Vulnerabilities Found**: 1 (0 critical, 0 high)
**Vulnerabilities Fixed**: 1
**Vulnerabilities Deferred**: 0

## Fixes Applied

| # | Severity | Description | Files |
|---|----------|-------------|-------|
| fix-001 | Medium | Path traversal via crafted workspace values in openclaw.json | `src/installer/step-ops.ts` |

## Details

`getAgentWorkspacePath()` reads the `workspace` field from `openclaw.json` agent entries and passes it directly to `path.join()`. A malicious or corrupted config could set workspace to `/etc/` or `../../sensitive-dir`, allowing `readProgressFile()` and `archiveRunProgress()` to read from or write to arbitrary locations.

**Fix**: Added `isWorkspaceSafe()` that uses `path.resolve()` to canonicalize the workspace path and verifies it falls within the user's home directory before use. Returns `null` (no-op) for unsafe paths.

## Regression Tests

- Build passes (`tsc` zero errors)
- `npm audit`: 0 vulnerabilities
- Path traversal blocked for absolute paths (`/etc/passwd`) and relative sequences (`../../etc`)

## Audit Comparison

**Before**: 1 medium vulnerability (path traversal)
**After**: 0 vulnerabilities

---

*This PR was produced by antfarm's security-audit workflow (run 597a546a), with manual step completion due to [#110](https://github.com/snarktank/antfarm/issues/110).*

🤖 Generated with [Claude Code](https://claude.com/claude-code)