### PR TITLE
fix: default optional template vars in single-step claim path

### DIFF
--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -92,6 +92,20 @@ export function resolveTemplate(template: string, context: Record<string, string
 }
 
 /**
+ * Template variables used in retry/feedback loops that may not exist on first run.
+ * Default them to empty string so findMissingTemplateKeys doesn't reject the step.
+ */
+const OPTIONAL_TEMPLATE_VARS = ["verify_feedback"] as const;
+
+export function defaultOptionalTemplateVars(context: Record<string, string>): void {
+  for (const key of OPTIONAL_TEMPLATE_VARS) {
+    if (!context[key]) {
+      context[key] = "";
+    }
+  }
+}
+
+/**
  * Find missing template placeholders for a given context object.
  */
 function findMissingTemplateKeys(template: string, context: Record<string, string>): string[] {
@@ -622,9 +636,7 @@ export function claimStep(agentId: string): ClaimResult {
       context["stories_remaining"] = String(pendingCount);
       context["progress"] = readProgressFile(step.run_id);
 
-      if (!context["verify_feedback"]) {
-        context["verify_feedback"] = "";
-      }
+      defaultOptionalTemplateVars(context);
 
       const missingKeys = findMissingTemplateKeys(step.input_template, context);
       if (missingKeys.length > 0) {
@@ -654,6 +666,8 @@ export function claimStep(agentId: string): ClaimResult {
   if (hasStories.cnt > 0) {
     context["progress"] = readProgressFile(step.run_id);
   }
+
+  defaultOptionalTemplateVars(context);
 
   const missingKeys = findMissingTemplateKeys(step.input_template, context);
   if (missingKeys.length > 0) {

--- a/tests/optional-template-vars.test.ts
+++ b/tests/optional-template-vars.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Regression test: optional template variables like {{verify_feedback}} must
+ * be defaulted to empty string so findMissingTemplateKeys doesn't reject steps
+ * on their first run (before any verify pass has populated the var).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { defaultOptionalTemplateVars, resolveTemplate } from "../dist/installer/step-ops.js";
+
+describe("defaultOptionalTemplateVars", () => {
+
+  it("sets verify_feedback to empty string when missing", () => {
+    const ctx: Record<string, string> = { task: "fix bug" };
+    defaultOptionalTemplateVars(ctx);
+    assert.equal(ctx["verify_feedback"], "");
+  });
+
+  it("preserves existing verify_feedback value", () => {
+    const ctx: Record<string, string> = { verify_feedback: "needs error handling" };
+    defaultOptionalTemplateVars(ctx);
+    assert.equal(ctx["verify_feedback"], "needs error handling");
+  });
+
+  it("allows resolveTemplate to resolve {{verify_feedback}} after defaults applied", () => {
+    const ctx: Record<string, string> = { task: "fix bug" };
+    defaultOptionalTemplateVars(ctx);
+    const result = resolveTemplate("Do {{task}}. Feedback: {{verify_feedback}}", ctx);
+    assert.equal(result, "Do fix bug. Feedback: ");
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `defaultOptionalTemplateVars` helper for retry/feedback loop vars that may not exist on first run
- Call it in both the story/loop and single-step claim paths before `findMissingTemplateKeys`
- Fixes bug where `{{verify_feedback}}` in bug-fix workflow's `fix` step template caused step failure on first run (the var is only populated on verify→fix retry loops)

## Root Cause
The story/loop claim path (line ~625) had a fallback: `if (!context["verify_feedback"]) context["verify_feedback"] = ""`
The single-step claim path (line ~658) did NOT have this fallback.
On first run, `verify_feedback` isn't in context → `findMissingTemplateKeys` finds it missing → step fails → run fails.

## Test Plan
- Added regression test (`tests/optional-template-vars.test.ts`)
- `bun run build` passes
- Full test suite passes