### PR TITLE
fix: add step reset command for stall recovery

### DIFF
--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -23,7 +23,7 @@ import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
 import { getRecentEvents, getRunEvents, type AntfarmEvent } from "../installer/events.js";
 import { startDaemon, stopDaemon, getDaemonStatus, isRunning } from "../server/daemonctl.js";
-import { claimStep, completeStep, failStep, getStories, peekStep } from "../installer/step-ops.js";
+import { claimStep, completeStep, failStep, resetStep, getStories, peekStep } from "../installer/step-ops.js";
 import { ensureCliSymlink } from "../installer/symlink.js";
 import { runMedicCheck, getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
 import { installMedicCron, uninstallMedicCron, isMedicCronInstalled } from "../medic/medic-cron.js";
@@ -108,6 +108,7 @@ function printUsage() {
       "antfarm step claim <agent-id>       Claim pending step, output resolved input as JSON",
       "antfarm step complete <step-id>      Complete step (reads output from stdin)",
       "antfarm step fail <step-id> <error>  Fail step with retry logic",
+      "antfarm step reset <step-id> <reason> Reset stalled step (uses abandon budget)",
       "antfarm step stories <run-id>       List stories for a run",
       "",
       "antfarm medic install                Install medic watchdog cron",
@@ -386,6 +387,13 @@ async function main() {
       if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
       const error = args.slice(3).join(" ").trim() || "Unknown error";
       const result = failStep(target, error);
+      process.stdout.write(JSON.stringify(result) + "\n");
+      return;
+    }
+    if (action === "reset") {
+      if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
+      const reason = args.slice(3).join(" ").trim() || "Stalled step reset";
+      const result = resetStep(target, reason);
       process.stdout.write(JSON.stringify(result) + "\n");
       return;
     }

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -938,3 +938,78 @@ export function failStep(stepId: string, error: string): { retrying: boolean; ru
     return { retrying: true, runFailed: false };
   }
 }
+
+/**
+ * Reset a stalled step using the abandonment budget instead of the retry budget.
+ * Use this for timeout/stall recovery — not for explicit agent failures.
+ *
+ * Single steps: increments abandoned_count (max MAX_ABANDON_RESETS).
+ * Loop steps with a current story: increments story retry_count (same as failStep loop path).
+ * Neither path touches the step's retry_count for single steps.
+ */
+export function resetStep(stepId: string, reason: string): { reset: boolean; runFailed: boolean } {
+  const db = getDb();
+
+  const step = db.prepare(
+    "SELECT run_id, retry_count, max_retries, type, current_story_id, abandoned_count FROM steps WHERE id = ?"
+  ).get(stepId) as { run_id: string; retry_count: number; max_retries: number; type: string; current_story_id: string | null; abandoned_count: number } | undefined;
+
+  if (!step) throw new Error(`Step not found: ${stepId}`);
+
+  const wfId = getWorkflowId(step.run_id);
+
+  // Loop step with a current story: apply per-story retry (same budget as failStep)
+  if (step.type === "loop" && step.current_story_id) {
+    const story = db.prepare(
+      "SELECT id, retry_count, max_retries, story_id, title FROM stories WHERE id = ?"
+    ).get(step.current_story_id) as { id: string; retry_count: number; max_retries: number; story_id: string; title: string } | undefined;
+
+    if (story) {
+      const newRetry = story.retry_count + 1;
+      if (newRetry > story.max_retries) {
+        // Story retries exhausted — fail everything
+        db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
+        db.prepare("UPDATE steps SET status = 'failed', output = ?, current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(reason, stepId);
+        db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+        emitEvent({ ts: new Date().toISOString(), event: "story.failed", runId: step.run_id, workflowId: wfId, stepId: stepId, storyId: story.story_id, storyTitle: story.title, detail: reason });
+        emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: stepId, detail: reason });
+        emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Story timeout retries exhausted" });
+        scheduleRunCronTeardown(step.run_id);
+        return { reset: false, runFailed: true };
+      }
+
+      // Reset story + step to pending for retry
+      db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
+      db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(stepId);
+      emitEvent({ ts: new Date().toISOString(), event: "step.timeout", runId: step.run_id, workflowId: wfId, stepId: stepId, detail: `Story ${story.story_id} reset — timeout (story retry ${newRetry})` });
+      logger.info(`Step reset (story timeout): ${story.story_id}`, { runId: step.run_id, stepId: stepId });
+      return { reset: true, runFailed: false };
+    }
+  }
+
+  // Single step (or loop without current story): use abandoned_count, NOT retry_count
+  const newAbandonCount = (step.abandoned_count ?? 0) + 1;
+
+  if (newAbandonCount >= MAX_ABANDON_RESETS) {
+    // Too many abandons — fail the step and run
+    db.prepare(
+      "UPDATE steps SET status = 'failed', output = ?, abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(`Step timed out and abandoned (${newAbandonCount} times): ${reason}`, newAbandonCount, stepId);
+    db.prepare(
+      "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
+    ).run(step.run_id);
+    emitEvent({ ts: new Date().toISOString(), event: "step.timeout", runId: step.run_id, workflowId: wfId, stepId: stepId, detail: `Abandon limit reached (${newAbandonCount}/${MAX_ABANDON_RESETS})` });
+    emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: stepId, detail: "Step abandoned too many times" });
+    emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Step abandoned and abandon limit reached" });
+    scheduleRunCronTeardown(step.run_id);
+    return { reset: false, runFailed: true };
+  }
+
+  // Reset to pending — do NOT increment retry_count
+  db.prepare(
+    "UPDATE steps SET status = 'pending', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
+  ).run(newAbandonCount, stepId);
+  emitEvent({ ts: new Date().toISOString(), event: "step.timeout", runId: step.run_id, workflowId: wfId, stepId: stepId, detail: `Reset to pending (abandon ${newAbandonCount}/${MAX_ABANDON_RESETS}): ${reason}` });
+  logger.info(`Step reset (abandon ${newAbandonCount}/${MAX_ABANDON_RESETS}): ${reason}`, { runId: step.run_id, stepId: stepId });
+  return { reset: true, runFailed: false };
+}

