### PR TITLE
fix(installer): remove invalid --delivery flag for openclaw CLI

### DIFF
--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -151,9 +151,8 @@ export async function createAgentCronJob(job: {
       args.push("--model", job.payload.model);
     }
 
-    if (job.delivery?.mode === "none") {
-      args.push("--delivery", "none");
-    }
+    // openclaw CLI uses --deliver (boolean flag), not --delivery <value>
+    // "none" mode means no delivery notification, so we simply omit the flag
 
     if (!job.enabled) {
       args.push("--disabled");


### PR DESCRIPTION
## Problem

When antfarm tries to create an agent cron job, it passes `--delivery none` to the openclaw CLI:

```ts
if (job.delivery?.mode === "none") {
  args.push("--delivery", "none");
}
```

However, the openclaw CLI does not support `--delivery <value>`. This causes every `antfarm workflow run` to fail with:

```
Cannot start workflow run: cron setup failed. Failed to create cron job for agent "triager":
CLI fallback failed: Error: error: unknown option '--delivery'
(Did you mean --deliver?)
```

## Fix

Remove the invalid flag. When `delivery.mode === "none"`, simply omit the flag — no delivery notification is the default behavior anyway.

The openclaw CLI only exposes `--deliver` as a boolean flag (to *send* a notification), not `--delivery <value>`.

## Testing

Verified locally with openclaw v2026.2.24:

```bash
antfarm workflow run bug-fix "test task"
# Before fix: Cannot start workflow run: cron
# After fix:  Run: #14 — Status: running ✅
```