### PR TITLE
fix: unblock verify_each claim and harden step idempotency

### DIFF
--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -37,6 +37,7 @@ TESTS: what tests you ran
 ANTFARM_EOF
 cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
 \`\`\`
+If that command returns JSON, reporting is complete. STOP immediately. Do not call step complete again.
 
 If the work FAILED:
 \`\`\`
@@ -47,6 +48,8 @@ RULES:
 1. NEVER end your session without calling step complete or step fail
 2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. NEVER call subagents/subagents steer to report completion. Only use antfarm step complete/step fail.
+5. NEVER call step complete more than once for the same stepId.
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }
@@ -74,6 +77,7 @@ TESTS: what tests you ran
 ANTFARM_EOF
 cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
 \`\`\`
+If that command returns JSON, reporting is complete. STOP immediately. Do not call step complete again.
 
 If the work FAILED:
 \`\`\`
@@ -84,6 +88,8 @@ RULES:
 1. NEVER end your session without calling step complete or step fail
 2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. NEVER call subagents/subagents steer to report completion. Only use antfarm step complete/step fail.
+5. NEVER call step complete more than once for the same stepId.
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -208,6 +208,54 @@ function formatCompletedStories(stories: Story[]): string {
 
 // ── T5: STORIES_JSON parsing ────────────────────────────────────────
 
+type ExistingStoryPayloadRow = {
+  story_id: string;
+  title: string;
+  description: string;
+  acceptance_criteria: string;
+};
+
+type ComparableStoryPayload = {
+  id: string;
+  title: string;
+  description: string;
+  acceptanceCriteria: unknown[];
+};
+
+function normalizeAcceptanceCriteria(value: unknown): unknown[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function normalizeIncomingStoryPayload(story: any): ComparableStoryPayload {
+  const ac = story?.acceptanceCriteria ?? story?.acceptance_criteria;
+  return {
+    id: String(story?.id ?? ""),
+    title: String(story?.title ?? ""),
+    description: String(story?.description ?? ""),
+    acceptanceCriteria: normalizeAcceptanceCriteria(ac),
+  };
+}
+
+function normalizeStoredStoryPayload(story: ExistingStoryPayloadRow): ComparableStoryPayload {
+  let parsedAc: unknown = [];
+  try {
+    parsedAc = JSON.parse(story.acceptance_criteria);
+  } catch {
+    // Existing DB rows should store valid JSON; fallback keeps comparison deterministic.
+    parsedAc = story.acceptance_criteria;
+  }
+  return {
+    id: String(story.story_id ?? ""),
+    title: String(story.title ?? ""),
+    description: String(story.description ?? ""),
+    acceptanceCriteria: normalizeAcceptanceCriteria(parsedAc),
+  };
+}
+
+function storiesPayloadHash(stories: ComparableStoryPayload[]): string {
+  return crypto.createHash("sha256").update(JSON.stringify(stories)).digest("hex");
+}
+
 /**
  * Parse STORIES_JSON from step output and insert stories into the DB.
  */
@@ -240,6 +288,19 @@ function parseAndInsertStories(output: string, runId: string): void {
   }
 
   const db = getDb();
+  const existingStories = db.prepare(
+    "SELECT story_id, title, description, acceptance_criteria FROM stories WHERE run_id = ? ORDER BY story_index ASC"
+  ).all(runId) as ExistingStoryPayloadRow[];
+  if (existingStories.length > 0) {
+    const incomingHash = storiesPayloadHash(stories.map(normalizeIncomingStoryPayload));
+    const existingHash = storiesPayloadHash(existingStories.map(normalizeStoredStoryPayload));
+
+    // Idempotent planner re-submission: ignore duplicate insertion attempts.
+    if (incomingHash === existingHash) return;
+
+    throw new Error("Run already has stories; refusing to append a different STORIES_JSON payload");
+  }
+
   const now = new Date().toISOString();
   const insert = db.prepare(
     "INSERT INTO stories (id, run_id, story_index, story_id, title, description, acceptance_criteria, status, retry_count, max_retries, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', 0, 2, ?, ?)"
@@ -496,12 +557,19 @@ export function claimStep(agentId: string): ClaimResult {
      FROM steps s
      JOIN runs r ON r.id = s.run_id
      WHERE s.agent_id = ? AND s.status = 'pending'
-       AND r.status NOT IN ('failed', 'cancelled')
+     AND r.status NOT IN ('failed', 'cancelled')
        AND NOT EXISTS (
          SELECT 1 FROM steps prev
          WHERE prev.run_id = s.run_id
            AND prev.step_index < s.step_index
            AND prev.status NOT IN ('done', 'skipped')
+           AND NOT (
+             prev.type = 'loop'
+             AND prev.status = 'running'
+             AND prev.current_story_id IS NULL
+             AND json_extract(prev.loop_config, '$.verifyEach') = 1
+             AND json_extract(prev.loop_config, '$.verifyStep') = s.step_id
+           )
        )
     ORDER BY s.step_index ASC, s.step_id ASC
      LIMIT 1`
