### PR TITLE
fix: support password auth mode in gateway API cron setup

### DIFF
--- a/tests/gateway-password-auth.test.ts
+++ b/tests/gateway-password-auth.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, mock, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+/**
+ * Regression test for https://github.com/snarktank/antfarm/issues/116
+ *
+ * When OpenClaw gateway is configured with auth.mode "password" (instead of
+ * "token"), antfarm's cron setup was sending NO Authorization header at all,
+ * causing 401 Unauthorized. The fix reads the auth mode and password from the
+ * config and sends `Bearer <password>` in that mode.
+ */
+describe("gateway-api password auth mode (#116)", () => {
+  const configDir = path.join(os.homedir(), ".openclaw");
+  const configPath = path.join(configDir, "openclaw.json");
+  let originalConfig: string | null = null;
+
+  beforeEach(() => {
+    // Back up the real config
+    try {
+      originalConfig = fs.readFileSync(configPath, "utf-8");
+    } catch {
+      originalConfig = null;
+    }
+  });
+
+  afterEach(() => {
+    // Restore the original config
+    if (originalConfig !== null) {
+      fs.writeFileSync(configPath, originalConfig, "utf-8");
+    }
+    // Clean up env var if set
+    delete process.env.OPENCLAW_GATEWAY_PASSWORD;
+  });
+
+  it("sends Bearer header with password when auth mode is password", async () => {
+    // Write a test config with password auth mode
+    const testConfig = {
+      gateway: {
+        port: 18789,
+        auth: {
+          mode: "password",
+          password: "my-secret-password",
+        },
+      },
+    };
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(testConfig), "utf-8");
+
+    // Re-import to pick up the new config
+    // Use a cache-busting query param to force re-evaluation
+    const mod = await import(`../dist/installer/gateway-api.js?v=${Date.now()}`);
+
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = mock.fn(async (_url: string, init: any) => {
+      capturedHeaders = init.headers || {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { id: "test-pw-123" } }),
+      };
+    }) as any;
+
+    try {
+      const result = await mod.createAgentCronJob({
+        name: "test/password-auth",
+        schedule: { kind: "every", everyMs: 300_000 },
+        sessionTarget: "isolated",
+        agentId: "test-agent",
+        payload: {
+          kind: "agentTurn",
+          message: "test prompt",
+        },
+        enabled: true,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(
+        capturedHeaders["Authorization"],
+        "Bearer my-secret-password",
+        "Should send password as Bearer token when auth mode is password"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sends Bearer header with token when auth mode is token", async () => {
+    const testConfig = {
+      gateway: {
+        port: 18789,
+        auth: {
+          mode: "token",
+          token: "my-token-value",
+        },
+      },
+    };
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(testConfig), "utf-8");
+
+    const mod = await import(`../dist/installer/gateway-api.js?v=token-${Date.now()}`);
+
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = mock.fn(async (_url: string, init: any) => {
+      capturedHeaders = init.headers || {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { id: "test-tok-123" } }),
+      };
+    }) as any;
+
+    try {
+      const result = await mod.createAgentCronJob({
+        name: "test/token-auth",
+        schedule: { kind: "every", everyMs: 300_000 },
+        sessionTarget: "isolated",
+        agentId: "test-agent",
+        payload: {
+          kind: "agentTurn",
+          message: "test prompt",
+        },
+        enabled: true,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(
+        capturedHeaders["Authorization"],
+        "Bearer my-token-value",
+        "Should send token as Bearer token when auth mode is token"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("uses OPENCLAW_GATEWAY_PASSWORD env var for password mode", async () => {
+    const testConfig = {
+      gateway: {
+        port: 18789,
+        auth: {
+          mode: "password",
+          // No password in config — should use env var
+        },
+      },
+    };
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(testConfig), "utf-8");
+
+    process.env.OPENCLAW_GATEWAY_PASSWORD = "env-password-secret";
+
+    const mod = await import(`../dist/installer/gateway-api.js?v=env-${Date.now()}`);
+
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = mock.fn(async (_url: string, init: any) => {
+      capturedHeaders = init.headers || {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { id: "test-env-123" } }),
+      };
+    }) as any;
+
+    try {
+      const result = await mod.createAgentCronJob({
+        name: "test/env-password",
+        schedule: { kind: "every", everyMs: 300_000 },
+        sessionTarget: "isolated",
+        agentId: "test-agent",
+        payload: {
+          kind: "agentTurn",
+          message: "test prompt",
+        },
+        enabled: true,
+      });
+
+      assert.equal(result.ok, true);
+      assert.equal(
+        capturedHeaders["Authorization"],
+        "Bearer env-password-secret",
+        "Should use OPENCLAW_GATEWAY_PASSWORD env var when auth mode is password"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("sends Bearer header with password in checkCronToolAvailable", async () => {
+    const testConfig = {
+      gateway: {
+        port: 18789,
+        auth: {
+          mode: "password",
+          password: "check-cron-pw",
+        },
+      },
+    };
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(testConfig), "utf-8");
+
+    const mod = await import(`../dist/installer/gateway-api.js?v=check-${Date.now()}`);
+
+    const originalFetch = globalThis.fetch;
+    let capturedHeaders: Record<string, string> = {};
+
+    globalThis.fetch = mock.fn(async (_url: string, init: any) => {
+      capturedHeaders = init.headers || {};
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: {} }),
+      };
+    }) as any;
+
+    try {
+      const result = await mod.checkCronToolAvailable();
+      assert.equal(result.ok, true);
+      assert.equal(
+        capturedHeaders["Authorization"],
+        "Bearer check-cron-pw",
+        "checkCronToolAvailable should also use password auth"
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});


### PR DESCRIPTION
## Bug Description
Gateway API cron setup functions fail with 401 Unauthorized when the gateway is configured with `auth.mode: "password"` instead of token-based auth. The `readOpenClawConfig()` function only reads `config.gateway.auth.token`, ignoring password mode entirely, so no Authorization header is sent.

**Severity:** High — cron job setup is completely broken for password-auth gateway configurations.

## Root Cause
The bug is in src/installer/gateway-api.ts in two places:

1. `readOpenClawConfig()` (line ~13-22) only reads `config.gateway?.auth?.token` and completely ignores `config.gateway?.auth?.mode` and `config.gateway?.auth?.password`. When the gateway is configured with `auth.mode: "password"`, the config has `gateway.auth.password` instead of (or without) `gateway.auth.token`. Since `readOpenClawConfig` only extracts `token`, it returns `undefined` for the secret.

2. `GatewayConfig` interface (line ~7-10) only has `url` and `token` fields — no concept of auth mode or password.

3. All HTTP functions (createAgentCronJobHTTP, listCronJobsHTTP, deleteCronJobHTTP, checkCronToolAvailable) use: `if (gateway.token) headers["Authorization"] = "Bearer " + gateway.token` — when token is undefined (password mode), NO Authorization header is set at all, causing 401.

Key discovery from the OpenClaw gateway source: The gateway's `handleToolsInvokeHttpRequest` extracts the Bearer token via `getBearerToken(req)` and passes it as BOTH `token` AND `password` in the `connectAuth` object: `connectAuth: token ? { token, password: token } : null`. Then `authorizeGatewayConnect` checks `connectAuth.password` against `auth.password` when mode is "password". This means the password should be sent in the same `Authorization: Bearer <secret>` format — the gateway uses the same Bearer token extraction for both modes, it just compares the value against either the configured token or password depending on the mode.

## Fix
Updated src/installer/gateway-api.ts: (1) Added 'secret' field to GatewayConfig interface, (2) Updated readOpenClawConfig() to read auth.mode and auth.password (plus OPENCLAW_GATEWAY_PASSWORD env var), (3) Updated getGatewayConfig() to compute unified secret based on auth mode, (4) Changed all 4 HTTP functions to use gateway.secret instead of gateway.token for Authorization header. Added tests/gateway-password-auth.test.ts with 4 regression tests.

## Regression Test
Added tests/gateway-password-auth.test.ts with 4 tests: (1) sends Bearer header with password when auth mode is password, (2) sends Bearer header with token when auth mode is token, (3) uses OPENCLAW_GATEWAY_PASSWORD env var for password mode, (4) sends Bearer header with password in checkCronToolAvailable. All 4 pass.

## Verification
1. Git diff matches claimed changes — 2 files modified: src/installer/gateway-api.ts (+29 lines) and tests/gateway-password-auth.test.ts (+235 lines, new file)
2. Fix addresses root cause: readOpenClawConfig() now reads auth.mode and auth.password; getGatewayConfig() computes unified secret; all 4 HTTP functions use gateway.secret instead of gateway.token
3. Regression test (tests/gateway-password-auth.test.ts) tests the specific bug scenario with 4 tests: password auth Bearer header, token auth Bearer header, env var override, and checkCronToolAvailable with password auth — all 4 pass
4. Regression test would fail without the fix (verified by logic review: without the fix, password mode has no token → no Authorization header → assertion fails)
5. TypeScript typecheck passes (tsc --noEmit)
6. Build passes (tsc) 
7. Full test suite: 138 pass, 3 fail — all 3 failures are PRE-EXISTING on main (polling timeout tests expecting 30 vs 120), not caused by this fix
8. Fix is minimal and targeted — no refactoring, no unrelated changes
9. All changes are inside the repo (src/installer/gateway-api.ts and tests/gateway-password-auth.test.ts)
10. Backward compatibility maintained: token mode still works (tested), gateway.token still populated for any other consumers
