### PR TITLE
fix: add agent-browser skill to feature-dev tester agent

### DIFF
--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -66,6 +66,8 @@ agents:
     description: Integration and E2E testing after all stories are implemented.
     workspace:
       baseDir: agents/tester
+      skills:
+        - agent-browser
       files:
         AGENTS.md: agents/tester/AGENTS.md
         SOUL.md: agents/tester/SOUL.md


### PR DESCRIPTION
The tester agent's step prompt and AGENTS.md both reference `agent-browser` for E2E testing, but the skill was not listed in the tester's workspace config in `workflow.yml`. This meant the agent never had the SKILL.md injected and couldn't use browser automation for integration testing.

The verifier and reviewer agents already had `agent-browser` listed — this just adds it to the tester as well.

**One-line change:** adds `skills: [agent-browser]` to the tester agent's workspace config in `workflows/feature-dev/workflow.yml`.