### PR TITLE
feat: Add health check endpoint

### DIFF
--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -75,6 +75,12 @@ export function startDashboard(port = 3333): http.Server {
     const url = new URL(req.url ?? "/", `http://localhost:${port}`);
     const p = url.pathname;
 
+    if (p === "/health") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ status: "ok", timestamp: new Date().toISOString() }));
+      return;
+    }
+
     if (p === "/api/workflows") {
       return json(res, loadWorkflows());
     }

--- a/tests/dashboard-health.test.ts
+++ b/tests/dashboard-health.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert";
+import http from "node:http";
+
+// Need to import from built file as per instructions
+// @ts-ignore - Importing from dist which might not exist yet during typecheck
+import { startDashboard } from "../dist/server/dashboard.js";
+
+test("GET /health returns 200 OK with status and timestamp", async (t) => {
+  // Start on random port
+  const server = startDashboard(0);
+  
+  // Wait for listening
+  await new Promise<void>((resolve) => {
+    if (server.listening) return resolve();
+    server.on("listening", resolve);
+  });
+
+  const address = server.address();
+  const port = (typeof address === "object" && address) ? address.port : 0;
+  
+  try {
+    const res = await fetch(`http://localhost:${port}/health`);
+    assert.strictEqual(res.status, 200, "Status should be 200");
+    
+    const body = await res.json();
+    assert.strictEqual(body.status, "ok", "Status in body should be ok");
+    assert.ok(!isNaN(Date.parse(body.timestamp)), "Timestamp should be valid");
+  } finally {
+    server.close();
+  }
+});


### PR DESCRIPTION
Implement /health endpoint in dashboard server. Verified that the endpoint returns 200 OK. Also includes unit tests.