### PR TITLE
fix(run): make cron setup failure non-fatal

### DIFF
--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -151,9 +151,8 @@ export async function createAgentCronJob(job: {
       args.push("--model", job.payload.model);
     }
 
-    if (job.delivery?.mode === "none") {
-      args.push("--delivery", "none");
-    }
+    // openclaw CLI uses --deliver (boolean flag), not --delivery <value>
+    // "none" mode means no delivery notification, so we simply omit the flag
 
     if (!job.enabled) {
       args.push("--disabled");

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -53,14 +53,13 @@ export async function runWorkflow(params: {
   }
 
   // Start crons for this workflow (no-op if already running from another run)
+  // Cron failure is non-fatal: patlabor-worker uses step peek/claim polling,
+  // so runs are viable without cron registration.
   try {
     await ensureWorkflowCrons(workflow);
   } catch (err) {
-    // Roll back the run since it can't advance without crons
-    const db2 = getDb();
-    db2.prepare("UPDATE runs SET status = 'failed', updated_at = ? WHERE id = ?").run(new Date().toISOString(), runId);
     const message = err instanceof Error ? err.message : String(err);
-    throw new Error(`Cannot start workflow run: cron setup failed. ${message}`);
+    logger.warn(`Cron setup failed (non-fatal, worker will poll): ${message}`);
   }
 
   emitEvent({ ts: new Date().toISOString(), event: "run.started", runId, workflowId: workflow.id });


### PR DESCRIPTION
## Problem

When `ensureWorkflowCrons()` throws, the run and all steps are already committed to the DB. The current code rolls back the run to `failed` and re-throws — so any external worker polling via `step peek/claim` sees `NO_WORK` for a run that is ready to execute.

## Fix

Make cron failure non-fatal: log a warning and leave the run as `running`. Workers that poll via `antfarm step peek` will find work regardless of whether crons registered.

No-op for setups where crons work correctly.

🤖 Generated with [Claude Code](https://claude.ai/code)