### PR TITLE
fix: add missing dev script to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/server/index.html dist/server/index.html && chmod +x dist/cli/cli.js && node scripts/inject-version.js",
+    "dev": "tsc -p tsconfig.json --watch",
     "start": "node dist/cli/cli.js"
   },
   "dependencies": {

--- a/tests/package-scripts.test.ts
+++ b/tests/package-scripts.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Regression test: ensure package.json defines the required npm scripts.
+ * This prevents missing scripts (like `dev`) from breaking contributor workflows.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+const pkgPath = path.resolve(import.meta.dirname, "..", "package.json");
+const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+
+describe("package.json scripts", () => {
+  it("defines a dev script so pnpm dev / npm run dev works", () => {
+    assert.ok(
+      typeof pkg.scripts?.dev === "string" && pkg.scripts.dev.length > 0,
+      'package.json must have a non-empty "dev" script'
+    );
+  });
+
+  it("defines a build script", () => {
+    assert.ok(
+      typeof pkg.scripts?.build === "string" && pkg.scripts.build.length > 0,
+      'package.json must have a non-empty "build" script'
+    );
+  });
+
+  it("defines a start script", () => {
+    assert.ok(
+      typeof pkg.scripts?.start === "string" && pkg.scripts.start.length > 0,
+      'package.json must have a non-empty "start" script'
+    );
+  });
+});


### PR DESCRIPTION
## Bug Description
The repository does not provide a `dev` npm script, so `pnpm dev` fails immediately and the development environment cannot be started via the expected command. This breaks the end-to-end local developer workflow for contributors expecting a standard dev entrypoint, though a partial workaround exists via build/start commands.

**Severity:** medium

## Root Cause
The `scripts` section in `package.json` only defined `build` and `start`. There was no `dev` entry, so running `pnpm dev` (or `npm run dev`) exited immediately with `ERR_PNPM_NO_SCRIPT  Missing script: dev`. Contributors following the conventional TypeScript project pattern of running `dev` for a watch-mode compile loop had no working entrypoint.

## Fix
Added a `dev` script to `package.json`:
```json
"dev": "tsc -p tsconfig.json --watch"
```
This starts the TypeScript compiler in watch mode, recompiling on every file change — the standard dev-loop pattern for TypeScript projects.

Also added `tests/package-scripts.test.ts` to prevent regression.

## Regression Test
`tests/package-scripts.test.ts` — a Node built-in test that reads `package.json` and asserts that `scripts.dev`, `scripts.build`, and `scripts.start` are all non-empty strings. Runs with `node --test`.

## Verification
- `pnpm dev` now starts `tsc --watch` instead of failing.
- All three script assertions in the regression test pass.
- `pnpm build` and `pnpm start` continue to work as before.