### PR TITLE
fix: polling agents include own id in allowAgents

### DIFF
--- a/src/installer/install.ts
+++ b/src/installer/install.ts
@@ -153,7 +153,16 @@ export function getMaxRoleTimeoutSeconds(): number {
   return Math.max(...Object.values(ROLE_POLICIES).map(r => r.timeoutSeconds));
 }
 
-const SUBAGENT_POLICY = { allowAgents: [] as string[] };
+/**
+ * Build subagent policy for a workflow agent.
+ *
+ * Polling cron sessions use sessions_spawn to hand off work to a
+ * dedicated worker session running the same agent.  The agent must
+ * list its own id in allowAgents or the spawn call is rejected.
+ */
+function buildSubagentPolicy(agentId: string) {
+  return { allowAgents: [agentId] };
+}
 
 /**
  * Infer an agent's role from its id when not explicitly set in workflow YAML.
@@ -219,7 +228,7 @@ function upsertAgent(
     workspace: agent.workspaceDir,
     agentDir: agent.agentDir,
     tools: buildToolsConfig(agent.role),
-    subagents: SUBAGENT_POLICY,
+    subagents: buildSubagentPolicy(agent.id),
   };
   if (agent.model) payload.model = agent.model;
   // Note: timeoutSeconds is NOT written to the agent config entry because


### PR DESCRIPTION
## Problem

v0.4.0 introduced two-phase polling: a cheap model claims work via `step claim`, then calls `sessions_spawn` to hand it off to a worker session. The worker runs under the same agent id.

`SUBAGENT_POLICY` hardcoded `allowAgents: []` for every provisioned agent. The spawn call returned `forbidden` because the agent had no permission to spawn itself. The poller had already claimed the step (status → `running`), so the step was stuck — no other agent could claim it, and the poller could not report failure.

## Root cause

`src/installer/install.ts`, line 156:

```ts
const SUBAGENT_POLICY = { allowAgents: [] as string[] };
```

Applied to all agents via `upsertAgent`. No agent could spawn any other agent (or itself).

## Fix

Replace the static empty-array constant with a per-agent function that includes the agent's own id:

```ts
function buildSubagentPolicy(agentId: string) {
  return { allowAgents: [agentId] };
}
```

One file changed, 11 insertions, 2 deletions. Compiles clean.

## Related

Partially addresses #106 (cron agent sessions route to main agent instead of per-workflow agents).