### PR TITLE
Add /api/ping endpoint to dashboard

### DIFF
--- a/src/server/dashboard.test.ts
+++ b/src/server/dashboard.test.ts
@@ -1,0 +1,33 @@
+import { startDashboard } from "./dashboard.js";
+import http from "node:http";
+
+async function fetch(url: string): Promise<{ status: number; headers: http.IncomingHttpHeaders; body: string }> {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      let data = "";
+      res.on("data", (chunk: Buffer) => { data += chunk; });
+      res.on("end", () => resolve({ status: res.statusCode!, headers: res.headers, body: data }));
+    }).on("error", reject);
+  });
+}
+
+async function main() {
+  const port = 39123;
+  const server = startDashboard(port);
+
+  // Wait for listen
+  await new Promise<void>((r) => setTimeout(r, 500));
+
+  try {
+    const res = await fetch(`http://localhost:${port}/api/ping`);
+    console.assert(res.status === 200, `Expected 200, got ${res.status}`);
+    console.assert(res.headers["content-type"] === "application/json", `Bad content-type: ${res.headers["content-type"]}`);
+    const body = JSON.parse(res.body);
+    console.assert(body.pong === true, `Expected {pong:true}, got ${JSON.stringify(body)}`);
+    console.log("✅ All /api/ping tests passed");
+  } finally {
+    server.close();
+  }
+}
+
+main().catch((e) => { console.error("❌ Test failed:", e); process.exit(1); });

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -75,6 +75,10 @@ export function startDashboard(port = 3333): http.Server {
     const url = new URL(req.url ?? "/", `http://localhost:${port}`);
     const p = url.pathname;
 
+    if (p === "/api/ping") {
+      return json(res, { pong: true });
+    }
+
     if (p === "/api/workflows") {
       return json(res, loadWorkflows());
     }


### PR DESCRIPTION
## Summary
Adds a GET `/api/ping` endpoint to the Antfarm dashboard that returns `{"pong": true}`.

## Changes
- Added GET `/api/ping` route to `dashboard.ts`
- Created `dashboard.test.ts` with integration test

## Testing
- Build passes successfully
- Manually tested endpoint by starting dashboard on port 19876 and hitting `/api/ping` with `http.get` — returns `{"pong": true}` with status 200