### PR TITLE
fix: unify duplicated gateway auth header construction into shared helper

### DIFF
--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -109,6 +109,29 @@ const UPDATE_HINT =
   `This may be fixed by updating OpenClaw: npm update -g openclaw`;
 
 // ---------------------------------------------------------------------------
+// Shared gateway HTTP helper — centralises auth header construction
+// ---------------------------------------------------------------------------
+
+/**
+ * Make an authenticated POST to the gateway's /tools/invoke endpoint.
+ * Resolves the gateway config, builds headers (including Bearer auth when a
+ * secret is available), and returns the raw `Response`.
+ *
+ * Throws on network errors so callers can catch and fall back to CLI.
+ */
+async function gatewayFetch(body: object): Promise<Response> {
+  const gateway = await getGatewayConfig();
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (gateway.secret) headers["Authorization"] = `Bearer ${gateway.secret}`;
+
+  return fetch(`${gateway.url}/tools/invoke`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Cron operations — HTTP first, CLI fallback
 // ---------------------------------------------------------------------------
 
@@ -183,16 +206,8 @@ async function createAgentCronJobHTTP(job: {
   delivery?: { mode: "none" | "announce"; channel?: string; to?: string };
   enabled: boolean;
 }): Promise<{ ok: boolean; error?: string; id?: string } | null> {
-  const gateway = await getGatewayConfig();
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (gateway.secret) headers["Authorization"] = `Bearer ${gateway.secret}`;
-
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ tool: "cron", args: { action: "add", job }, sessionKey: "agent:main:main" }),
-    });
+    const response = await gatewayFetch({ tool: "cron", args: { action: "add", job }, sessionKey: "agent:main:main" });
 
     if (response.status === 404) return null; // signal CLI fallback
 
@@ -216,16 +231,8 @@ async function createAgentCronJobHTTP(job: {
  */
 export async function checkCronToolAvailable(): Promise<{ ok: boolean; error?: string }> {
   // Try HTTP
-  const gateway = await getGatewayConfig();
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (gateway.secret) headers["Authorization"] = `Bearer ${gateway.secret}`;
-
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ tool: "cron", args: { action: "list" } }),
-    });
+    const response = await gatewayFetch({ tool: "cron", args: { action: "list" } });
 
     if (response.ok) return { ok: true };
 
@@ -268,16 +275,8 @@ export async function listCronJobs(): Promise<{ ok: boolean; jobs?: Array<{ id: 
 
 /** HTTP-only list. Returns null on 404/network error. */
 async function listCronJobsHTTP(): Promise<{ ok: boolean; jobs?: Array<{ id: string; name: string }>; error?: string } | null> {
-  const gateway = await getGatewayConfig();
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (gateway.secret) headers["Authorization"] = `Bearer ${gateway.secret}`;
-
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ tool: "cron", args: { action: "list" }, sessionKey: "agent:main:main" }),
-    });
+    const response = await gatewayFetch({ tool: "cron", args: { action: "list" }, sessionKey: "agent:main:main" });
 
     if (response.status === 404) return null;
 
@@ -323,16 +322,8 @@ export async function deleteCronJob(jobId: string): Promise<{ ok: boolean; error
 
 /** HTTP-only delete. Returns null on 404/network error. */
 async function deleteCronJobHTTP(jobId: string): Promise<{ ok: boolean; error?: string } | null> {
-  const gateway = await getGatewayConfig();
   try {
-    const headers: Record<string, string> = { "Content-Type": "application/json" };
-    if (gateway.secret) headers["Authorization"] = `Bearer ${gateway.secret}`;
-
-    const response = await fetch(`${gateway.url}/tools/invoke`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ tool: "cron", args: { action: "remove", id: jobId }, sessionKey: "agent:main:main" }),
-    });
+    const response = await gatewayFetch({ tool: "cron", args: { action: "remove", id: jobId }, sessionKey: "agent:main:main" });
 
     if (response.status === 404) return null;
 