@@ -680,10 +748,14 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
+    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id, status FROM steps WHERE id = ?"
+  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null; status: string } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
+  if (step.status !== "running") {
+    // Idempotency guard: duplicate completions should be no-ops.
+    return { advanced: false, runCompleted: false };
+  }
 
   // Guard: don't process completions for failed runs
   const runCheck = db.prepare("SELECT status FROM runs WHERE id = ?").get(step.run_id) as { status: string } | undefined;
@@ -1036,7 +1108,7 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT run_id, step_id, retry_count, max_retries, type, current_story_id FROM steps WHERE id = ?"
+    "SELECT run_id, step_id, retry_count, max_retries, type, current_story_id, status FROM steps WHERE id = ?"
   ).get(stepId) as {
     run_id: string;
     step_id: string;
@@ -1044,9 +1116,14 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
     max_retries: number;
     type: string;
     current_story_id: string | null;
+    status: string;
   } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
+  if (step.status === "done") {
+    // Idempotency guard: a completed step cannot be failed afterwards.
+    return { retrying: false, runFailed: false };
+  }
 
   // T9: Loop step failure — per-story retry
   if (step.type === "loop" && step.current_story_id) {

--- a/tests/polling-prompt.test.ts
+++ b/tests/polling-prompt.test.ts
@@ -43,6 +43,8 @@ describe("buildPollingPrompt", () => {
     const prompt = buildPollingPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("step complete"), "should include step complete from work prompt");
     assert.ok(prompt.includes("step fail"), "should include step fail from work prompt");
+    assert.ok(prompt.includes("STOP immediately"), "should include stop-immediately safeguard");
+    assert.ok(prompt.includes("Do not call step complete again"), "should include duplicate completion guard");
     assert.ok(prompt.includes("---START WORK PROMPT---"), "should delimit work prompt");
     assert.ok(prompt.includes("---END WORK PROMPT---"), "should delimit work prompt");
   });

