### PR TITLE
feat: configurable workflows directory via env var

### DIFF
--- a/src/installer/paths.ts
+++ b/src/installer/paths.ts
@@ -5,7 +5,12 @@ import { fileURLToPath } from "node:url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Bundled workflows ship with antfarm (in the repo's workflows/ directory)
+// Override with ANTFARM_WORKFLOWS_DIR to load workflows from an external location.
 export function resolveBundledWorkflowsDir(): string {
+  const env = process.env.ANTFARM_WORKFLOWS_DIR?.trim();
+  if (env) {
+    return path.resolve(env);
+  }
   // From dist/installer/paths.js -> ../../workflows
   return path.resolve(__dirname, "..", "..", "workflows");
 }


### PR DESCRIPTION
## Summary
- `resolveBundledWorkflowsDir()` in `paths.ts` now checks `ANTFARM_WORKFLOWS_DIR` env var before falling back to the bundled `workflows/` directory
- Enables workflows to live outside the antfarm repo (e.g. in mission-control or a shared location)
- All consumers (`dashboard.ts`, `workflow-fetch.ts`, `paths.ts`) automatically pick up the override since they go through `resolveBundledWorkflowsDir()`

## Test plan
- [ ] `ANTFARM_WORKFLOWS_DIR=/path/to/workflows antfarm workflow list` resolves correctly
- [ ] Without env var, default bundled `workflows/` is used (backwards compatible)
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)