### PR TITLE
fix: install skills to .agents/skills/ for OpenClaw discovery

### DIFF
--- a/src/installer/agent-provision.ts
+++ b/src/installer/agent-provision.ts
@@ -76,7 +76,7 @@ export async function provisionAgents(params: {
     }
 
     if (agent.workspace.skills?.length) {
-      const skillsDir = path.join(workspaceDir, "skills");
+      const skillsDir = path.join(workspaceDir, ".agents", "skills");
       await ensureDir(skillsDir);
     }
 
@@ -136,7 +136,7 @@ async function installExternalSkills(workflow: WorkflowSpec): Promise<void> {
     if (externalSkills.length === 0) continue;
 
     const workspaceDir = resolveWorkspaceDir({ workflowId: workflow.id, agent });
-    const skillsDir = path.join(workspaceDir, "skills");
+    const skillsDir = path.join(workspaceDir, ".agents", "skills");
     await ensureDir(skillsDir);
 
     for (const skillName of externalSkills) {
@@ -165,7 +165,7 @@ async function installWorkflowSkill(workflow: WorkflowSpec, workflowDir: string)
       continue;
     }
     const workspaceDir = resolveWorkspaceDir({ workflowId: workflow.id, agent });
-    const targetDir = path.join(workspaceDir, "skills");
+    const targetDir = path.join(workspaceDir, ".agents", "skills");
     await ensureDir(targetDir);
     const destination = path.join(targetDir, "antfarm-workflows");
     await fs.rm(destination, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

OpenClaw discovers agent skills from `.agents/skills/` in the workspace root, but antfarm installs them to `skills/`. This means skills listed in `workflow.yml` are never visible to agents — they simply don't appear in the agent's `<available_skills>` list.

## Fix

Changed all three skill installation paths in `agent-provision.ts` from `skills/` to `.agents/skills/`:

1. Initial skills dir creation during agent provisioning
2. External skill installation (user-defined skills from `~/.openclaw/skills/`)
3. Bundled `antfarm-workflows` skill installation

## Testing

- Confirmed OpenClaw discovers skills from `.agents/skills/` (not `skills/`)
- Build passes cleanly
- Verified the fix by manually symlinking to `.agents/skills/` and confirming agent visibility