--- a/tests/step-ops-idempotency.test.ts
+++ b/tests/step-ops-idempotency.test.ts
@@ -1,0 +1,147 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type Db = {
+  prepare: (sql: string) => {
+    run: (...args: unknown[]) => void;
+    get: (...args: unknown[]) => unknown;
+  };
+};
+
+type DbModule = { getDb: () => Db };
+type StepOpsModule = {
+  completeStep: (stepId: string, output: string) => { advanced: boolean; runCompleted: boolean };
+  failStep: (stepId: string, error: string) => Promise<{ retrying: boolean; runFailed: boolean }>;
+};
+
+const STEP_OPS_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/installer/step-ops.js")).href;
+const DB_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/db.js")).href;
+
+let originalHome: string | undefined;
+let tmpHome: string;
+let dbModule: DbModule;
+let stepOpsModule: StepOpsModule;
+let sqlite: Db;
+
+async function loadFreshModules(): Promise<void> {
+  const nonce = `${Date.now()}-${Math.random()}`;
+  dbModule = await import(`${DB_URL}?v=${nonce}`) as DbModule;
+  stepOpsModule = await import(`${STEP_OPS_URL}?v=${nonce}`) as StepOpsModule;
+  sqlite = dbModule.getDb();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+describe("step-ops idempotency guards", () => {
+  before(async () => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-idempotency-"));
+    process.env.HOME = tmpHome;
+    await loadFreshModules();
+  });
+
+  beforeEach(() => {
+    sqlite.prepare("DELETE FROM stories").run();
+    sqlite.prepare("DELETE FROM steps").run();
+    sqlite.prepare("DELETE FROM runs").run();
+  });
+
+  after(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("completeStep is a no-op when step is not running", () => {
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = now();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan', 'wf_planner', 0, 'input', 'STATUS: done', 'done', 'single', ?, ?)"
+    ).run(stepId, runId, t, t);
+
+    const result = stepOpsModule.completeStep(stepId, "STATUS: done\nCHANGES: duplicate completion");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const run = sqlite.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };
+    assert.equal(run.context, "{}", "run context must remain unchanged");
+  });
+
+  it("failStep is a no-op for already-completed steps", async () => {
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = now();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, type, created_at, updated_at) VALUES (?, ?, 'verify', 'wf_verifier', 1, 'input', 'STATUS: done', 'done', 0, 2, 'single', ?, ?)"
+    ).run(stepId, runId, t, t);
+
+    const result = await stepOpsModule.failStep(stepId, "late failure");
+    assert.deepEqual(result, { retrying: false, runFailed: false });
+
+    const run = sqlite.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "running", "run must not be failed by a late failStep");
+  });
+
+  it("STORIES_JSON insertion is idempotent for same payload and rejects different payloads", () => {
+    const runId = crypto.randomUUID();
+    const t = now();
+    const stepA = crypto.randomUUID();
+    const stepB = crypto.randomUUID();
+    const stepC = crypto.randomUUID();
+    const stepD = crypto.randomUUID();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'wf', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan-a', 'wf_planner', 0, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepA, runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan-b', 'wf_planner', 1, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepB, runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan-c', 'wf_planner', 2, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepC, runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan-d', 'wf_planner', 3, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepD, runId, t, t);
+
+    const payloadA = `STATUS: done\nSTORIES_JSON: [{"id":"US-001","title":"T1","description":"D1","acceptanceCriteria":["A1"]}]`;
+    const payloadB = `STATUS: done\nSTORIES_JSON: [{"id":"US-999","title":"T2","description":"D2","acceptanceCriteria":["A2"]}]`;
+    const payloadC = `STATUS: done\nSTORIES_JSON: [{"id":"US-001","title":"T1 updated","description":"D1 updated","acceptanceCriteria":["A1","A2"]}]`;
+
+    stepOpsModule.completeStep(stepA, payloadA);
+    stepOpsModule.completeStep(stepB, payloadA); // idempotent re-submission should no-op
+
+    const storyCount = sqlite.prepare("SELECT COUNT(*) as cnt FROM stories WHERE run_id = ?").get(runId) as { cnt: number };
+    assert.equal(storyCount.cnt, 1);
+
+    assert.throws(
+      () => stepOpsModule.completeStep(stepC, payloadB),
+      /Run already has stories; refusing to append a different STORIES_JSON payload/
+    );
+    assert.throws(
+      () => stepOpsModule.completeStep(stepD, payloadC),
+      /Run already has stories; refusing to append a different STORIES_JSON payload/
+    );
+  });
+});

--- a/tests/verify-each-claim-regression.test.ts
+++ b/tests/verify-each-claim-regression.test.ts
@@ -1,0 +1,130 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type ClaimResult = {
+  found: boolean;
+  stepId?: string;
+  runId?: string;
+  resolvedInput?: string;
+};
+
+type DbModule = {
+  getDb: () => {
+    prepare: (sql: string) => {
+      run: (...args: unknown[]) => void;
+      get: (...args: unknown[]) => unknown;
+    };
+  };
+};
+
+type StepOpsModule = {
+  claimStep: (agentId: string) => ClaimResult;
+};
+
+const STEP_OPS_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/installer/step-ops.js")).href;
+const DB_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/db.js")).href;
+
+let originalHome: string | undefined;
+let tmpHome: string;
+let dbModule: DbModule;
+let stepOpsModule: StepOpsModule;
+let sqlite: ReturnType<DbModule["getDb"]>;
+
+async function loadFreshModules(): Promise<void> {
+  const nonce = `${Date.now()}-${Math.random()}`;
+  dbModule = await import(`${DB_URL}?v=${nonce}`) as DbModule;
+  stepOpsModule = await import(`${STEP_OPS_URL}?v=${nonce}`) as StepOpsModule;
+  sqlite = dbModule.getDb();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+describe("claimStep verify_each regression", () => {
+  before(async () => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-verify-each-"));
+    process.env.HOME = tmpHome;
+    await loadFreshModules();
+  });
+
+  beforeEach(() => {
+    sqlite.prepare("DELETE FROM stories").run();
+    sqlite.prepare("DELETE FROM steps").run();
+    sqlite.prepare("DELETE FROM runs").run();
+  });
+
+  after(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("allows verify step claim when preceding loop is running and waiting for verify_each", async () => {
+    const runId = crypto.randomUUID();
+    const t = now();
+    const implementDbId = crypto.randomUUID();
+    const verifyDbId = crypto.randomUUID();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'feature-dev', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, loop_config, current_story_id, created_at, updated_at) VALUES (?, ?, 'implement', 'feature-dev_developer', 2, 'implement', 'STATUS: done', 'running', 'loop', ?, NULL, ?, ?)"
+    ).run(
+      implementDbId,
+      runId,
+      JSON.stringify({ over: "stories", completion: "all_done", verifyEach: true, verifyStep: "verify" }),
+      t,
+      t
+    );
+
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'verify', 'feature-dev_verifier', 3, 'verify-input', 'STATUS: done', 'pending', 'single', ?, ?)"
+    ).run(verifyDbId, runId, t, t);
+
+    const result = stepOpsModule.claimStep("feature-dev_verifier");
+
+    assert.equal(result.found, true);
+    assert.equal(result.stepId, verifyDbId);
+    assert.equal(result.runId, runId);
+  });
+
+  it("does not bypass other pending steps that are unrelated to verify_each", async () => {
+    const runId = crypto.randomUUID();
+    const t = now();
+    const implementDbId = crypto.randomUUID();
+    const reviewDbId = crypto.randomUUID();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'feature-dev', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, loop_config, current_story_id, created_at, updated_at) VALUES (?, ?, 'implement', 'feature-dev_developer', 2, 'implement', 'STATUS: done', 'running', 'loop', ?, NULL, ?, ?)"
+    ).run(
+      implementDbId,
+      runId,
+      JSON.stringify({ over: "stories", completion: "all_done", verifyEach: true, verifyStep: "verify" }),
+      t,
+      t
+    );
+
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'review', 'feature-dev_reviewer', 6, 'review-input', 'STATUS: done', 'pending', 'single', ?, ?)"
+    ).run(reviewDbId, runId, t, t);
+
+    const result = stepOpsModule.claimStep("feature-dev_reviewer");
+    assert.equal(result.found, false);
+  });
+});