--- a/tests/gateway-api-unified-auth.test.ts
+++ b/tests/gateway-api-unified-auth.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+/**
+ * Regression test: all gateway HTTP functions must use consistent auth headers.
+ *
+ * Before this fix, each of the 4 HTTP functions (createAgentCronJobHTTP,
+ * listCronJobsHTTP, deleteCronJobHTTP, checkCronToolAvailable) independently
+ * constructed their own Authorization headers by calling getGatewayConfig()
+ * and manually building the headers object. This duplication meant a change
+ * to auth logic (e.g. a new header, a different auth scheme) had to be
+ * replicated in 4 places.
+ *
+ * The fix extracts a shared `gatewayFetch()` helper. This test verifies that
+ * ALL exported HTTP-facing functions send identical Authorization headers for
+ * the same config, proving they share a single auth code path.
+ */
+
+const configDir = path.join(os.homedir(), ".openclaw");
+const configPath = path.join(configDir, "openclaw.json");
+
+/** Helper: temporarily write a config, run a callback, then restore. */
+async function withConfig<T>(config: object, fn: () => Promise<T>): Promise<T> {
+  let originalConfig: string | null = null;
+  try {
+    originalConfig = fs.readFileSync(configPath, "utf-8");
+  } catch {
+    originalConfig = null;
+  }
+
+  try {
+    fs.mkdirSync(configDir, { recursive: true });
+    fs.writeFileSync(configPath, JSON.stringify(config), "utf-8");
+    return await fn();
+  } finally {
+    if (originalConfig !== null) {
+      fs.writeFileSync(configPath, originalConfig, "utf-8");
+    }
+  }
+}
+
+/** Helper: temporarily mock globalThis.fetch, run a callback, then restore. */
+async function withMockFetch<T>(
+  mockImpl: (...args: any[]) => any,
+  fn: (fetchMock: ReturnType<typeof mock.fn>) => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const mockFn = mock.fn(mockImpl) as any;
+  globalThis.fetch = mockFn;
+  try {
+    return await fn(mockFn);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+const okResponse = async () => ({
+  ok: true,
+  status: 200,
+  json: async () => ({ ok: true, result: { id: "test-id", jobs: [] } }),
+  text: async () => "ok",
+});
+
+describe("gateway-api unified auth helper (regression)", () => {
+  it("all HTTP functions send identical Authorization headers", async () => {
+    const testConfig = {
+      gateway: { port: 18789, auth: { mode: "token", token: "unified-auth-test-secret" } },
+    };
+
+    await withConfig(testConfig, async () => {
+      const mod = await import(`../dist/installer/gateway-api.js?v=unified-${Date.now()}`);
+      const capturedHeaders: Array<string | undefined> = [];
+
+      await withMockFetch(
+        async (_url: string, init: any) => {
+          capturedHeaders.push(init.headers?.["Authorization"]);
+          return okResponse();
+        },
+        async () => {
+          // 1. createAgentCronJob (triggers createAgentCronJobHTTP)
+          await mod.createAgentCronJob({
+            name: "test/unified-auth",
+            schedule: { kind: "every", everyMs: 300_000 },
+            sessionTarget: "isolated",
+            agentId: "test-agent",
+            payload: { kind: "agentTurn", message: "test" },
+            enabled: true,
+          });
+
+          // 2. checkCronToolAvailable
+          await mod.checkCronToolAvailable();
+
+          // 3. listCronJobs (triggers listCronJobsHTTP)
+          await mod.listCronJobs();
+
+          // 4. deleteCronJob (triggers deleteCronJobHTTP)
+          await mod.deleteCronJob("test-job-id");
+
+          // All 4 calls should have been made
+          assert.equal(capturedHeaders.length, 4, "Expected exactly 4 fetch calls");
+
+          // All should have the same Authorization header
+          const expectedAuth = "Bearer unified-auth-test-secret";
+          for (let i = 0; i < capturedHeaders.length; i++) {
+            assert.equal(
+              capturedHeaders[i],
+              expectedAuth,
+              `Fetch call #${i + 1} should have Authorization: ${expectedAuth}`,
+            );
+          }
+
+          // Verify they're all identical (the core regression check)
+          const uniqueAuths = new Set(capturedHeaders);
+          assert.equal(uniqueAuths.size, 1, "All HTTP functions must use the same auth header value");
+        },
+      );
+    });
+  });
+
+  it("all HTTP functions send Content-Type: application/json", async () => {
+    const testConfig = {
+      gateway: { port: 18789, auth: { mode: "token", token: "ct-test" } },
+    };
+
+    await withConfig(testConfig, async () => {
+      const mod = await import(`../dist/installer/gateway-api.js?v=ct-${Date.now()}`);
+      const capturedContentTypes: string[] = [];
+
+      await withMockFetch(
+        async (_url: string, init: any) => {
+          capturedContentTypes.push(init.headers?.["Content-Type"]);
+          return okResponse();
+        },
+        async () => {
+          await mod.createAgentCronJob({
+            name: "test/ct",
+            schedule: { kind: "every", everyMs: 300_000 },
+            sessionTarget: "isolated",
+            agentId: "test",
+            payload: { kind: "agentTurn", message: "t" },
+            enabled: true,
+          });
+          await mod.checkCronToolAvailable();
+          await mod.listCronJobs();
+          await mod.deleteCronJob("id");
+
+          assert.equal(capturedContentTypes.length, 4);
+          for (const ct of capturedContentTypes) {
+            assert.equal(ct, "application/json");
+          }
+        },
+      );
+    });
+  });
+
+  it("all HTTP functions hit the same /tools/invoke endpoint", async () => {
+    const testConfig = {
+      gateway: { port: 18789, auth: { mode: "token", token: "url-test" } },
+    };
+
+    await withConfig(testConfig, async () => {
+      const mod = await import(`../dist/installer/gateway-api.js?v=url-${Date.now()}`);
+      const capturedUrls: string[] = [];
+
+      await withMockFetch(
+        async (url: string) => {
+          capturedUrls.push(url);
+          return okResponse();
+        },
+        async () => {
+          await mod.createAgentCronJob({
+            name: "test/url",
+            schedule: { kind: "every", everyMs: 300_000 },
+            sessionTarget: "isolated",
+            agentId: "test",
+            payload: { kind: "agentTurn", message: "t" },
+            enabled: true,
+          });
+          await mod.checkCronToolAvailable();
+          await mod.listCronJobs();
+          await mod.deleteCronJob("id");
+
+          assert.equal(capturedUrls.length, 4);
+          const expectedUrl = "http://127.0.0.1:18789/tools/invoke";
+          for (const url of capturedUrls) {
+            assert.equal(url, expectedUrl);
+          }
+        },
+      );
+    });
+  });
+
+  it("omits Authorization header when no secret is configured", async () => {
+    const noAuthConfig = { gateway: { port: 18789 } };
+
+    await withConfig(noAuthConfig, async () => {
+      const mod = await import(`../dist/installer/gateway-api.js?v=noauth-${Date.now()}`);
+      const capturedHeaders: Array<Record<string, string>> = [];
+
+      await withMockFetch(
+        async (_url: string, init: any) => {
+          capturedHeaders.push({ ...init.headers });
+          return okResponse();
+        },
+        async () => {
+          await mod.createAgentCronJob({
+            name: "test/noauth",
+            schedule: { kind: "every", everyMs: 300_000 },
+            sessionTarget: "isolated",
+            agentId: "test",
+            payload: { kind: "agentTurn", message: "t" },
+            enabled: true,
+          });
+          await mod.listCronJobs();
+
+          for (const headers of capturedHeaders) {
+            assert.equal(
+              headers["Authorization"],
+              undefined,
+              "Should not send Authorization when no secret is configured",
+            );
+          }
+        },
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Bug Description
The authentication handling in antfarm's gateway-api.ts has redundant patterns: every HTTP function (createAgentCronJobHTTP, listCronJobsHTTP, deleteCronJobHTTP, checkCronToolAvailable) independently constructs Authorization headers using the same getGatewayConfig() + secret resolution. This is a code quality / maintainability concern rather than a functional bug. A simplified/unified auth helper could reduce duplication and make the auth flow easier to reason about. The payment-allocator auth.ts is a separate concern (Express middleware for API key validation) and is not directly related. No tests are currently failing and no errors are being thrown by the existing auth implementation.

**Severity:** low

## Root Cause
This is NOT a functional bug — it is a code quality/maintainability concern. The authentication handling in gateway-api.ts has a well-structured foundation (getGatewayConfig() correctly resolves the unified "secret" from either token or password mode), but every HTTP function (createAgentCronJobHTTP, listCronJobsHTTP, deleteCronJobHTTP, checkCronToolAvailable) independently repeats the same 3-line pattern: (1) call getGatewayConfig(), (2) create headers object, (3) conditionally add Authorization Bearer header. This is duplicated across 4 functions (lines ~150, ~195, ~230, ~265 approximately). The duplication means any future auth change (e.g., adding API key auth, custom headers, or retry logic) must be replicated in 4+ places, increasing risk of inconsistency. The payment-allocator auth.ts is a completely separate Express middleware concern and is NOT related to this issue. All existing tests pass — no functional breakage exists.

## Fix
Extracted a shared gatewayFetch() helper in src/installer/gateway-api.ts that centralises getGatewayConfig() + auth header construction + fetch POST call. Replaced duplicated auth patterns in all 4 HTTP functions (createAgentCronJobHTTP, listCronJobsHTTP, deleteCronJobHTTP, checkCronToolAvailable) with calls to this single helper. No behavioral changes. Scoped strictly to gateway-api.ts — payment-allocator auth.ts was NOT modified.

## Regression Test
Added tests/gateway-api-unified-auth.test.ts with 4 tests: (1) all HTTP functions send identical Authorization headers, (2) all send Content-Type: application/json, (3) all hit the same /tools/invoke endpoint, (4) no Authorization header when no secret configured.

## Verification
All existing tests pass. The gatewayFetch() helper correctly centralises auth header construction replacing 4 duplicated patterns. Fix is minimal, scoped to gateway-api.ts, no unintended side effects. This is a maintainability refactor addressing code duplication, not a functional bug fix.
