### PR TITLE
fix: stability improvements for race conditions, timeouts, and stuck steps

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -7,6 +7,8 @@ import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
 import { startDaemon, stopDaemon, getDaemonStatus, isRunning } from "../server/daemonctl.js";
 import { claimStep, completeStep, failStep, getStories } from "../installer/step-ops.js";
+import { findStuckSteps, recoverStuckSteps } from "../installer/stuck-recovery.js";
+import { deleteAgentCronJobs, listCronJobs } from "../installer/gateway-api.js";
 import { ensureCliSymlink } from "../installer/symlink.js";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
@@ -49,6 +51,9 @@ function printUsage() {
       "antfarm step complete <step-id>      Complete step (reads output from stdin)",
       "antfarm step fail <step-id> <error>  Fail step with retry logic",
       "antfarm step stories <run-id>       List stories for a run",
+      "",
+      "antfarm recover stuck [minutes]      Reset steps stuck in 'running' (default: 30 min)",
+      "antfarm cleanup crons                Delete all antfarm-managed cron jobs",
       "",
       "antfarm logs [<lines>]               Show recent log entries",
       "",
@@ -245,6 +250,40 @@ async function main() {
     process.stderr.write(`Unknown step action: ${action}\n`);
     printUsage();
     process.exit(1);
+  }
+
+  if (group === "recover" && action === "stuck") {
+    const minutes = parseInt(args[2], 10) || 30;
+    const stuck = findStuckSteps(minutes);
+    if (stuck.length === 0) {
+      console.log(`No steps stuck for more than ${minutes} minutes.`);
+      return;
+    }
+    console.log(`Found ${stuck.length} stuck step(s):`);
+    for (const s of stuck) {
+      console.log(`  ${s.id.slice(0, 8)}  ${s.step_id.padEnd(14)}  agent=${s.agent_id}  updated=${s.updated_at}`);
+    }
+    const recovered = recoverStuckSteps(minutes);
+    console.log(`Recovered ${recovered} step(s) back to pending.`);
+    return;
+  }
+
+  if (group === "cleanup" && action === "crons") {
+    const result = await listCronJobs();
+    if (!result.ok) {
+      process.stderr.write(`Failed to list crons: ${result.error}\n`);
+      process.exit(1);
+    }
+    const jobs = result.jobs ?? [];
+    const antfarmJobs = jobs.filter(j => j.name.startsWith("antfarm:"));
+    if (antfarmJobs.length === 0) {
+      console.log("No antfarm cron jobs found.");
+      return;
+    }
+    console.log(`Deleting ${antfarmJobs.length} antfarm cron job(s)...`);
+    await deleteAgentCronJobs("antfarm:");
+    console.log("Done.");
+    return;
   }
 
   if (group === "logs") {

--- a/src/db.ts
+++ b/src/db.ts
@@ -7,18 +7,14 @@ const DB_DIR = path.join(os.homedir(), ".openclaw", "antfarm");
 const DB_PATH = path.join(DB_DIR, "antfarm.db");
 
 let _db: DatabaseSync | null = null;
-let _dbOpenedAt = 0;
-const DB_MAX_AGE_MS = 5000;
 
 export function getDb(): DatabaseSync {
-  const now = Date.now();
-  if (_db && (now - _dbOpenedAt) < DB_MAX_AGE_MS) return _db;
-  if (_db) { try { _db.close(); } catch {} }
+  if (_db) return _db;
 
   fs.mkdirSync(DB_DIR, { recursive: true });
   _db = new DatabaseSync(DB_PATH);
-  _dbOpenedAt = now;
   _db.exec("PRAGMA journal_mode=WAL");
+  _db.exec("PRAGMA busy_timeout=5000");
   _db.exec("PRAGMA foreign_keys=ON");
   migrate(_db);
   return _db;

--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -30,6 +30,26 @@ async function getGatewayConfig(): Promise<GatewayConfig> {
   };
 }
 
+const FETCH_TIMEOUT_MS = 10_000;
+const MAX_RETRIES = 3;
+
+async function fetchWithRetry(url: string, options: RequestInit): Promise<Response> {
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+      const res = await fetch(url, { ...options, signal: controller.signal });
+      clearTimeout(timer);
+      return res;
+    } catch (err: any) {
+      clearTimeout(timer);
+      if (attempt === MAX_RETRIES - 1) throw err;
+      await new Promise(r => setTimeout(r, 500 * Math.pow(2, attempt)));
+    }
+  }
+  throw new Error("fetchWithRetry: all retries exhausted");
+}
+
 export async function createAgentCronJob(job: {
   name: string;
   schedule: { kind: string; everyMs?: number; anchorMs?: number };
@@ -45,7 +65,7 @@ export async function createAgentCronJob(job: {
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (gateway.token) headers["Authorization"] = `Bearer ${gateway.token}`;
 
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
+    const response = await fetchWithRetry(`${gateway.url}/tools/invoke`, {
       method: "POST",
       headers,
       body: JSON.stringify({ tool: "cron", args: { action: "add", job } }),
@@ -73,7 +93,7 @@ export async function listCronJobs(): Promise<{ ok: boolean; jobs?: Array<{ id: 
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (gateway.token) headers["Authorization"] = `Bearer ${gateway.token}`;
 
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
+    const response = await fetchWithRetry(`${gateway.url}/tools/invoke`, {
       method: "POST",
       headers,
       body: JSON.stringify({ tool: "cron", args: { action: "list" } }),
@@ -114,7 +134,7 @@ export async function deleteCronJob(jobId: string): Promise<{ ok: boolean; error
     const headers: Record<string, string> = { "Content-Type": "application/json" };
     if (gateway.token) headers["Authorization"] = `Bearer ${gateway.token}`;
 
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
+    const response = await fetchWithRetry(`${gateway.url}/tools/invoke`, {
       method: "POST",
       headers,
       body: JSON.stringify({ tool: "cron", args: { action: "remove", id: jobId } }),

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -194,200 +194,255 @@ interface ClaimResult {
 
 /**
  * Find and claim a pending step for an agent, returning the resolved input.
+ * Wrapped in BEGIN IMMEDIATE to prevent concurrent claim races.
  */
 export function claimStep(agentId: string): ClaimResult {
   const db = getDb();
+  db.exec("BEGIN IMMEDIATE");
+  let teardownRunId: string | undefined;
+  try {
+    const step = db.prepare(
+      "SELECT id, run_id, input_template, type, loop_config FROM steps WHERE agent_id = ? AND status = 'pending' LIMIT 1"
+    ).get(agentId) as { id: string; run_id: string; input_template: string; type: string; loop_config: string | null } | undefined;
 
-  const step = db.prepare(
-    "SELECT id, run_id, input_template, type, loop_config FROM steps WHERE agent_id = ? AND status = 'pending' LIMIT 1"
-  ).get(agentId) as { id: string; run_id: string; input_template: string; type: string; loop_config: string | null } | undefined;
-
-  if (!step) return { found: false };
-
-  // Get run context
-  const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string } | undefined;
-  const context: Record<string, string> = run ? JSON.parse(run.context) : {};
-
-  // T6: Loop step claim logic
-  if (step.type === "loop") {
-    const loopConfig: LoopConfig | null = step.loop_config ? JSON.parse(step.loop_config) : null;
-    if (loopConfig?.over === "stories") {
-      // Find next pending story
-      const nextStory = db.prepare(
-        "SELECT * FROM stories WHERE run_id = ? AND status = 'pending' ORDER BY story_index ASC LIMIT 1"
-      ).get(step.run_id) as any | undefined;
-
-      if (!nextStory) {
-        // No more stories — mark step done and advance
-        db.prepare(
-          "UPDATE steps SET status = 'done', updated_at = datetime('now') WHERE id = ?"
-        ).run(step.id);
-        advancePipeline(step.run_id);
-        return { found: false };
-      }
-
-      // Claim the story
-      db.prepare(
-        "UPDATE stories SET status = 'running', updated_at = datetime('now') WHERE id = ?"
-      ).run(nextStory.id);
-      db.prepare(
-        "UPDATE steps SET status = 'running', current_story_id = ?, updated_at = datetime('now') WHERE id = ?"
-      ).run(nextStory.id, step.id);
-
-      // Build story template vars
-      const story: Story = {
-        id: nextStory.id,
-        runId: nextStory.run_id,
-        storyIndex: nextStory.story_index,
-        storyId: nextStory.story_id,
-        title: nextStory.title,
-        description: nextStory.description,
-        acceptanceCriteria: JSON.parse(nextStory.acceptance_criteria),
-        status: nextStory.status,
-        output: nextStory.output ?? undefined,
-        retryCount: nextStory.retry_count,
-        maxRetries: nextStory.max_retries,
-      };
-
-      const allStories = getStories(step.run_id);
-      const pendingCount = allStories.filter(s => s.status === "pending" || s.status === "running").length;
-
-      context["current_story"] = formatStoryForTemplate(story);
-      context["current_story_id"] = story.storyId;
-      context["current_story_title"] = story.title;
-      context["completed_stories"] = formatCompletedStories(allStories);
-      context["stories_remaining"] = String(pendingCount);
-      context["progress"] = readProgressFile(step.run_id);
-
-      if (!context["verify_feedback"]) {
-        context["verify_feedback"] = "";
-      }
-
-      const resolvedInput = resolveTemplate(step.input_template, context);
-      return { found: true, stepId: step.id, runId: step.run_id, resolvedInput };
+    if (!step) {
+      db.exec("COMMIT");
+      return { found: false };
     }
+
+    // Get run context
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string } | undefined;
+    const context: Record<string, string> = run ? JSON.parse(run.context) : {};
+
+    // T6: Loop step claim logic
+    if (step.type === "loop") {
+      const loopConfig: LoopConfig | null = step.loop_config ? JSON.parse(step.loop_config) : null;
+      if (loopConfig?.over === "stories") {
+        // Find next pending story
+        const nextStory = db.prepare(
+          "SELECT * FROM stories WHERE run_id = ? AND status = 'pending' ORDER BY story_index ASC LIMIT 1"
+        ).get(step.run_id) as any | undefined;
+
+        if (!nextStory) {
+          // No more stories — mark step done and advance
+          db.prepare(
+            "UPDATE steps SET status = 'done', updated_at = datetime('now') WHERE id = ?"
+          ).run(step.id);
+          const result = advancePipeline(step.run_id);
+          teardownRunId = result.teardownRunId;
+          db.exec("COMMIT");
+          if (teardownRunId) scheduleRunCronTeardown(teardownRunId);
+          return { found: false };
+        }
+
+        // Claim the story
+        db.prepare(
+          "UPDATE stories SET status = 'running', updated_at = datetime('now') WHERE id = ?"
+        ).run(nextStory.id);
+        db.prepare(
+          "UPDATE steps SET status = 'running', current_story_id = ?, updated_at = datetime('now') WHERE id = ?"
+        ).run(nextStory.id, step.id);
+
+        // Build story template vars
+        const story: Story = {
+          id: nextStory.id,
+          runId: nextStory.run_id,
+          storyIndex: nextStory.story_index,
+          storyId: nextStory.story_id,
+          title: nextStory.title,
+          description: nextStory.description,
+          acceptanceCriteria: JSON.parse(nextStory.acceptance_criteria),
+          status: nextStory.status,
+          output: nextStory.output ?? undefined,
+          retryCount: nextStory.retry_count,
+          maxRetries: nextStory.max_retries,
+        };
+
+        const allStories = getStories(step.run_id);
+        const pendingCount = allStories.filter(s => s.status === "pending" || s.status === "running").length;
+
+        context["current_story"] = formatStoryForTemplate(story);
+        context["current_story_id"] = story.storyId;
+        context["current_story_title"] = story.title;
+        context["completed_stories"] = formatCompletedStories(allStories);
+        context["stories_remaining"] = String(pendingCount);
+        context["progress"] = readProgressFile(step.run_id);
+
+        if (!context["verify_feedback"]) {
+          context["verify_feedback"] = "";
+        }
+
+        const resolvedInput = resolveTemplate(step.input_template, context);
+        db.exec("COMMIT");
+        return { found: true, stepId: step.id, runId: step.run_id, resolvedInput };
+      }
+    }
+
+    // Single step: claim with optimistic lock
+    const updateResult = db.prepare(
+      "UPDATE steps SET status = 'running', updated_at = datetime('now') WHERE id = ? AND status = 'pending'"
+    ).run(step.id);
+
+    if (updateResult.changes === 0) {
+      // Another caller already claimed this step
+      db.exec("COMMIT");
+      return { found: false };
+    }
+
+    // Inject progress for any step in a run that has stories
+    const hasStories = db.prepare(
+      "SELECT COUNT(*) as cnt FROM stories WHERE run_id = ?"
+    ).get(step.run_id) as { cnt: number };
+    if (hasStories.cnt > 0) {
+      context["progress"] = readProgressFile(step.run_id);
+    }
+
+    const resolvedInput = resolveTemplate(step.input_template, context);
+
+    db.exec("COMMIT");
+    return {
+      found: true,
+      stepId: step.id,
+      runId: step.run_id,
+      resolvedInput,
+    };
+  } catch (e) {
+    try { db.exec("ROLLBACK"); } catch {}
+    throw e;
   }
-
-  // Single step: existing logic
-  db.prepare(
-    "UPDATE steps SET status = 'running', updated_at = datetime('now') WHERE id = ? AND status = 'pending'"
-  ).run(step.id);
-
-  // Inject progress for any step in a run that has stories
-  const hasStories = db.prepare(
-    "SELECT COUNT(*) as cnt FROM stories WHERE run_id = ?"
-  ).get(step.run_id) as { cnt: number };
-  if (hasStories.cnt > 0) {
-    context["progress"] = readProgressFile(step.run_id);
-  }
-
-  const resolvedInput = resolveTemplate(step.input_template, context);
-
-  return {
-    found: true,
-    stepId: step.id,
-    runId: step.run_id,
-    resolvedInput,
-  };
 }
 
 // ── Complete ────────────────────────────────────────────────────────
 
 /**
  * Complete a step: save output, merge context, advance pipeline.
+ * Wrapped in BEGIN IMMEDIATE for atomicity; parseAndInsertStories failures
+ * cause the step to fail gracefully instead of crashing.
  */
 export function completeStep(stepId: string, output: string): { advanced: boolean; runCompleted: boolean } {
   const db = getDb();
+  db.exec("BEGIN IMMEDIATE");
+  try {
+    const step = db.prepare(
+      "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
+    ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
 
-  const step = db.prepare(
-    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
-
-  if (!step) throw new Error(`Step not found: ${stepId}`);
-
-  // Merge KEY: value lines into run context
-  const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string };
-  const context: Record<string, string> = JSON.parse(run.context);
-
-  for (const line of output.split("\n")) {
-    const match = line.match(/^([A-Z_]+):\s*(.+)$/);
-    if (match && !match[1].startsWith("STORIES_JSON")) {
-      context[match[1].toLowerCase()] = match[2].trim();
+    if (!step) {
+      db.exec("ROLLBACK");
+      throw new Error(`Step not found: ${stepId}`);
     }
-  }
 
-  db.prepare(
-    "UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?"
-  ).run(JSON.stringify(context), step.run_id);
+    // Merge KEY: value lines into run context
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string };
+    const context: Record<string, string> = JSON.parse(run.context);
 
-  // T5: Parse STORIES_JSON from output (any step, typically the planner)
-  parseAndInsertStories(output, step.run_id);
-
-  // T7: Loop step completion
-  if (step.type === "loop" && step.current_story_id) {
-    // Mark current story done
-    db.prepare(
-      "UPDATE stories SET status = 'done', output = ?, updated_at = datetime('now') WHERE id = ?"
-    ).run(output, step.current_story_id);
-
-    // Clear current_story_id, save output
-    db.prepare(
-      "UPDATE steps SET current_story_id = NULL, output = ?, updated_at = datetime('now') WHERE id = ?"
-    ).run(output, step.id);
-
-    const loopConfig: LoopConfig | null = step.loop_config ? JSON.parse(step.loop_config) : null;
-
-    // T8: verify_each flow — set verify step to pending
-    if (loopConfig?.verifyEach && loopConfig.verifyStep) {
-      const verifyStep = db.prepare(
-        "SELECT id FROM steps WHERE run_id = ? AND step_id = ? LIMIT 1"
-      ).get(step.run_id, loopConfig.verifyStep) as { id: string } | undefined;
-
-      if (verifyStep) {
-        db.prepare(
-          "UPDATE steps SET status = 'pending', updated_at = datetime('now') WHERE id = ?"
-        ).run(verifyStep.id);
-        // Loop step stays 'running'
-        db.prepare(
-          "UPDATE steps SET status = 'running', updated_at = datetime('now') WHERE id = ?"
-        ).run(step.id);
-        return { advanced: false, runCompleted: false };
+    for (const line of output.split("\n")) {
+      const match = line.match(/^([A-Z_]+):\s*(.+)$/);
+      if (match && !match[1].startsWith("STORIES_JSON")) {
+        context[match[1].toLowerCase()] = match[2].trim();
       }
     }
 
-    // No verify_each: check for more stories
-    return checkLoopContinuation(step.run_id, step.id);
-  }
+    db.prepare(
+      "UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(JSON.stringify(context), step.run_id);
 
-  // T8: Check if this is a verify step triggered by verify-each
-  const loopStepRow = db.prepare(
-    "SELECT id, loop_config, run_id FROM steps WHERE run_id = ? AND type = 'loop' AND status = 'running' LIMIT 1"
-  ).get(step.run_id) as { id: string; loop_config: string | null; run_id: string } | undefined;
-
-  if (loopStepRow?.loop_config) {
-    const lc: LoopConfig = JSON.parse(loopStepRow.loop_config);
-    if (lc.verifyEach && lc.verifyStep === step.step_id) {
-      return handleVerifyEachCompletion(step, loopStepRow.id, output, context);
+    // T5: Parse STORIES_JSON from output (any step, typically the planner).
+    // If parsing fails, fail the step gracefully instead of crashing.
+    try {
+      parseAndInsertStories(output, step.run_id);
+    } catch (parseErr) {
+      db.prepare(
+        "UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(`STORIES_JSON parse error: ${(parseErr as Error).message}\n\n${output}`, stepId);
+      db.prepare(
+        "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
+      ).run(step.run_id);
+      db.exec("COMMIT");
+      scheduleRunCronTeardown(step.run_id);
+      return { advanced: false, runCompleted: false };
     }
+
+    // T7: Loop step completion
+    if (step.type === "loop" && step.current_story_id) {
+      // Mark current story done
+      db.prepare(
+        "UPDATE stories SET status = 'done', output = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(output, step.current_story_id);
+
+      // Clear current_story_id, save output
+      db.prepare(
+        "UPDATE steps SET current_story_id = NULL, output = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(output, step.id);
+
+      const loopConfig: LoopConfig | null = step.loop_config ? JSON.parse(step.loop_config) : null;
+
+      // T8: verify_each flow — set verify step to pending
+      if (loopConfig?.verifyEach && loopConfig.verifyStep) {
+        const verifyStep = db.prepare(
+          "SELECT id FROM steps WHERE run_id = ? AND step_id = ? LIMIT 1"
+        ).get(step.run_id, loopConfig.verifyStep) as { id: string } | undefined;
+
+        if (verifyStep) {
+          db.prepare(
+            "UPDATE steps SET status = 'pending', updated_at = datetime('now') WHERE id = ?"
+          ).run(verifyStep.id);
+          // Loop step stays 'running'
+          db.prepare(
+            "UPDATE steps SET status = 'running', updated_at = datetime('now') WHERE id = ?"
+          ).run(step.id);
+          db.exec("COMMIT");
+          return { advanced: false, runCompleted: false };
+        }
+      }
+
+      // No verify_each: check for more stories
+      const result = checkLoopContinuation(step.run_id, step.id);
+      db.exec("COMMIT");
+      if (result.teardownRunId) scheduleRunCronTeardown(result.teardownRunId);
+      return { advanced: result.advanced, runCompleted: result.runCompleted };
+    }
+
+    // T8: Check if this is a verify step triggered by verify-each
+    const loopStepRow = db.prepare(
+      "SELECT id, loop_config, run_id FROM steps WHERE run_id = ? AND type = 'loop' AND status = 'running' LIMIT 1"
+    ).get(step.run_id) as { id: string; loop_config: string | null; run_id: string } | undefined;
+
+    if (loopStepRow?.loop_config) {
+      const lc: LoopConfig = JSON.parse(loopStepRow.loop_config);
+      if (lc.verifyEach && lc.verifyStep === step.step_id) {
+        const result = handleVerifyEachCompletion(step, loopStepRow.id, output, context);
+        db.exec("COMMIT");
+        if (result.teardownRunId) scheduleRunCronTeardown(result.teardownRunId);
+        return { advanced: result.advanced, runCompleted: result.runCompleted };
+      }
+    }
+
+    // Single step: mark done and advance
+    db.prepare(
+      "UPDATE steps SET status = 'done', output = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(output, stepId);
+
+    const result = advancePipeline(step.run_id);
+    db.exec("COMMIT");
+    if (result.teardownRunId) scheduleRunCronTeardown(result.teardownRunId);
+    return { advanced: result.advanced, runCompleted: result.runCompleted };
+  } catch (e) {
+    try { db.exec("ROLLBACK"); } catch {}
+    throw e;
   }
-
-  // Single step: mark done and advance
-  db.prepare(
-    "UPDATE steps SET status = 'done', output = ?, updated_at = datetime('now') WHERE id = ?"
-  ).run(output, stepId);
-
-  return advancePipeline(step.run_id);
 }
 
 /**
  * Handle verify-each completion: pass or fail the story.
+ * Does NOT call scheduleRunCronTeardown — caller must check teardownRunId after COMMIT.
  */
 function handleVerifyEachCompletion(
   verifyStep: { id: string; run_id: string; step_id: string; step_index: number },
   loopStepId: string,
   output: string,
   context: Record<string, string>
-): { advanced: boolean; runCompleted: boolean } {
+): PipelineResult {
   const db = getDb();
   const status = context["status"]?.toLowerCase();
 
@@ -409,8 +464,7 @@ function handleVerifyEachCompletion(
         db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, lastDoneStory.id);
         db.prepare("UPDATE steps SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(loopStepId);
         db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(verifyStep.run_id);
-        scheduleRunCronTeardown(verifyStep.run_id);
-        return { advanced: false, runCompleted: false };
+        return { advanced: false, runCompleted: false, teardownRunId: verifyStep.run_id };
       }
 
       // Set story back to pending for retry
@@ -437,7 +491,7 @@ function handleVerifyEachCompletion(
 /**
  * Check if the loop has more stories; if so set loop step pending, otherwise done + advance.
  */
-function checkLoopContinuation(runId: string, loopStepId: string): { advanced: boolean; runCompleted: boolean } {
+function checkLoopContinuation(runId: string, loopStepId: string): PipelineResult {
   const db = getDb();
   const pendingStory = db.prepare(
     "SELECT id FROM stories WHERE run_id = ? AND status = 'pending' LIMIT 1"
@@ -470,10 +524,17 @@ function checkLoopContinuation(runId: string, loopStepId: string): { advanced: b
   return advancePipeline(runId);
 }
 
+interface PipelineResult {
+  advanced: boolean;
+  runCompleted: boolean;
+  teardownRunId?: string;
+}
+
 /**
  * Advance the pipeline: find the next waiting step and make it pending, or complete the run.
+ * Does NOT call scheduleRunCronTeardown — caller must check teardownRunId after COMMIT.
  */
-function advancePipeline(runId: string): { advanced: boolean; runCompleted: boolean } {
+function advancePipeline(runId: string): PipelineResult {
   const db = getDb();
   const next = db.prepare(
     "SELECT id FROM steps WHERE run_id = ? AND status = 'waiting' ORDER BY step_index ASC LIMIT 1"
@@ -489,8 +550,7 @@ function advancePipeline(runId: string): { advanced: boolean; runCompleted: bool
       "UPDATE runs SET status = 'completed', updated_at = datetime('now') WHERE id = ?"
     ).run(runId);
     archiveRunProgress(runId);
-    scheduleRunCronTeardown(runId);
-    return { advanced: false, runCompleted: true };
+    return { advanced: false, runCompleted: true, teardownRunId: runId };
   }
 }
 
@@ -519,56 +579,72 @@ export function archiveRunProgress(runId: string): void {
 
 /**
  * Fail a step, with retry logic. For loop steps, applies per-story retry.
+ * Wrapped in BEGIN IMMEDIATE for atomicity.
  */
 export function failStep(stepId: string, error: string): { retrying: boolean; runFailed: boolean } {
   const db = getDb();
+  db.exec("BEGIN IMMEDIATE");
+  let teardownRunId: string | undefined;
+  try {
+    const step = db.prepare(
+      "SELECT run_id, retry_count, max_retries, type, current_story_id FROM steps WHERE id = ?"
+    ).get(stepId) as { run_id: string; retry_count: number; max_retries: number; type: string; current_story_id: string | null } | undefined;
 
-  const step = db.prepare(
-    "SELECT run_id, retry_count, max_retries, type, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { run_id: string; retry_count: number; max_retries: number; type: string; current_story_id: string | null } | undefined;
+    if (!step) {
+      db.exec("ROLLBACK");
+      throw new Error(`Step not found: ${stepId}`);
+    }
 
-  if (!step) throw new Error(`Step not found: ${stepId}`);
+    // T9: Loop step failure — per-story retry
+    if (step.type === "loop" && step.current_story_id) {
+      const story = db.prepare(
+        "SELECT id, retry_count, max_retries FROM stories WHERE id = ?"
+      ).get(step.current_story_id) as { id: string; retry_count: number; max_retries: number } | undefined;
 
-  // T9: Loop step failure — per-story retry
-  if (step.type === "loop" && step.current_story_id) {
-    const story = db.prepare(
-      "SELECT id, retry_count, max_retries FROM stories WHERE id = ?"
-    ).get(step.current_story_id) as { id: string; retry_count: number; max_retries: number } | undefined;
+      if (story) {
+        const newRetry = story.retry_count + 1;
+        if (newRetry >= story.max_retries) {
+          // Story retries exhausted
+          db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
+          db.prepare("UPDATE steps SET status = 'failed', output = ?, current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(error, stepId);
+          db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+          teardownRunId = step.run_id;
+          db.exec("COMMIT");
+          if (teardownRunId) scheduleRunCronTeardown(teardownRunId);
+          return { retrying: false, runFailed: true };
+        }
 
-    if (story) {
-      const newRetry = story.retry_count + 1;
-      if (newRetry >= story.max_retries) {
-        // Story retries exhausted
-        db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
-        db.prepare("UPDATE steps SET status = 'failed', output = ?, current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(error, stepId);
-        db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
-        scheduleRunCronTeardown(step.run_id);
-        return { retrying: false, runFailed: true };
+        // Retry the story
+        db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
+        db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(stepId);
+        db.exec("COMMIT");
+        return { retrying: true, runFailed: false };
       }
+    }
 
-      // Retry the story
-      db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
-      db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(stepId);
+    // Single step: existing logic
+    const newRetryCount = step.retry_count + 1;
+
+    if (newRetryCount >= step.max_retries) {
+      db.prepare(
+        "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(error, newRetryCount, stepId);
+      db.prepare(
+        "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
+      ).run(step.run_id);
+      teardownRunId = step.run_id;
+      db.exec("COMMIT");
+      if (teardownRunId) scheduleRunCronTeardown(teardownRunId);
+      return { retrying: false, runFailed: true };
+    } else {
+      db.prepare(
+        "UPDATE steps SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(newRetryCount, stepId);
+      db.exec("COMMIT");
       return { retrying: true, runFailed: false };
     }
-  }
-
-  // Single step: existing logic
-  const newRetryCount = step.retry_count + 1;
-
-  if (newRetryCount >= step.max_retries) {
-    db.prepare(
-      "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
-    ).run(error, newRetryCount, stepId);
-    db.prepare(
-      "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
-    ).run(step.run_id);
-    scheduleRunCronTeardown(step.run_id);
-    return { retrying: false, runFailed: true };
-  } else {
-    db.prepare(
-      "UPDATE steps SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?"
-    ).run(newRetryCount, stepId);
-    return { retrying: true, runFailed: false };
+  } catch (e) {
+    try { db.exec("ROLLBACK"); } catch {}
+    throw e;
   }
 }

--- a/src/installer/stuck-recovery.ts
+++ b/src/installer/stuck-recovery.ts
@@ -1,0 +1,52 @@
+import { getDb } from "../db.js";
+
+interface StuckStep {
+  id: string;
+  run_id: string;
+  step_id: string;
+  agent_id: string;
+  status: string;
+  updated_at: string;
+}
+
+/**
+ * Find steps that have been in "running" status for longer than the threshold.
+ */
+export function findStuckSteps(thresholdMinutes = 30): StuckStep[] {
+  const db = getDb();
+  return db.prepare(
+    `SELECT id, run_id, step_id, agent_id, status, updated_at
+     FROM steps
+     WHERE status = 'running'
+       AND (julianday('now') - julianday(updated_at)) * 24 * 60 > ?
+     ORDER BY updated_at ASC`
+  ).all(thresholdMinutes) as unknown as StuckStep[];
+}
+
+/**
+ * Reset stuck steps back to "pending" so they can be re-claimed.
+ * Returns the number of steps recovered.
+ */
+export function recoverStuckSteps(thresholdMinutes = 30): number {
+  const db = getDb();
+  const stuck = findStuckSteps(thresholdMinutes);
+  if (stuck.length === 0) return 0;
+
+  for (const step of stuck) {
+    db.prepare(
+      "UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?"
+    ).run(step.id);
+
+    // If this was a loop step with a running story, reset the story too
+    const runningStory = db.prepare(
+      "SELECT id FROM stories WHERE run_id = ? AND status = 'running' LIMIT 1"
+    ).get(step.run_id) as { id: string } | undefined;
+    if (runningStory) {
+      db.prepare(
+        "UPDATE stories SET status = 'pending', updated_at = datetime('now') WHERE id = ?"
+      ).run(runningStory.id);
+    }
+  }
+
+  return stuck.length;
+}


### PR DESCRIPTION
## Summary

- **db.ts**: Remove 5s connection recycling that caused DB handle churn; add `PRAGMA busy_timeout=5000` to handle concurrent access gracefully
- **step-ops.ts**: Wrap `claimStep`/`completeStep`/`failStep` in `BEGIN IMMEDIATE` transactions to prevent race conditions; add `changes===0` guard so concurrent claims don't double-assign; try-catch around `STORIES_JSON` parsing so malformed agent output fails the step gracefully instead of crashing
- **gateway-api.ts**: Add `fetchWithRetry()` with 10s `AbortController` timeout + 3x exponential backoff (500ms/1s/2s) to handle gateway unavailability
- **stuck-recovery.ts**: New module to detect and recover steps stuck in "running" state beyond a configurable threshold (default 30 min)
- **cli.ts**: Add `antfarm recover stuck [minutes]` and `antfarm cleanup crons` commands

## Test plan

- [ ] `npm run build` passes clean
- [ ] Start a workflow run, verify it completes end-to-end
- [ ] Run `antfarm step claim <agent-id>` twice simultaneously — only one gets work
- [ ] Feed malformed STORIES_JSON — step fails gracefully, run marked failed
- [ ] Stop gateway, attempt workflow run — timeout error within ~30s
- [ ] Set a step to "running" with old timestamp, run `antfarm recover stuck` — resets to pending
- [ ] Run `antfarm cleanup crons` — deletes all antfarm-prefixed cron jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)