--- a/tests/work-prompt.test.ts
+++ b/tests/work-prompt.test.ts
@@ -6,6 +6,8 @@ describe("buildWorkPrompt", () => {
   it("contains step complete instructions", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("step complete"));
+    assert.ok(prompt.includes("STOP immediately"), "should require immediate stop after reporting");
+    assert.ok(prompt.includes("Do not call step complete again"), "should prohibit duplicate completion");
   });
 
   it("contains step fail instructions", () => {
@@ -22,6 +24,10 @@ describe("buildWorkPrompt", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("CRITICAL"));
     assert.ok(prompt.includes("stuck forever"));
+    assert.ok(
+      prompt.includes("NEVER call subagents/subagents steer"),
+      "should forbid completion via subagents/subagents steer"
+    );
   });
 
   it("does not include HEARTBEAT_OK or NO_WORK", () => {


### PR DESCRIPTION
## Summary

This PR fixes a workflow deadlock in `verify_each` mode and hardens step terminal behavior to be idempotent.

### Fixes included

1. Unblock `verify_each` claim path in `claimStep`
- File: `src/installer/step-ops.ts`
- Problem: when loop step is `running` with `current_story_id = NULL` (waiting for verify), the verify step could remain `pending` but still be unclaimable due to predecessor gating.
- Fix: allow this specific predecessor state when it is a loop step with:
  - `verifyEach = true`
  - `verifyStep = current step_id`

2. Make `completeStep` idempotent
- File: `src/installer/step-ops.ts`
- Fix: return no-op unless current step status is `running`.

3. Make `failStep` idempotent for completed steps
- File: `src/installer/step-ops.ts`
- Fix: return no-op when step status is already `done`.

4. Prevent duplicate/mixed `STORIES_JSON` insertion
- File: `src/installer/step-ops.ts`
- Fix:
  - if stories already exist and incoming story IDs are identical => idempotent no-op
  - if incoming payload differs => throw explicit error (refuse mixed payload)

5. Strengthen cron/work prompt guidance
- File: `src/installer/agent-cron.ts`
- Added explicit instructions to:
  - stop immediately after `step complete` succeeds
  - never use `subagents/subagents steer` to report completion
  - never call `step complete` more than once for a step

## Tests

### New tests
- `tests/verify-each-claim-regression.test.ts`
  - verifies verify step is claimable in the loop-running-waiting-for-verify state
  - verifies unrelated pending steps are still correctly gated
- `tests/step-ops-idempotency.test.ts`
  - `completeStep` no-op when step is not running
  - `failStep` no-op when step is already done
  - `STORIES_JSON` idempotent re-submission behavior + mismatch rejection

### Updated tests
- `tests/work-prompt.test.ts`
- `tests/polling-prompt.test.ts`

## Verification run

- Build: `npm run build` ✅
- Tests:
  - `node --experimental-strip-types --test tests/work-prompt.test.ts tests/polling-prompt.test.ts tests/verify-each-claim-regression.test.ts tests/step-ops-idempotency.test.ts` ✅