--- a/tests/step-reset.test.ts
+++ b/tests/step-reset.test.ts
@@ -1,0 +1,336 @@
+/**
+ * Tests for resetStep() — timeout/stall recovery using abandon budget.
+ *
+ * Validates:
+ * 1. Single step: increments abandoned_count, NOT retry_count
+ * 2. Single step exhaustion: 5th abandon fails step+run
+ * 3. Loop step with story: increments story retry_count, NOT step retry_count
+ * 4. Loop step story exhaustion: fails story+step+run
+ * 5. Backward compat: failStep still uses retry_count (not abandoned_count)
+ */
+
+import { DatabaseSync } from "node:sqlite";
+import crypto from "node:crypto";
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+
+// ── In-memory DB setup ──────────────────────────────────────────────
+
+function createTestDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+
+  db.exec(`
+    CREATE TABLE runs (
+      id TEXT PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      task TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      context TEXT NOT NULL DEFAULT '{}',
+      notify_url TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE steps (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES runs(id),
+      step_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      step_index INTEGER NOT NULL,
+      input_template TEXT NOT NULL,
+      expects TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'waiting',
+      output TEXT,
+      retry_count INTEGER DEFAULT 0,
+      max_retries INTEGER DEFAULT 2,
+      abandoned_count INTEGER DEFAULT 0,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      type TEXT NOT NULL DEFAULT 'single',
+      loop_config TEXT,
+      current_story_id TEXT
+    );
+
+    CREATE TABLE stories (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES runs(id),
+      story_index INTEGER NOT NULL,
+      story_id TEXT NOT NULL,
+      title TEXT NOT NULL,
+      description TEXT NOT NULL DEFAULT '',
+      acceptance_criteria TEXT NOT NULL DEFAULT '[]',
+      status TEXT NOT NULL DEFAULT 'pending',
+      output TEXT,
+      retry_count INTEGER DEFAULT 0,
+      max_retries INTEGER DEFAULT 2,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      ts TEXT NOT NULL,
+      event TEXT NOT NULL,
+      run_id TEXT,
+      workflow_id TEXT,
+      step_id TEXT,
+      agent_id TEXT,
+      story_id TEXT,
+      story_title TEXT,
+      detail TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `);
+
+  return db;
+}
+
+function ts(): string {
+  return new Date().toISOString();
+}
+
+// ── Direct DB logic tests (no module import needed) ─────────────────
+
+const MAX_ABANDON_RESETS = 5; // mirrors constant in step-ops.ts
+
+describe("resetStep logic — single step (direct DB validation)", () => {
+  it("increments abandoned_count and resets to pending", () => {
+    const db = createTestDb();
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, abandoned_count, created_at, updated_at, type) VALUES (?, ?, 'verify', 'wf_verifier', 4, '', '', 'running', 0, 0, ?, ?, 'single')"
+    ).run(stepId, runId, t, t);
+
+    // Simulate resetStep: increment abandoned_count, reset to pending
+    const step = db.prepare("SELECT abandoned_count, retry_count FROM steps WHERE id = ?").get(stepId) as { abandoned_count: number; retry_count: number };
+    const newAbandonCount = (step.abandoned_count ?? 0) + 1;
+
+    assert.ok(newAbandonCount < MAX_ABANDON_RESETS, "Not yet exhausted");
+
+    db.prepare("UPDATE steps SET status = 'pending', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?").run(newAbandonCount, stepId);
+
+    const after = db.prepare("SELECT status, abandoned_count, retry_count FROM steps WHERE id = ?").get(stepId) as { status: string; abandoned_count: number; retry_count: number };
+
+    assert.equal(after.status, "pending", "Step should be reset to pending");
+    assert.equal(after.abandoned_count, 1, "Abandoned count should be 1");
+    assert.equal(after.retry_count, 0, "Retry count should be UNCHANGED (still 0)");
+  });
+
+  it("fails step and run when abandoned_count reaches MAX_ABANDON_RESETS", () => {
+    const db = createTestDb();
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    // Step already at abandoned_count = 4 (one more will exhaust)
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, abandoned_count, created_at, updated_at, type) VALUES (?, ?, 'verify', 'wf_verifier', 4, '', '', 'running', 0, 4, ?, ?, 'single')"
+    ).run(stepId, runId, t, t);
+
+    const step = db.prepare("SELECT abandoned_count FROM steps WHERE id = ?").get(stepId) as { abandoned_count: number };
+    const newAbandonCount = (step.abandoned_count ?? 0) + 1;
+
+    assert.equal(newAbandonCount, 5, "Should reach MAX_ABANDON_RESETS");
+    assert.ok(newAbandonCount >= MAX_ABANDON_RESETS, "Should be at limit");
+
+    // Simulate reset exhaustion: fail step + run
+    db.prepare("UPDATE steps SET status = 'failed', abandoned_count = ?, output = 'Stalled too many times', updated_at = datetime('now') WHERE id = ?").run(newAbandonCount, stepId);
+    db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(runId);
+
+    const afterStep = db.prepare("SELECT status, abandoned_count, retry_count FROM steps WHERE id = ?").get(stepId) as { status: string; abandoned_count: number; retry_count: number };
+    const afterRun = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+
+    assert.equal(afterStep.status, "failed", "Step should be failed");
+    assert.equal(afterStep.abandoned_count, 5, "Abandoned count should be 5");
+    assert.equal(afterStep.retry_count, 0, "Retry count should still be 0");
+    assert.equal(afterRun.status, "failed", "Run should be failed");
+  });
+});
+
+describe("resetStep logic — loop step with story (direct DB validation)", () => {
+  it("increments story retry_count and resets both to pending", () => {
+    const db = createTestDb();
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const storyId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'fd', 'build feature', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    db.prepare(
+      "INSERT INTO stories (id, run_id, story_index, story_id, title, status, retry_count, max_retries, created_at, updated_at) VALUES (?, ?, 0, 'US-001', 'Add login form', 'running', 0, 2, ?, ?)"
+    ).run(storyId, runId, t, t);
+
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, abandoned_count, created_at, updated_at, type, current_story_id) VALUES (?, ?, 'implement', 'fd_developer', 3, '', '', 'running', 0, 0, ?, ?, 'loop', ?)"
+    ).run(stepId, runId, t, t, storyId);
+
+    // Simulate resetStep loop path: increment story retry, reset both
+    const story = db.prepare("SELECT retry_count, max_retries FROM stories WHERE id = ?").get(storyId) as { retry_count: number; max_retries: number };
+    const newRetry = story.retry_count + 1;
+
+    assert.ok(newRetry <= story.max_retries, "Story retries not exhausted");
+
+    db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, storyId);
+    db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(stepId);
+
+    const afterStory = db.prepare("SELECT status, retry_count FROM stories WHERE id = ?").get(storyId) as { status: string; retry_count: number };
+    const afterStep = db.prepare("SELECT status, retry_count, abandoned_count, current_story_id FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; abandoned_count: number; current_story_id: string | null };
+
+    assert.equal(afterStory.status, "pending", "Story should be reset to pending");
+    assert.equal(afterStory.retry_count, 1, "Story retry_count should increment");
+    assert.equal(afterStep.status, "pending", "Step should be reset to pending");
+    assert.equal(afterStep.retry_count, 0, "Step retry_count should be UNCHANGED");
+    assert.equal(afterStep.abandoned_count, 0, "Step abandoned_count should be UNCHANGED for loop path");
+    assert.equal(afterStep.current_story_id, null, "current_story_id should be cleared");
+  });
+
+  it("fails story+step+run when story retries exhausted", () => {
+    const db = createTestDb();
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const storyId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'fd', 'build feature', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    // Story at max retries (retry_count = 2, max_retries = 2)
+    db.prepare(
+      "INSERT INTO stories (id, run_id, story_index, story_id, title, status, retry_count, max_retries, created_at, updated_at) VALUES (?, ?, 0, 'US-001', 'Add login form', 'running', 2, 2, ?, ?)"
+    ).run(storyId, runId, t, t);
+
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, abandoned_count, created_at, updated_at, type, current_story_id) VALUES (?, ?, 'implement', 'fd_developer', 3, '', '', 'running', 0, 0, ?, ?, 'loop', ?)"
+    ).run(stepId, runId, t, t, storyId);
+
+    const story = db.prepare("SELECT retry_count, max_retries FROM stories WHERE id = ?").get(storyId) as { retry_count: number; max_retries: number };
+    const newRetry = story.retry_count + 1;
+
+    assert.ok(newRetry > story.max_retries, "Story retries should be exhausted");
+
+    // Simulate: fail everything
+    db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, storyId);
+    db.prepare("UPDATE steps SET status = 'failed', current_story_id = NULL, output = 'Story timeout', updated_at = datetime('now') WHERE id = ?").run(stepId);
+    db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(runId);
+
+    const afterStory = db.prepare("SELECT status, retry_count FROM stories WHERE id = ?").get(storyId) as { status: string; retry_count: number };
+    const afterStep = db.prepare("SELECT status, retry_count FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number };
+    const afterRun = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+
+    assert.equal(afterStory.status, "failed", "Story should be failed");
+    assert.equal(afterStory.retry_count, 3, "Story retry_count should be 3 (exceeded max of 2)");
+    assert.equal(afterStep.status, "failed", "Step should be failed");
+    assert.equal(afterStep.retry_count, 0, "Step retry_count should still be 0");
+    assert.equal(afterRun.status, "failed", "Run should be failed");
+  });
+});
+
+describe("backward compat — failStep still uses retry_count", () => {
+  it("failStep increments retry_count, not abandoned_count", () => {
+    const db = createTestDb();
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, abandoned_count, created_at, updated_at, type) VALUES (?, ?, 'verify', 'wf_verifier', 4, '', '', 'running', 0, 2, 0, ?, ?, 'single')"
+    ).run(stepId, runId, t, t);
+
+    // failStep logic: increment retry_count
+    const step = db.prepare("SELECT retry_count, max_retries FROM steps WHERE id = ?").get(stepId) as { retry_count: number; max_retries: number };
+    const newRetryCount = step.retry_count + 1;
+
+    assert.ok(newRetryCount <= step.max_retries, "Not yet exhausted");
+
+    db.prepare("UPDATE steps SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetryCount, stepId);
+
+    const after = db.prepare("SELECT status, retry_count, abandoned_count FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; abandoned_count: number };
+
+    assert.equal(after.status, "pending", "Step should retry");
+    assert.equal(after.retry_count, 1, "retry_count should increment");
+    assert.equal(after.abandoned_count, 0, "abandoned_count should be UNCHANGED");
+  });
+});
+
+// ── Integration test: actual resetStep function via ANTFARM_DB_PATH ──
+
+describe("resetStep function (integration)", () => {
+  let tmpDbPath: string;
+  let originalDbPath: string | undefined;
+
+  before(async () => {
+    const os = await import("node:os");
+    const path = await import("node:path");
+    tmpDbPath = path.join(os.tmpdir(), `antfarm-test-reset-${crypto.randomUUID()}.db`);
+    originalDbPath = process.env.ANTFARM_DB_PATH;
+    process.env.ANTFARM_DB_PATH = tmpDbPath;
+  });
+
+  after(async () => {
+    if (originalDbPath !== undefined) {
+      process.env.ANTFARM_DB_PATH = originalDbPath;
+    } else {
+      delete process.env.ANTFARM_DB_PATH;
+    }
+    const fs = await import("node:fs");
+    try { fs.unlinkSync(tmpDbPath); } catch {}
+  });
+
+  it("resets a single step to pending using abandon budget", async () => {
+    // Dynamic import to pick up test DB path
+    const { resetStep } = await import("../dist/installer/step-ops.js");
+    const { getDb } = await import("../dist/db.js");
+    const db = getDb();
+
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = ts();
+
+    db.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'test-wf', 'test task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    db.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, abandoned_count, created_at, updated_at, type) VALUES (?, ?, 'verify', 'test-wf_verifier', 4, '', '', 'running', 1, 2, 0, ?, ?, 'single')"
+    ).run(stepId, runId, t, t);
+
+    const result = resetStep(stepId, "Agent stalled — session timeout");
+
+    assert.equal(result.reset, true, "Should return reset: true");
+    assert.equal(result.runFailed, false, "Should return runFailed: false");
+
+    const step = db.prepare("SELECT status, retry_count, abandoned_count FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; abandoned_count: number };
+
+    assert.equal(step.status, "pending", "Step should be pending");
+    assert.equal(step.retry_count, 1, "retry_count should be UNCHANGED (was 1, still 1)");
+    assert.equal(step.abandoned_count, 1, "abandoned_count should be 1");
+  });
+
+  it("throws for non-existent step", async () => {
+    const { resetStep } = await import("../dist/installer/step-ops.js");
+    assert.throws(
+      () => resetStep("nonexistent-id", "test"),
+      /Step not found/,
+      "Should throw for missing step"
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #194 — stall-watcher burns `retry_count` via `step fail`.

The stall-watcher was calling `step fail` for timed-out steps, which burned the `retry_count` budget (max 2). Steps that stall from transient issues (Ollama restart, agent-browser hang) exhausted retries before real work ever failed.

### Changes

- **`resetStep()` function** in `step-ops.ts` — uses the `abandoned_count` budget (max 5) instead of `retry_count` (max 2), matching the existing `cleanupAbandonedSteps()` logic
- **`antfarm step reset <step-id> <reason>`** CLI command in `cli.ts`
- Loop steps with an active story use the story retry budget; neither path touches `retry_count` for single steps
- Emits `step.timeout` events (not `step.failed`) for better observability

## Test plan

- [x] `npx tsc` — clean build (0 errors)
- [x] `node --test tests/step-reset.test.ts` — 7/7 new tests pass
- [x] `node --test tests/**/*.test.ts` — 169/169 pass (full main suite), 0 fail
- [x] CLI verified: `antfarm step reset` shows missing-arg error, `antfarm help` lists the command
- [ ] Deploy and verify stall-watcher uses `step reset` on next stuck step

🤖 Generated with [Claude Code](https://claude.com/claude-code)