### PR TITLE
feat: medic watchdog agent for workflow health monitoring

### DIFF
--- a/src/medic/checks.ts
+++ b/src/medic/checks.ts
@@ -1,0 +1,210 @@
+/**
+ * Medic health checks — modular functions that inspect DB state and return findings.
+ */
+import { getDb } from "../db.js";
+import { getMaxRoleTimeoutSeconds } from "../installer/install.js";
+
+export type MedicSeverity = "info" | "warning" | "critical";
+export type MedicActionType =
+  | "reset_step"
+  | "fail_run"
+  | "teardown_crons"
+  | "none";
+
+export interface MedicFinding {
+  check: string;
+  severity: MedicSeverity;
+  message: string;
+  action: MedicActionType;
+  /** IDs of affected entities */
+  runId?: string;
+  stepId?: string;
+  /** Whether the medic auto-remediated this */
+  remediated: boolean;
+}
+
+// ── Check: Stuck Steps ──────────────────────────────────────────────
+
+const MAX_ROLE_TIMEOUT_MS = (getMaxRoleTimeoutSeconds() + 5 * 60) * 1000;
+
+/**
+ * Find steps that have been "running" longer than the max role timeout.
+ * These are likely abandoned by crashed/timed-out agents.
+ */
+export function checkStuckSteps(): MedicFinding[] {
+  const db = getDb();
+  const findings: MedicFinding[] = [];
+
+  const stuck = db.prepare(`
+    SELECT s.id, s.step_id, s.run_id, s.agent_id, s.updated_at, s.abandoned_count,
+           r.workflow_id, r.task
+    FROM steps s
+    JOIN runs r ON r.id = s.run_id
+    WHERE s.status = 'running'
+      AND r.status = 'running'
+      AND (julianday('now') - julianday(s.updated_at)) * 86400000 > ?
+  `).all(MAX_ROLE_TIMEOUT_MS) as Array<{
+    id: string; step_id: string; run_id: string; agent_id: string;
+    updated_at: string; abandoned_count: number; workflow_id: string; task: string;
+  }>;
+
+  for (const step of stuck) {
+    const ageMin = Math.round(
+      (Date.now() - new Date(step.updated_at).getTime()) / 60000
+    );
+    findings.push({
+      check: "stuck_steps",
+      severity: "warning",
+      message: `Step "${step.step_id}" in run ${step.run_id.slice(0, 8)} (${step.workflow_id}) has been running for ${ageMin}min — likely abandoned by agent ${step.agent_id}`,
+      action: "reset_step",
+      runId: step.run_id,
+      stepId: step.id,
+      remediated: false, // caller decides whether to remediate
+    });
+  }
+
+  return findings;
+}
+
+// ── Check: Stalled Runs ─────────────────────────────────────────────
+
+const STALL_THRESHOLD_MS = MAX_ROLE_TIMEOUT_MS * 2;
+
+/**
+ * Find runs where no step has transitioned in 2x the max role timeout.
+ * This catches systemic issues (all agents broken, crons failing, etc).
+ */
+export function checkStalledRuns(): MedicFinding[] {
+  const db = getDb();
+  const findings: MedicFinding[] = [];
+
+  // Get running runs where the most recent step update is stale
+  const stalled = db.prepare(`
+    SELECT r.id, r.workflow_id, r.task, r.updated_at,
+           MAX(s.updated_at) as last_step_update
+    FROM runs r
+    JOIN steps s ON s.run_id = r.id
+    WHERE r.status = 'running'
+    GROUP BY r.id
+    HAVING (julianday('now') - julianday(MAX(s.updated_at))) * 86400000 > ?
+  `).all(STALL_THRESHOLD_MS) as Array<{
+    id: string; workflow_id: string; task: string;
+    updated_at: string; last_step_update: string;
+  }>;
+
+  for (const run of stalled) {
+    const ageMin = Math.round(
+      (Date.now() - new Date(run.last_step_update).getTime()) / 60000
+    );
+    findings.push({
+      check: "stalled_runs",
+      severity: "critical",
+      message: `Run ${run.id.slice(0, 8)} (${run.workflow_id}: "${run.task.slice(0, 60)}") has had no step progress for ${ageMin}min`,
+      action: "none", // alert only — don't auto-fail without human input
+      runId: run.id,
+      remediated: false,
+    });
+  }
+
+  return findings;
+}
+
+// ── Check: Dead Runs ────────────────────────────────────────────────
+
+/**
+ * Find runs marked as "running" but all steps are terminal (done/failed)
+ * with no waiting/pending/running steps left. These are zombie runs.
+ */
+export function checkDeadRuns(): MedicFinding[] {
+  const db = getDb();
+  const findings: MedicFinding[] = [];
+
+  const zombies = db.prepare(`
+    SELECT r.id, r.workflow_id, r.task
+    FROM runs r
+    WHERE r.status = 'running'
+      AND NOT EXISTS (
+        SELECT 1 FROM steps s
+        WHERE s.run_id = r.id
+        AND s.status IN ('waiting', 'pending', 'running')
+      )
+  `).all() as Array<{ id: string; workflow_id: string; task: string }>;
+
+  for (const run of zombies) {
+    // Check if all steps are done (should be completed) or some are failed
+    const failed = db.prepare(
+      "SELECT COUNT(*) as cnt FROM steps WHERE run_id = ? AND status = 'failed'"
+    ).get(run.id) as { cnt: number };
+
+    const action: MedicActionType = "fail_run";
+    const detail = failed.cnt > 0
+      ? `${failed.cnt} failed step(s), no active steps remaining`
+      : `All steps terminal but run still marked as running`;
+
+    findings.push({
+      check: "dead_runs",
+      severity: "critical",
+      message: `Run ${run.id.slice(0, 8)} (${run.workflow_id}) is a zombie — ${detail}`,
+      action,
+      runId: run.id,
+      remediated: false,
+    });
+  }
+
+  return findings;
+}
+
+// ── Check: Orphaned Crons ───────────────────────────────────────────
+
+/**
+ * Check if agent crons exist for workflows with zero active runs.
+ * Returns workflow IDs that should have their crons torn down.
+ *
+ * NOTE: This check requires the list of current cron jobs to be passed in,
+ * since reading crons is async (gateway API). The medic runner handles this.
+ */
+export function checkOrphanedCrons(
+  cronJobs: Array<{ id: string; name: string }>,
+): MedicFinding[] {
+  const db = getDb();
+  const findings: MedicFinding[] = [];
+
+  // Extract unique workflow IDs from antfarm cron job names
+  const workflowIds = new Set<string>();
+  for (const job of cronJobs) {
+    const match = job.name.match(/^antfarm\/([^/]+)\//);
+    if (match) workflowIds.add(match[1]);
+  }
+
+  for (const wfId of workflowIds) {
+    const active = db.prepare(
+      "SELECT COUNT(*) as cnt FROM runs WHERE workflow_id = ? AND status = 'running'"
+    ).get(wfId) as { cnt: number };
+
+    if (active.cnt === 0) {
+      const jobCount = cronJobs.filter(j => j.name.startsWith(`antfarm/${wfId}/`)).length;
+      findings.push({
+        check: "orphaned_crons",
+        severity: "warning",
+        message: `${jobCount} cron job(s) for workflow "${wfId}" still running but no active runs exist`,
+        action: "teardown_crons",
+        remediated: false,
+      });
+    }
+  }
+
+  return findings;
+}
+
+// ── Run All Checks ──────────────────────────────────────────────────
+
+/**
+ * Run all synchronous checks (everything except orphaned crons which needs async cron list).
+ */
+export function runSyncChecks(): MedicFinding[] {
+  return [
+    ...checkStuckSteps(),
+    ...checkStalledRuns(),
+    ...checkDeadRuns(),
+  ];
+}

--- a/src/medic/medic-cron.ts
+++ b/src/medic/medic-cron.ts
@@ -1,0 +1,115 @@
+/**
+ * Medic cron management — install/uninstall the medic's periodic check cron job.
+ */
+import { createAgentCronJob, deleteCronJob, listCronJobs } from "../installer/gateway-api.js";
+import { resolveAntfarmCli } from "../installer/paths.js";
+import { readOpenClawConfig, writeOpenClawConfig } from "../installer/openclaw-config.js";
+
+const MEDIC_CRON_NAME = "antfarm/medic";
+const MEDIC_EVERY_MS = 5 * 60 * 1000; // 5 minutes
+const MEDIC_MODEL = "claude-sonnet-4-20250514";
+const MEDIC_TIMEOUT_SECONDS = 120;
+
+function buildMedicPrompt(): string {
+  const cli = resolveAntfarmCli();
+  return `You are the Antfarm Medic — a health watchdog for workflow runs.
+
+Run the medic check:
+\`\`\`
+node ${cli} medic run
+\`\`\`
+
+If the output says "All clear", reply HEARTBEAT_OK and stop.
+
+If issues were found, summarize what was detected and what actions were taken.
+If there are critical unremediated issues, use sessions_send to alert the main session:
+\`\`\`
+sessions_send(sessionKey: "agent:main:main", message: "🚑 Antfarm Medic Alert: <summary of critical issues>")
+\`\`\`
+
+Do NOT attempt to fix issues yourself beyond what the medic check already handles.`;
+}
+
+async function ensureMedicAgent(): Promise<void> {
+  try {
+    const { path, config } = await readOpenClawConfig();
+    const agents = config.agents?.list ?? [];
+    if (agents.some((a: any) => a.id === "antfarm-medic")) return;
+
+    if (!config.agents) config.agents = {};
+    if (!config.agents.list) config.agents.list = [];
+    config.agents.list.push({
+      id: "antfarm-medic",
+      name: "Antfarm Medic",
+      model: MEDIC_MODEL,
+    });
+    await writeOpenClawConfig(path, config);
+  } catch {
+    // best-effort — cron will still work without agent provisioning
+  }
+}
+
+async function removeMedicAgent(): Promise<void> {
+  try {
+    const { path, config } = await readOpenClawConfig();
+    const agents = config.agents?.list ?? [];
+    const idx = agents.findIndex((a: any) => a.id === "antfarm-medic");
+    if (idx === -1) return;
+    agents.splice(idx, 1);
+    await writeOpenClawConfig(path, config);
+  } catch {
+    // best-effort
+  }
+}
+
+export async function installMedicCron(): Promise<{ ok: boolean; error?: string }> {
+  // Check if already installed
+  const existing = await findMedicCronJob();
+  if (existing) {
+    return { ok: true }; // already installed
+  }
+
+  // Ensure agent is provisioned in OpenClaw config
+  await ensureMedicAgent();
+
+  const result = await createAgentCronJob({
+    name: MEDIC_CRON_NAME,
+    schedule: { kind: "every", everyMs: MEDIC_EVERY_MS },
+    sessionTarget: "isolated",
+    agentId: "antfarm-medic",
+    payload: {
+      kind: "agentTurn",
+      message: buildMedicPrompt(),
+      model: MEDIC_MODEL,
+      timeoutSeconds: MEDIC_TIMEOUT_SECONDS,
+    },
+    delivery: { mode: "none" },
+    enabled: true,
+  });
+
+  return result;
+}
+
+export async function uninstallMedicCron(): Promise<{ ok: boolean; error?: string }> {
+  const job = await findMedicCronJob();
+  if (!job) {
+    await removeMedicAgent();
+    return { ok: true }; // nothing to remove
+  }
+  const result = await deleteCronJob(job.id);
+  if (result.ok) {
+    await removeMedicAgent();
+  }
+  return result;
+}
+
+export async function isMedicCronInstalled(): Promise<boolean> {
+  const job = await findMedicCronJob();
+  return job !== null;
+}
+
+async function findMedicCronJob(): Promise<{ id: string; name: string } | null> {
+  const result = await listCronJobs();
+  if (!result.ok || !result.jobs) return null;
+  return result.jobs.find(j => j.name === MEDIC_CRON_NAME) ?? null;
+}

--- a/src/medic/medic.ts
+++ b/src/medic/medic.ts
@@ -1,0 +1,280 @@
+/**
+ * Medic — the antfarm health watchdog.
+ *
+ * Runs periodic health checks on workflow runs, detects stuck/stalled/dead state,
+ * and takes corrective action where safe. Logs all findings to the medic_checks table.
+ */
+import { getDb } from "../db.js";
+import { emitEvent, type EventType } from "../installer/events.js";
+import { teardownWorkflowCronsIfIdle } from "../installer/agent-cron.js";
+import { listCronJobs } from "../installer/gateway-api.js";
+import {
+  runSyncChecks,
+  checkOrphanedCrons,
+  type MedicFinding,
+} from "./checks.js";
+import crypto from "node:crypto";
+
+// ── DB Migration ────────────────────────────────────────────────────
+
+export function ensureMedicTables(): void {
+  const db = getDb();
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS medic_checks (
+      id TEXT PRIMARY KEY,
+      checked_at TEXT NOT NULL,
+      issues_found INTEGER DEFAULT 0,
+      actions_taken INTEGER DEFAULT 0,
+      summary TEXT,
+      details TEXT
+    )
+  `);
+}
+
+// ── Remediation ─────────────────────────────────────────────────────
+
+/**
+ * Attempt to remediate a finding. Returns true if action was taken.
+ */
+async function remediate(finding: MedicFinding): Promise<boolean> {
+  const db = getDb();
+
+  switch (finding.action) {
+    case "reset_step": {
+      if (!finding.stepId) return false;
+      // Reset the stuck step to pending so it can be reclaimed
+      const step = db.prepare(
+        "SELECT abandoned_count FROM steps WHERE id = ?"
+      ).get(finding.stepId) as { abandoned_count: number } | undefined;
+      if (!step) return false;
+
+      const newCount = (step.abandoned_count ?? 0) + 1;
+      // Don't auto-reset if already abandoned too many times — let cleanupAbandonedSteps handle final failure
+      if (newCount >= 5) {
+        db.prepare(
+          "UPDATE steps SET status = 'failed', output = 'Medic: abandoned too many times', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
+        ).run(newCount, finding.stepId);
+        if (finding.runId) {
+          db.prepare(
+            "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
+          ).run(finding.runId);
+          emitEvent({
+            ts: new Date().toISOString(),
+            event: "run.failed" as EventType,
+            runId: finding.runId,
+            detail: "Medic: step abandoned too many times",
+          });
+        }
+        return true;
+      }
+
+      db.prepare(
+        "UPDATE steps SET status = 'pending', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(newCount, finding.stepId);
+      if (finding.runId) {
+        emitEvent({
+          ts: new Date().toISOString(),
+          event: "step.timeout" as EventType,
+          runId: finding.runId,
+          stepId: finding.stepId,
+          detail: `Medic: reset stuck step (abandon ${newCount}/5)`,
+        });
+      }
+      return true;
+    }
+
+    case "fail_run": {
+      if (!finding.runId) return false;
+      const run = db.prepare("SELECT status, workflow_id FROM runs WHERE id = ?").get(finding.runId) as { status: string; workflow_id: string } | undefined;
+      if (!run || run.status !== "running") return false;
+
+      db.prepare(
+        "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
+      ).run(finding.runId);
+      // Also fail any non-terminal steps
+      db.prepare(
+        "UPDATE steps SET status = 'failed', output = 'Medic: run marked as dead', updated_at = datetime('now') WHERE run_id = ? AND status IN ('waiting', 'pending', 'running')"
+      ).run(finding.runId);
+      emitEvent({
+        ts: new Date().toISOString(),
+        event: "run.failed" as EventType,
+        runId: finding.runId,
+        workflowId: run.workflow_id,
+        detail: "Medic: zombie run — all steps terminal but run still marked running",
+      });
+      // Try to clean up crons
+      try { await teardownWorkflowCronsIfIdle(run.workflow_id); } catch {}
+      return true;
+    }
+
+    case "teardown_crons": {
+      // Extract workflow ID from the message (format: "... for workflow "xyz" ...")
+      const match = finding.message.match(/workflow "([^"]+)"/);
+      if (!match) return false;
+      try {
+        await teardownWorkflowCronsIfIdle(match[1]);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    case "none":
+    default:
+      return false;
+  }
+}
+
+// ── Main Check Runner ───────────────────────────────────────────────
+
+export interface MedicCheckResult {
+  id: string;
+  checkedAt: string;
+  issuesFound: number;
+  actionsTaken: number;
+  summary: string;
+  findings: MedicFinding[];
+}
+
+/**
+ * Run all medic checks, remediate what we can, and log results.
+ */
+export async function runMedicCheck(): Promise<MedicCheckResult> {
+  ensureMedicTables();
+
+  // Gather all findings
+  const findings: MedicFinding[] = runSyncChecks();
+
+  // Async check: orphaned crons
+  try {
+    const cronResult = await listCronJobs();
+    if (cronResult.ok && cronResult.jobs) {
+      const antfarmCrons = cronResult.jobs.filter(j => j.name.startsWith("antfarm/"));
+      findings.push(...checkOrphanedCrons(antfarmCrons));
+    }
+  } catch {
+    // Can't check crons — skip this check
+  }
+
+  // Remediate
+  let actionsTaken = 0;
+  for (const finding of findings) {
+    if (finding.action !== "none") {
+      const success = await remediate(finding);
+      if (success) {
+        finding.remediated = true;
+        actionsTaken++;
+      }
+    }
+  }
+
+  // Build summary
+  const parts: string[] = [];
+  if (findings.length === 0) {
+    parts.push("All clear — no issues found");
+  } else {
+    const critical = findings.filter(f => f.severity === "critical").length;
+    const warnings = findings.filter(f => f.severity === "warning").length;
+    if (critical > 0) parts.push(`${critical} critical`);
+    if (warnings > 0) parts.push(`${warnings} warning(s)`);
+    if (actionsTaken > 0) parts.push(`${actionsTaken} auto-fixed`);
+  }
+  const summary = parts.join(", ");
+
+  // Log to DB
+  const checkId = crypto.randomUUID();
+  const checkedAt = new Date().toISOString();
+  const db = getDb();
+  db.prepare(
+    "INSERT INTO medic_checks (id, checked_at, issues_found, actions_taken, summary, details) VALUES (?, ?, ?, ?, ?, ?)"
+  ).run(checkId, checkedAt, findings.length, actionsTaken, summary, JSON.stringify(findings));
+
+  // Prune old checks (keep last 500)
+  db.prepare(`
+    DELETE FROM medic_checks WHERE id NOT IN (
+      SELECT id FROM medic_checks ORDER BY checked_at DESC LIMIT 500
+    )
+  `).run();
+
+  return {
+    id: checkId,
+    checkedAt,
+    issuesFound: findings.length,
+    actionsTaken,
+    summary,
+    findings,
+  };
+}
+
+// ── Query Helpers ───────────────────────────────────────────────────
+
+export interface MedicStatus {
+  installed: boolean;
+  lastCheck: { checkedAt: string; summary: string; issuesFound: number; actionsTaken: number } | null;
+  recentChecks: number; // checks in last 24h
+  recentIssues: number; // issues found in last 24h
+  recentActions: number; // actions taken in last 24h
+}
+
+export function getMedicStatus(): MedicStatus {
+  try {
+    ensureMedicTables();
+    const db = getDb();
+
+    const last = db.prepare(
+      "SELECT checked_at, summary, issues_found, actions_taken FROM medic_checks ORDER BY checked_at DESC LIMIT 1"
+    ).get() as { checked_at: string; summary: string; issues_found: number; actions_taken: number } | undefined;
+
+    const stats = db.prepare(`
+      SELECT COUNT(*) as checks, COALESCE(SUM(issues_found), 0) as issues, COALESCE(SUM(actions_taken), 0) as actions
+      FROM medic_checks
+      WHERE checked_at > datetime('now', '-24 hours')
+    `).get() as { checks: number; issues: number; actions: number };
+
+    return {
+      installed: true,
+      lastCheck: last ? {
+        checkedAt: last.checked_at,
+        summary: last.summary,
+        issuesFound: last.issues_found,
+        actionsTaken: last.actions_taken,
+      } : null,
+      recentChecks: stats.checks,
+      recentIssues: stats.issues,
+      recentActions: stats.actions,
+    };
+  } catch {
+    return { installed: false, lastCheck: null, recentChecks: 0, recentIssues: 0, recentActions: 0 };
+  }
+}
+
+export function getRecentMedicChecks(limit = 20): Array<{
+  id: string;
+  checkedAt: string;
+  issuesFound: number;
+  actionsTaken: number;
+  summary: string;
+  details: MedicFinding[];
+}> {
+  try {
+    ensureMedicTables();
+    const db = getDb();
+    const rows = db.prepare(
+      "SELECT * FROM medic_checks ORDER BY checked_at DESC LIMIT ?"
+    ).all(limit) as Array<{
+      id: string; checked_at: string; issues_found: number;
+      actions_taken: number; summary: string; details: string;
+    }>;
+
+    return rows.map(r => ({
+      id: r.id,
+      checkedAt: r.checked_at,
+      issuesFound: r.issues_found,
+      actionsTaken: r.actions_taken,
+      summary: r.summary,
+      details: JSON.parse(r.details ?? "[]"),
+    }));
+  } catch {
+    return [];
+  }
+}

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -8,6 +8,7 @@ import YAML from "yaml";
 
 import type { RunInfo, StepInfo } from "../installer/status.js";
 import { getRunEvents } from "../installer/events.js";
+import { getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -101,6 +102,16 @@ export function startDashboard(port = 3333): http.Server {
     if (p === "/api/runs") {
       const wf = url.searchParams.get("workflow") ?? undefined;
       return json(res, getRuns(wf));
+    }
+
+    // Medic API
+    if (p === "/api/medic/status") {
+      return json(res, getMedicStatus());
+    }
+
+    if (p === "/api/medic/checks") {
+      const limit = parseInt(url.searchParams.get("limit") ?? "20", 10);
+      return json(res, getRecentMedicChecks(limit));
     }
 
     // Serve fonts

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -182,6 +182,28 @@ select:focus{outline:none;border-color:#8ECFC0}
 .story-chevron-open{transform:rotate(90deg)}
 .step-open{display:block!important}
 .step-chevron-open{transform:rotate(90deg)}
+
+/* ── Medic indicator ───────────────────────────────────────────── */
+.medic-badge{display:flex;align-items:center;gap:6px;font-size:12px;color:rgba(255,255,255,.85);cursor:pointer;padding:4px 10px;border:1px solid rgba(255,255,255,.15);border-radius:6px;background:transparent;transition:border-color .15s,background .15s}
+.medic-badge:hover{border-color:rgba(255,255,255,.4);background:rgba(255,255,255,.05)}
+.medic-dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.medic-dot.healthy{background:#4ade80;box-shadow:0 0 6px rgba(74,222,128,.5);animation:pulse 2s infinite}
+.medic-dot.warning{background:#fbbf24;box-shadow:0 0 6px rgba(251,191,36,.5)}
+.medic-dot.critical{background:#f87171;box-shadow:0 0 6px rgba(248,113,113,.5);animation:pulse 1s infinite}
+.medic-dot.unknown{background:#9ca3af}
+@keyframes pulse{0%,100%{opacity:1}50%{opacity:.5}}
+
+.medic-panel{position:fixed;top:60px;right:16px;width:340px;max-height:500px;background:var(--bg-surface);border:1px solid var(--border);border-radius:10px;box-shadow:0 8px 32px var(--shadow-heavy);z-index:50;overflow:hidden;display:none;flex-direction:column}
+.medic-panel.open{display:flex}
+.medic-panel-header{padding:14px 16px;border-bottom:1px solid var(--border-light);font-size:14px;font-weight:600;color:var(--text-primary);display:flex;align-items:center;gap:8px}
+.medic-panel-body{padding:12px 16px;overflow-y:auto;flex:1}
+.medic-stat{display:flex;justify-content:space-between;padding:6px 0;font-size:12px;color:var(--text-secondary);border-bottom:1px solid var(--border-light)}
+.medic-stat:last-child{border-bottom:none}
+.medic-stat-value{font-weight:600;color:var(--text-primary)}
+.medic-check-row{padding:8px 0;border-bottom:1px solid var(--border-light);font-size:11px;line-height:1.5}
+.medic-check-row:last-child{border-bottom:none}
+.medic-check-time{color:var(--text-secondary);font-family:'Geist Mono',monospace}
+.medic-check-summary{color:var(--text-primary);margin-left:8px}
 </style>
 </head>
 <body>
@@ -189,9 +211,17 @@ select:focus{outline:none;border-color:#8ECFC0}
   <h1><span>antfarm</span> dashboard</h1>
   <select id="wf-select"><option value="">Loading...</option></select>
   <button class="theme-toggle" id="theme-toggle" title="Toggle light/dark mode" aria-label="Toggle light/dark mode">☀️</button>
+  <div class="medic-badge" id="medic-badge" onclick="toggleMedicPanel()" title="Medic watchdog status">
+    <span class="medic-dot unknown" id="medic-dot"></span>
+    <span id="medic-label">Medic</span>
+  </div>
   <span class="refresh-note" id="refresh-note">Auto-refresh: 30s</span>
 </header>
 <div class="board" id="board"><div class="empty" style="margin:auto">Select a workflow</div></div>
+<div class="medic-panel" id="medic-panel">
+  <div class="medic-panel-header">🚑 Medic Watchdog</div>
+  <div class="medic-panel-body" id="medic-panel-body">Loading...</div>
+</div>
 <div class="overlay" id="overlay" onclick="if(event.target===this)closePanel()">
   <div class="panel" id="panel"></div>
 </div>
@@ -424,6 +454,104 @@ async function loadStories(runId) {
 document.getElementById('wf-select').addEventListener('change', e => selectWorkflow(e.target.value));
 loadWorkflows();
 setInterval(() => { if (currentWf) loadRuns(); }, 30000);
+
+// ── Medic ───────────────────────────────────────────────────────
+let medicPanelOpen = false;
+
+function toggleMedicPanel() {
+  medicPanelOpen = !medicPanelOpen;
+  document.getElementById('medic-panel').classList.toggle('open', medicPanelOpen);
+  if (medicPanelOpen) loadMedicData();
+}
+
+document.addEventListener('click', e => {
+  if (!medicPanelOpen) return;
+  const panel = document.getElementById('medic-panel');
+  const badge = document.getElementById('medic-badge');
+  if (!panel.contains(e.target) && !badge.contains(e.target)) {
+    medicPanelOpen = false;
+    panel.classList.remove('open');
+  }
+});
+
+async function loadMedicStatus() {
+  try {
+    const status = await fetchJSON('/api/medic/status');
+    const dot = document.getElementById('medic-dot');
+    const label = document.getElementById('medic-label');
+
+    if (!status.installed || !status.lastCheck) {
+      dot.className = 'medic-dot unknown';
+      label.textContent = 'Medic';
+      return;
+    }
+
+    const ageMin = Math.round((Date.now() - new Date(status.lastCheck.checkedAt).getTime()) / 60000);
+    const hasIssues = status.lastCheck.issuesFound > 0;
+    const isStale = ageMin > 10;
+
+    if (hasIssues && status.lastCheck.actionsTaken < status.lastCheck.issuesFound) {
+      dot.className = 'medic-dot critical';
+      label.textContent = `${status.lastCheck.issuesFound} issue(s)`;
+    } else if (isStale) {
+      dot.className = 'medic-dot warning';
+      label.textContent = `${ageMin}m ago`;
+    } else if (hasIssues) {
+      dot.className = 'medic-dot warning';
+      label.textContent = `${status.lastCheck.issuesFound} fixed`;
+    } else {
+      dot.className = 'medic-dot healthy';
+      label.textContent = `${ageMin}m ago`;
+    }
+  } catch {
+    document.getElementById('medic-dot').className = 'medic-dot unknown';
+    document.getElementById('medic-label').textContent = 'Medic';
+  }
+}
+
+async function loadMedicData() {
+  const body = document.getElementById('medic-panel-body');
+  try {
+    const [status, checks] = await Promise.all([
+      fetchJSON('/api/medic/status'),
+      fetchJSON('/api/medic/checks?limit=10'),
+    ]);
+
+    let html = '';
+    html += '<div style="margin-bottom:12px">';
+    if (status.lastCheck) {
+      const ageMin = Math.round((Date.now() - new Date(status.lastCheck.checkedAt).getTime()) / 60000);
+      html += `<div class="medic-stat"><span>Last check</span><span class="medic-stat-value">${ageMin}m ago</span></div>`;
+      html += `<div class="medic-stat"><span>Result</span><span class="medic-stat-value">${esc(status.lastCheck.summary)}</span></div>`;
+    } else {
+      html += '<div class="medic-stat"><span>Last check</span><span class="medic-stat-value">Never</span></div>';
+    }
+    html += `<div class="medic-stat"><span>Checks (24h)</span><span class="medic-stat-value">${status.recentChecks}</span></div>`;
+    html += `<div class="medic-stat"><span>Issues found (24h)</span><span class="medic-stat-value">${status.recentIssues}</span></div>`;
+    html += `<div class="medic-stat"><span>Auto-fixed (24h)</span><span class="medic-stat-value">${status.recentActions}</span></div>`;
+    html += '</div>';
+
+    if (checks.length > 0) {
+      html += '<div style="font-size:12px;font-weight:600;color:var(--text-primary);margin-bottom:8px">Recent Checks</div>';
+      for (const c of checks) {
+        const t = new Date(c.checkedAt).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'});
+        const icon = c.issuesFound === 0 ? '·' : c.actionsTaken > 0 ? '~' : '!';
+        const color = c.issuesFound === 0 ? 'var(--text-secondary)' : c.actionsTaken >= c.issuesFound ? 'var(--accent-teal)' : 'var(--accent-orange)';
+        html += `<div class="medic-check-row">
+          <span class="medic-check-time">${t}</span>
+          <span class="medic-check-summary" style="color:${color}">${icon} ${esc(c.summary)}</span>
+        </div>`;
+      }
+    }
+
+    body.innerHTML = html || '<div style="color:var(--text-secondary);font-size:12px;padding:8px 0">No medic data yet. Run <code>antfarm medic install</code> to enable.</div>';
+  } catch {
+    body.innerHTML = '<div style="color:var(--text-secondary);font-size:12px;padding:8px 0">Could not load medic data.</div>';
+  }
+}
+
+loadMedicStatus();
+setInterval(loadMedicStatus, 30000);
 
 // ── Theme toggle ──────────────────────────────────────────────────
 (function initTheme() {


### PR DESCRIPTION
## What

Adds a **medic agent** — a singleton system watchdog that monitors all antfarm workflow runs for health issues and takes corrective action.

## Why

We've been manually diagnosing stuck workflows via `sqlite3` commands and manual cron cleanup. The medic automates this:
- Detects stuck steps (running past timeout) and resets them
- Flags stalled runs (no progress for extended periods)
- Catches zombie runs (all steps done/failed but run still 'running')
- Finds orphaned crons (agents polling with no active runs to serve)

## What's included

### New module: `src/medic/`
- **checks.ts** — Modular health check functions (stuck steps, stalled runs, dead runs, orphaned crons)
- **medic.ts** — Check runner, remediation engine, DB logging (`medic_checks` table)
- **medic-cron.ts** — Cron install/uninstall + agent provisioning in OpenClaw config

### CLI commands
```
antfarm medic install     # Creates cron (every 5 min, sonnet — cheap)
antfarm medic uninstall   # Removes cron + agent config
antfarm medic run         # Manual health check
antfarm medic status      # Overview
antfarm medic log [N]     # Recent check history
```

### Dashboard
- **Header indicator** — pulsing green/yellow/red dot showing medic health at a glance
- **Click-to-open panel** — stats (last 24h checks, issues, auto-fixes) + recent check log
- **API endpoints** — `/api/medic/status`, `/api/medic/checks`

## Testing

Manually tested all CLI commands + dashboard integration. Medic cron is already running on the test instance.

Closes #125 (if we want to file one)