### PR TITLE
docs: restore operating-model compatibility stubs for downstream pointers

### DIFF
--- a/docs/operating-model/ANTFARM_OPERATING_MODEL_CANONICAL.md
+++ b/docs/operating-model/ANTFARM_OPERATING_MODEL_CANONICAL.md
@@ -1,0 +1,9 @@
+# ANTFARM_OPERATING_MODEL_CANONICAL
+
+Compatibility stubs for cross-repo pointer continuity.
+
+Authoritative in-repo reference:
+- docs/creating-workflows.md
+
+## Notes
+- Do not assume external runbooks exist in-repo.

--- a/docs/operating-model/ANTFARM_PROJECT_PROFILE_TEMPLATE.md
+++ b/docs/operating-model/ANTFARM_PROJECT_PROFILE_TEMPLATE.md
@@ -1,0 +1,9 @@
+# ANTFARM_PROJECT_PROFILE_TEMPLATE
+
+Compatibility stubs for cross-repo pointer continuity.
+
+Authoritative in-repo reference:
+- docs/creating-workflows.md
+
+## Notes
+- Do not assume external runbooks exist in-repo.


### PR DESCRIPTION
Problem: downstream docs reference docs/operating-model/ANTFARM_OPERATING_MODEL_CANONICAL.md and docs/operating-model/ANTFARM_PROJECT_PROFILE_TEMPLATE.md, but these paths are missing in current Antfarm.

Fix: add lightweight compatibility stubs at those paths, pointing to verified in-repo reference docs/creating-workflows.md.

Safety: docs-only change; no runtime/workflow behavior changes.

Verification: only adds two files under docs/operating-model/.