### PR TITLE
Fix out-of-order pending step claims by enforcing previous-step completion

### DIFF
--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -428,13 +428,22 @@ export function claimStep(agentId: string): ClaimResult {
   const db = getDb();
 
   const step = db.prepare(
-    `SELECT s.id, s.step_id, s.run_id, s.input_template, s.type, s.loop_config
+    `SELECT s.id, s.step_id, s.run_id, s.step_index, s.input_template, s.type, s.loop_config
      FROM steps s
      JOIN runs r ON r.id = s.run_id
-     WHERE s.agent_id = ? AND s.status = 'pending'
+     WHERE s.agent_id = ?
+       AND s.status = 'pending'
        AND r.status NOT IN ('failed', 'cancelled')
+       AND NOT EXISTS (
+         SELECT 1
+         FROM steps prev
+         WHERE prev.run_id = s.run_id
+           AND prev.step_index < s.step_index
+           AND prev.status != 'done'
+       )
+     ORDER BY s.created_at ASC
      LIMIT 1`
-  ).get(agentId) as { id: string; step_id: string; run_id: string; input_template: string; type: string; loop_config: string | null } | undefined;
+  ).get(agentId) as { id: string; step_id: string; run_id: string; step_index: number; input_template: string; type: string; loop_config: string | null } | undefined;
 
   if (!step) return { found: false };
 


### PR DESCRIPTION
## Summary

Fixes out-of-order step claiming by ensuring a pending step is only claimable when all previous steps in the same run are already `done`.

## Problem

In some runs, later steps could be claimed while earlier steps were still pending/running, which could produce confusing pipeline state transitions (e.g. handoff appearing done before PR/devops).

## Change

In `claimNextStep` (`src/installer/step-ops.ts`), add a guard:

- For a pending step `s`, only allow claim when there is **no previous step** in the same run with `step_index < s.step_index` and `status != 'done'`.
- Keep selecting the oldest eligible pending step.

## Why this helps

This enforces strict step ordering at claim time and prevents race-like out-of-order progression in asynchronous polling environments.

## Scope

- Runtime behavior change in step claiming logic only.
- No workflow YAML changes.
- No UI/dashboard changes.

Closes #250.
