### PR TITLE
Add safe workflow runner helper with per-repo locking

### DIFF
--- a/docs/creating-workflows.md
+++ b/docs/creating-workflows.md
@@ -331,6 +331,29 @@ antfarm workflow install my-workflow
 
 This provisions agent workspaces, registers agents in OpenClaw config, and sets up cron polling.
 
+## Running safely (avoid per-repo concurrency)
+
+If you're iterating quickly, it's easy to trigger overlapping runs against the same repository.
+A simple pattern is to use a per-repository file lock before starting a new workflow run.
+
+This repo includes a helper script:
+
+```bash
+scripts/run-safe.sh <repo_path> <workflow_id> "<task>"
+```
+
+Example:
+
+```bash
+scripts/run-safe.sh /home/me/projects/my-app feature-dev "Add OAuth login"
+```
+
+The script:
+- verifies `repo_path` is a git repository,
+- acquires a lock file under `/tmp`,
+- exits early if another run is already active for that repo,
+- starts the workflow only when the lock is acquired.
+
 ## Tips
 
 - **Be specific in input templates.** Agents get the input as their entire task context. Vague inputs produce vague results.

--- a/scripts/run-safe.sh
+++ b/scripts/run-safe.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run an Antfarm workflow with a per-repository lock to avoid concurrent runs
+# stepping on each other.
+#
+# Usage:
+#   scripts/run-safe.sh <repo_path> <workflow_id> <task>
+#
+# Example:
+#   scripts/run-safe.sh /home/me/projects/myapp feature-dev "Implement X"
+
+if [ "$#" -lt 3 ]; then
+  echo "Usage: $0 <repo_path> <workflow_id> <task>"
+  exit 1
+fi
+
+REPO_PATH="$1"
+WORKFLOW_ID="$2"
+TASK="$3"
+
+if [ ! -d "$REPO_PATH/.git" ]; then
+  echo "Error: '$REPO_PATH' is not a git repository (.git missing)."
+  exit 2
+fi
+
+SAFE_KEY=$(echo "$REPO_PATH" | sed 's#[^a-zA-Z0-9_.-]#_#g')
+LOCK_FILE="/tmp/antfarm-${SAFE_KEY}.lock"
+
+exec 9>"$LOCK_FILE"
+if ! flock -n 9; then
+  echo "Another Antfarm run appears to be active for: $REPO_PATH"
+  echo "Lock file: $LOCK_FILE"
+  exit 3
+fi
+
+cd "$REPO_PATH"
+antfarm workflow run "$WORKFLOW_ID" "$TASK"


### PR DESCRIPTION
## Summary

This PR adds a small helper script and documentation update to reduce accidental concurrent workflow runs against the same repository.

### What is included

1. `scripts/run-safe.sh`
   - Validates that the provided path is a git repository.
   - Uses a per-repo lock file under `/tmp` (via `flock`).
   - Exits early if another run for the same repository is already active.
   - Starts the workflow only after the lock is acquired.

2. `docs/creating-workflows.md`
   - Adds a new section: **Running safely (avoid per-repo concurrency)**
   - Documents how and why to use `scripts/run-safe.sh`.

## Why

When iterating quickly, it is easy to trigger overlapping runs on the same repo. In practice this can cause noisy state transitions and confusing run outcomes. This helper provides a lightweight guardrail without changing workflow semantics.

## Scope

- No core runtime behavior changed
- No workflow YAML behavior changed
- Script + docs only

## Example

```bash
scripts/run-safe.sh /home/me/projects/my-app feature-dev "Add OAuth login"
```