### PR TITLE
fix: document two-phase polling architecture in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ triage → investigate → setup → fix → verify → PR
 2. **Install** — One command provisions everything: agent workspaces, cron polling, subagent permissions. No Docker, no queues, no external services.
 3. **Run** — Agents poll for work independently. Claim a step, do the work, pass context to the next agent. SQLite tracks state. Cron keeps it moving.
 
+### Two-Phase Polling Architecture
+
+Antfarm uses a two-phase polling design to minimize cost:
+
+**Phase 1 — Cheap polling.** A lightweight model (Sonnet by default) runs on a cron schedule (every 5 minutes). It calls `step peek` to check for pending work. If there's nothing to do, it exits immediately. This keeps idle costs near zero.
+
+**Phase 2 — Expensive workers.** When work exists, the polling model claims the step (`step claim`) and spawns a dedicated worker session using the configured work model (Opus by default) via `sessions_spawn`. The expensive model only runs when there's actual work to process.
+
+**Configuration:**
+
+| Setting | Scope | Purpose |
+|---------|-------|---------|
+| `agent.pollingModel` | Per-agent | Override the polling model for a specific agent |
+| `workflow.polling.model` | Per-workflow | Set the polling model for all agents in a workflow |
+| `agent.model` | Per-agent | Set the work model (used in Phase 2) |
+
+The default polling model is `default` (resolves to Sonnet). The default work model is `default` (resolves to Opus). See `src/installer/agent-cron.ts` for implementation details.
+
 ### Minimal by design
 
 YAML + SQLite + cron. That's it. No Redis, no Kafka, no container orchestrator. Antfarm is a TypeScript CLI with zero external dependencies. It runs wherever OpenClaw runs.

--- a/tests/two-phase-polling-docs.test.ts
+++ b/tests/two-phase-polling-docs.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression test: README.md documents the two-phase polling architecture.
+ *
+ * This test ensures the README contains documentation about the two-phase
+ * polling design (cheap polling + expensive workers) so users understand
+ * the cost-optimization pattern.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+const README_PATH = path.resolve(import.meta.dirname, "..", "README.md");
+
+describe("README documents two-phase polling architecture", () => {
+  const readme = fs.readFileSync(README_PATH, "utf-8");
+
+  it("has a Two-Phase Polling Architecture section", () => {
+    assert.ok(
+      readme.includes("Two-Phase Polling Architecture"),
+      "README should contain a 'Two-Phase Polling Architecture' section"
+    );
+  });
+
+  it("documents Phase 1 cheap polling", () => {
+    assert.ok(
+      readme.includes("step peek"),
+      "README should mention 'step peek' for Phase 1 polling"
+    );
+  });
+
+  it("documents Phase 2 expensive workers", () => {
+    assert.ok(
+      readme.includes("sessions_spawn"),
+      "README should mention 'sessions_spawn' for Phase 2 worker spawning"
+    );
+  });
+
+  it("documents polling model configuration options", () => {
+    assert.ok(
+      readme.includes("pollingModel"),
+      "README should document the pollingModel configuration"
+    );
+    assert.ok(
+      readme.includes("polling.model"),
+      "README should document the workflow-level polling.model configuration"
+    );
+  });
+
+  it("references the implementation source file", () => {
+    assert.ok(
+      readme.includes("agent-cron.ts"),
+      "README should reference agent-cron.ts for implementation details"
+    );
+  });
+});


### PR DESCRIPTION
## Bug Description
The antfarm README.md lacks documentation of the two-phase polling architecture. Phase 1 uses a cheap model (Sonnet) for periodic polling to check for pending work, and Phase 2 spawns expensive workers (Opus) only when work is found. This pattern is implemented in src/installer/agent-cron.ts but not explained to users. This is a documentation enhancement request, not a bug.

**Severity:** low

## Root Cause
The README.md has no section documenting the two-phase polling architecture. The code in src/installer/agent-cron.ts (lines 91-151) implements a clear two-phase design: Phase 1 uses a cheap model (DEFAULT_POLLING_MODEL = claude-sonnet-4-20250514) via cron to run a lightweight "step peek" check every 5 minutes. Phase 2 only triggers when work exists — the polling prompt instructs the cheap model to call "step claim" and then spawn an expensive worker (defaulting to claude-opus-4-6) via sessions_spawn. The polling model is configurable per-agent (agent.pollingModel) or per-workflow (workflow.polling.model), and the work model comes from agent.model. This cost-optimization pattern is entirely undocumented in README.md — only a brief mention of "cron polling" exists at line 65.

## Fix
Added "Two-Phase Polling Architecture" section to README.md explaining Phase 1 (cheap Sonnet polling via step peek), Phase 2 (expensive Opus workers via sessions_spawn), configuration options, and referencing agent-cron.ts. Added tests/two-phase-polling-docs.test.ts.

## Regression Test
Added tests/two-phase-polling-docs.test.ts with 5 tests verifying README documents the two-phase polling section, step peek, sessions_spawn, pollingModel config, and agent-cron.ts reference.

## Verification
1) Diff contains exactly 2 files (README.md + test) matching claimed changes. 2) README adds a clear Two-Phase Polling Architecture section documenting Phase 1 (step peek, cheap Sonnet polling), Phase 2 (sessions_spawn, expensive Opus workers), config table, and agent-cron.ts reference. 3) Regression test has 5 assertions that would fail if the README section were reverted. 4) All new tests pass. 10 pre-existing failures exist on main (unrelated frontend detection tests). 5) Fix is minimal and targeted — documentation only, no code changes. 6) All changes inside repo.
