### PR TITLE
feat: add built-in workflow for creating Antfarm workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Paste a bug report. Get back a fix with a regression test. Triager reproduces it
 triage → investigate → setup → fix → verify → PR
 ```
 
+### workflow-dev `6 agents`
+
+Describe the workflow you want. Get back a tested PR that scaffolds the workflow contract, agent files, and retry wiring. Built for bootstrapping new Antfarm workflows without hand-writing every prompt and YAML stanza.
+
+```
+plan → specify → setup → implement → verify → PR
+```
+
 ---
 
 ## Why It Works
@@ -86,6 +94,11 @@ $ antfarm workflow install feature-dev
 $ antfarm workflow run feature-dev "Add user authentication with OAuth"
 Run: a1fdf573
 Workflow: feature-dev
+Status: running
+
+$ antfarm workflow run workflow-dev "Create a customer-onboarding workflow with setup, implement, verify, and pr steps"
+Run: b7ceaa91
+Workflow: workflow-dev
 Status: running
 
 $ antfarm workflow status "OAuth"

--- a/docs/creating-workflows.md
+++ b/docs/creating-workflows.md
@@ -321,6 +321,49 @@ Reference them from your workflow:
       IDENTITY.md: ../../agents/shared/setup/IDENTITY.md
 ```
 
+## Bootstrap a New Workflow with `workflow-dev`
+
+Use the built-in workflow authoring pipeline when you want Antfarm to generate or update a workflow for you.
+
+### Runnable example
+
+```bash
+antfarm workflow install workflow-dev
+antfarm workflow run workflow-dev "Create an incident-response workflow for production outages"
+```
+
+### Task input template
+
+Use a task string (or issue body) that includes these sections:
+
+```
+Goal: <what workflow to create/update>
+Repository: <path or repo slug>
+Workflow ID: <new-or-existing-id>
+Agents: <which agents are needed and why>
+Pipeline: <ordered step list>
+Constraints: <safety, tooling, path, or environment constraints>
+Acceptance Criteria:
+- <criterion 1>
+- <criterion 2>
+- Typecheck passes
+```
+
+Acceptance criteria should be concrete and mechanically verifiable (file exists, command passes, output contains key). Avoid subjective criteria like "looks good".
+
+### Required output contract (KEY: value)
+
+The workflow expects deterministic KEY: value lines from each step. At minimum:
+
+- **plan**: `STATUS`, `REPO`, `BRANCH`, `STORIES_JSON`
+- **specify**: `STATUS`, `SPEC_JSON`, `SPEC_CHECKS`
+- **implement**: `STATUS`, `WORKFLOW_ID`, `CREATED_FILES`, `PRESERVED_FILES`, `AGENTS_CREATED`, `CHANGES`, `TESTS`
+- **verify** success: `STATUS: done`, `VERIFIED`
+- **verify** retry path: `STATUS: retry`, `ISSUES`
+- **pr**: `STATUS`, `PR`
+
+These keys feed downstream template variables. If keys are missing or malformed, orchestration and retry behavior can fail.
+
 ## Installing Your Workflow
 
 Place your workflow directory in `workflows/` and run:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/server/index.html dist/server/index.html && chmod +x dist/cli/cli.js && node scripts/inject-version.js",
-    "start": "node dist/cli/cli.js"
+    "start": "node dist/cli/cli.js",
+    "test": "npm run build && node --test tests/*.test.ts"
   },
   "dependencies": {
     "json5": "^2.2.3",

--- a/tests/fixtures/workflow-dev-smoke-task.json
+++ b/tests/fixtures/workflow-dev-smoke-task.json
@@ -1,0 +1,9 @@
+{
+  "task": "create antfarm workflow for create antfarm workflow",
+  "repo": "/root/.openclaw/workspace/antfarm",
+  "branch": "feature/workflow-create-antfarm-workflow",
+  "build_cmd": "npm run build",
+  "test_cmd": "npm test",
+  "changes": "Generated workflow.yml and agent workspace files",
+  "current_story": "Story US-008: Add final smoke test for generated workflow artifact validity"
+}

--- a/tests/polling-timeout-consistency.test.ts
+++ b/tests/polling-timeout-consistency.test.ts
@@ -37,8 +37,8 @@ describe("polling timeout consistency across all workflows", () => {
     assert.ok(checked >= 3, `Expected at least 3 workflows with polling, found ${checked}`);
   });
 
-  it("bug-fix, feature-dev, and security-audit all use 120s timeout", async () => {
-    const expectedWorkflows = ["bug-fix", "feature-dev", "security-audit"];
+  it("bug-fix, feature-dev, security-audit, and workflow-dev all use 120s timeout", async () => {
+    const expectedWorkflows = ["bug-fix", "feature-dev", "security-audit", "workflow-dev"];
 
     for (const name of expectedWorkflows) {
       const dir = path.join(WORKFLOWS_DIR, name);

--- a/tests/polling-timeout-sync.test.ts
+++ b/tests/polling-timeout-sync.test.ts
@@ -17,7 +17,7 @@ import assert from "node:assert/strict";
 
 const WORKFLOWS_DIR = path.resolve(import.meta.dirname, "..", "workflows");
 
-const WORKFLOW_NAMES = ["bug-fix", "feature-dev", "security-audit"];
+const WORKFLOW_NAMES = ["bug-fix", "feature-dev", "security-audit", "workflow-dev"];
 
 describe("polling timeout sync across all workflows", () => {
   for (const name of WORKFLOW_NAMES) {

--- a/tests/two-phase-integration.test.ts
+++ b/tests/two-phase-integration.test.ts
@@ -119,11 +119,12 @@ describe("two-phase-integration", () => {
       assert.ok(prompt.includes("step fail"));
     });
 
-    it("all three workflows produce valid prompts", () => {
+    it("all built-in workflows produce valid prompts", () => {
       const workflows = [
         { id: "feature-dev", agents: ["planner", "developer", "reviewer", "verifier"] },
         { id: "security-audit", agents: ["scanner", "analyst", "remediator"] },
         { id: "bug-fix", agents: ["triager", "fixer", "verifier"] },
+        { id: "workflow-dev", agents: ["planner", "architect", "setup", "developer", "verifier", "pr"] },
       ];
 
       for (const wf of workflows) {

--- a/tests/workflow-dev-artifact-smoke.test.ts
+++ b/tests/workflow-dev-artifact-smoke.test.ts
@@ -1,0 +1,83 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { readFileSync, existsSync } from "node:fs";
+import YAML from "yaml";
+import { loadWorkflowSpec } from "../dist/installer/workflow-spec.js";
+import { resolveTemplate } from "../dist/installer/step-ops.js";
+
+type SmokeFixture = {
+  task: string;
+  repo: string;
+  branch: string;
+  build_cmd: string;
+  test_cmd: string;
+  changes: string;
+  current_story: string;
+};
+
+describe("workflow-dev generated artifact smoke", () => {
+  it("validates workflow artifact structure and step-agent references from fixture-driven generation path", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const repoRoot = path.resolve(workflowDir, "..", "..");
+    const fixturePath = path.resolve("tests/fixtures/workflow-dev-smoke-task.json");
+    const fixture = JSON.parse(readFileSync(fixturePath, "utf8")) as SmokeFixture;
+
+    const spec = await loadWorkflowSpec(workflowDir);
+    const implementStep = spec.steps.find((step) => step.id === "implement");
+    const verifyStep = spec.steps.find((step) => step.id === "verify");
+
+    assert.ok(implementStep?.input, "implement step input should exist");
+    assert.ok(verifyStep?.input, "verify step input should exist");
+
+    const implementInput = resolveTemplate(implementStep!.input, fixture);
+    const verifyInput = resolveTemplate(verifyStep!.input, fixture);
+
+    assert.ok(implementInput.includes(fixture.task));
+    assert.ok(implementInput.includes(fixture.current_story));
+    assert.ok(implementInput.includes("Generate or update `workflow.yml`"));
+    assert.ok(implementInput.includes("`AGENTS.md`, `SOUL.md`, and `IDENTITY.md`"));
+
+    assert.ok(verifyInput.includes(fixture.task));
+    assert.ok(verifyInput.includes(fixture.changes));
+    assert.ok(verifyInput.includes("Generated `workflow.yml` parses as valid YAML"));
+    assert.ok(verifyInput.includes("references a declared agent id"));
+
+    const workflowYamlPath = path.join(workflowDir, "workflow.yml");
+    const parsed = YAML.parse(readFileSync(workflowYamlPath, "utf8")) as {
+      id?: string;
+      name?: string;
+      version?: number;
+      description?: string;
+      agents?: Array<{ id?: string; workspace?: { files?: Record<string, string> } }>;
+      steps?: Array<{ id?: string; agent?: string; input?: string }>;
+    };
+
+    assert.equal(parsed.id, "workflow-dev");
+    assert.ok(parsed.name, "workflow name is required");
+    assert.equal(typeof parsed.version, "number");
+    assert.ok(parsed.description, "workflow description is required");
+    assert.ok(Array.isArray(parsed.agents) && parsed.agents.length > 0, "agents are required");
+    assert.ok(Array.isArray(parsed.steps) && parsed.steps.length > 0, "steps are required");
+
+    const agentIds = new Set((parsed.agents ?? []).map((agent) => agent.id).filter(Boolean));
+    for (const step of parsed.steps ?? []) {
+      assert.ok(step.id, "step.id is required");
+      assert.ok(step.agent, "step.agent is required");
+      assert.ok(step.input, `step ${step.id} input is required`);
+      assert.ok(agentIds.has(step.agent), `step ${step.id} references undeclared agent ${step.agent}`);
+    }
+
+    for (const agent of parsed.agents ?? []) {
+      const files = agent.workspace?.files ?? {};
+      for (const required of ["AGENTS.md", "SOUL.md", "IDENTITY.md"]) {
+        assert.ok(files[required], `agent ${agent.id} missing ${required} mapping`);
+        const resolved = path.resolve(workflowDir, files[required]);
+        const inWorkflowDir = resolved.startsWith(workflowDir);
+        const inRepo = resolved.startsWith(repoRoot);
+        assert.ok(inWorkflowDir || inRepo, `agent ${agent.id} ${required} path escapes repo`);
+        assert.ok(existsSync(resolved), `agent ${agent.id} missing file on disk: ${files[required]}`);
+      }
+    }
+  });
+});

--- a/tests/workflow-dev-docs.test.ts
+++ b/tests/workflow-dev-docs.test.ts
@@ -1,0 +1,38 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+
+describe("workflow-dev documentation", () => {
+  it("documents workflow-dev in README workflow catalog with pipeline summary", () => {
+    const readme = readFileSync(path.resolve("README.md"), "utf-8");
+
+    assert.ok(readme.includes("### workflow-dev `6 agents`"));
+    assert.ok(readme.includes("plan → specify → setup → implement → verify → PR"));
+  });
+
+  it("includes a runnable workflow-dev command example", () => {
+    const readme = readFileSync(path.resolve("README.md"), "utf-8");
+    const docs = readFileSync(path.resolve("docs/creating-workflows.md"), "utf-8");
+
+    assert.ok(readme.includes('antfarm workflow run workflow-dev "Create a customer-onboarding workflow with setup, implement, verify, and pr steps"'));
+    assert.ok(docs.includes("antfarm workflow install workflow-dev"));
+    assert.ok(docs.includes('antfarm workflow run workflow-dev "Create an incident-response workflow for production outages"'));
+  });
+
+  it("documents required task structure and KEY: value output contract", () => {
+    const docs = readFileSync(path.resolve("docs/creating-workflows.md"), "utf-8");
+
+    assert.ok(docs.includes("Goal:"));
+    assert.ok(docs.includes("Pipeline:"));
+    assert.ok(docs.includes("Acceptance Criteria:"));
+    assert.ok(docs.includes("Typecheck passes"));
+
+    assert.ok(docs.includes("Required output contract (KEY: value)"));
+    assert.ok(docs.includes("`STORIES_JSON`"));
+    assert.ok(docs.includes("`SPEC_JSON`"));
+    assert.ok(docs.includes("`CREATED_FILES`"));
+    assert.ok(docs.includes("`STATUS: retry`"));
+    assert.ok(docs.includes("`ISSUES`"));
+  });
+});

--- a/tests/workflow-dev-install-uninstall.test.ts
+++ b/tests/workflow-dev-install-uninstall.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+
+import { listBundledWorkflows } from "../dist/installer/workflow-fetch.js";
+import { installWorkflow } from "../dist/installer/install.js";
+import { uninstallWorkflow } from "../dist/installer/uninstall.js";
+
+describe("workflow-dev install/list/uninstall", () => {
+  let tmpDir: string;
+  let fakeHome: string;
+  let stateDir: string;
+  let configPath: string;
+  let originalHome: string | undefined;
+  let originalState: string | undefined;
+  let originalConfigPath: string | undefined;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "antfarm-workflow-dev-"));
+    fakeHome = path.join(tmpDir, "home");
+    stateDir = path.join(fakeHome, ".openclaw");
+    configPath = path.join(stateDir, "openclaw.json");
+
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(
+      configPath,
+      JSON.stringify({
+        agents: {
+          list: [
+            { id: "main", name: "Main", default: true, workspace: path.join(stateDir, "workspaces", "main") },
+            { id: "feature-dev_planner", name: "Existing Feature Planner", workspace: path.join(stateDir, "workspaces", "workflows", "feature-dev", "planner") },
+          ],
+        },
+      }, null, 2) + "\n",
+      "utf-8",
+    );
+
+    originalHome = process.env.HOME;
+    originalState = process.env.OPENCLAW_STATE_DIR;
+    originalConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+
+    process.env.HOME = fakeHome;
+    process.env.OPENCLAW_STATE_DIR = stateDir;
+    process.env.OPENCLAW_CONFIG_PATH = configPath;
+  });
+
+  afterEach(async () => {
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+
+    if (originalState === undefined) delete process.env.OPENCLAW_STATE_DIR;
+    else process.env.OPENCLAW_STATE_DIR = originalState;
+
+    if (originalConfigPath === undefined) delete process.env.OPENCLAW_CONFIG_PATH;
+    else process.env.OPENCLAW_CONFIG_PATH = originalConfigPath;
+
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("lists workflow-dev and installs/uninstalls only workflow-specific artifacts", async () => {
+    const workflows = await listBundledWorkflows();
+    assert.ok(workflows.includes("workflow-dev"), "workflow list should include workflow-dev");
+
+    await installWorkflow({ workflowId: "workflow-dev" });
+
+    const workflowDir = path.join(stateDir, "antfarm", "workflows", "workflow-dev");
+    const workflowWorkspace = path.join(stateDir, "workspaces", "workflows", "workflow-dev");
+    const plannerWorkspace = path.join(workflowWorkspace, "agents", "planner");
+    const plannerAgentDir = path.join(stateDir, "agents", "workflow-dev_planner", "agent");
+
+    await fs.access(path.join(workflowDir, "workflow.yml"));
+    await fs.access(path.join(workflowDir, "metadata.json"));
+    await fs.access(path.join(plannerWorkspace, "AGENTS.md"));
+    await fs.access(plannerAgentDir);
+
+    const installedConfig = JSON.parse(await fs.readFile(configPath, "utf-8"));
+    const installedAgentIds = (installedConfig.agents?.list ?? []).map((entry: any) => entry.id);
+
+    assert.ok(installedAgentIds.includes("workflow-dev_planner"), "workflow-dev planner should be provisioned");
+    assert.ok(installedAgentIds.includes("workflow-dev_architect"), "workflow-dev architect should be provisioned");
+    assert.ok(installedAgentIds.includes("feature-dev_planner"), "existing workflows should remain untouched");
+
+    await uninstallWorkflow({ workflowId: "workflow-dev" });
+
+    await assert.rejects(fs.access(workflowDir), "workflow install dir should be removed on uninstall");
+    await assert.rejects(fs.access(workflowWorkspace), "workflow workspace should be removed on uninstall");
+    await assert.rejects(fs.access(path.join(stateDir, "agents", "workflow-dev_planner")), "workflow-dev agent dir should be removed");
+
+    const finalConfig = JSON.parse(await fs.readFile(configPath, "utf-8"));
+    const finalAgentIds = (finalConfig.agents?.list ?? []).map((entry: any) => entry.id);
+
+    assert.ok(!finalAgentIds.some((id: string) => id.startsWith("workflow-dev_")), "workflow-dev agents should be removed");
+    assert.ok(finalAgentIds.includes("feature-dev_planner"), "other workflow agents must remain");
+  });
+});

--- a/tests/workflow-dev-polling.test.ts
+++ b/tests/workflow-dev-polling.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { execFileSync } from "node:child_process";
+import crypto from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import { loadWorkflowSpec } from "../dist/installer/workflow-spec.js";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+const CLI = path.join(REPO_ROOT, "dist", "cli", "cli.js");
+const WORKFLOW_DIR = path.join(REPO_ROOT, "workflows", "workflow-dev");
+const STORIES_JSON = '[{"id":"US-006","title":"Add polling tests","description":"desc","acceptanceCriteria":["ac"]}]';
+
+function initDb(dbPath: string): DatabaseSync {
+  const db = new DatabaseSync(dbPath);
+  db.exec(`
+    CREATE TABLE runs (id TEXT PRIMARY KEY, workflow_id TEXT, task TEXT, status TEXT, context TEXT, notify_url TEXT, run_number INTEGER, created_at TEXT, updated_at TEXT);
+    CREATE TABLE steps (id TEXT PRIMARY KEY, run_id TEXT, step_id TEXT, agent_id TEXT, step_index INTEGER, input_template TEXT, expects TEXT, status TEXT, output TEXT, retry_count INTEGER, max_retries INTEGER, abandoned_count INTEGER, created_at TEXT, updated_at TEXT, type TEXT, loop_config TEXT, current_story_id TEXT);
+    CREATE TABLE stories (id TEXT PRIMARY KEY, run_id TEXT, story_index INTEGER, story_id TEXT, title TEXT, description TEXT, acceptance_criteria TEXT, status TEXT, output TEXT, retry_count INTEGER, max_retries INTEGER, created_at TEXT, updated_at TEXT);
+    CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, ts TEXT, event TEXT, run_id TEXT, workflow_id TEXT, step_id TEXT, agent_id TEXT, story_id TEXT, story_title TEXT, detail TEXT, created_at TEXT);
+  `);
+  return db;
+}
+
+describe("workflow-dev polling progression", () => {
+  let tmpDir: string;
+  let env: NodeJS.ProcessEnv;
+  let db: DatabaseSync;
+
+  beforeEach(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "antfarm-workflow-dev-polling-"));
+    const stateDir = path.join(tmpDir, "state");
+    await fs.mkdir(stateDir, { recursive: true });
+    await fs.writeFile(path.join(stateDir, "openclaw.json"), JSON.stringify({ agents: { list: [] } }), "utf8");
+    env = { ...process.env, HOME: tmpDir, OPENCLAW_STATE_DIR: stateDir, OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json") };
+
+    const dbPath = path.join(tmpDir, ".openclaw", "antfarm", "antfarm.db");
+    await fs.mkdir(path.dirname(dbPath), { recursive: true });
+    db = initDb(dbPath);
+  });
+
+  afterEach(async () => {
+    db.close();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  function cli(args: string[], input?: string): string {
+    return execFileSync("node", [CLI, ...args], { cwd: REPO_ROOT, env, encoding: "utf8", input }).trim();
+  }
+
+  async function seedRun() {
+    const spec = await loadWorkflowSpec(WORKFLOW_DIR);
+    const runId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    db.prepare("INSERT INTO runs VALUES (?, ?, ?, 'running', ?, NULL, 1, ?, ?)")
+      .run(runId, spec.id, "task", JSON.stringify({ task: "task" }), now, now);
+
+    const stepIds: Record<string, string> = {};
+    spec.steps.forEach((s, i) => {
+      const id = crypto.randomUUID();
+      stepIds[s.id] = id;
+      db.prepare("INSERT INTO steps VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, 0, ?, 0, ?, ?, ?, ?, NULL)")
+        .run(id, runId, s.id, `${spec.id}_${s.agent}`, i, s.input, s.expects, i === 0 ? "pending" : "waiting", s.max_retries ?? s.on_fail?.max_retries ?? 2, now, now, s.type ?? "single", s.loop ? JSON.stringify(s.loop) : null);
+    });
+    return { runId, stepIds };
+  }
+
+  it("runs all configured steps in order and completes", async () => {
+    const { runId, stepIds } = await seedRun();
+    const ordered: string[] = [];
+
+    const plan = JSON.parse(cli(["step", "claim", "workflow-dev_planner"]));
+    ordered.push("plan");
+    cli(["step", "complete", plan.stepId], `STATUS: done\nREPO: /repo\nBRANCH: feature/x\nSTORIES_JSON: ${STORIES_JSON}`);
+    db.prepare("UPDATE runs SET context = json_set(context, '$.stories_json', ?) WHERE id = ?").run(STORIES_JSON, runId);
+
+    const specify = JSON.parse(cli(["step", "claim", "workflow-dev_architect"]));
+    ordered.push("specify");
+    cli(["step", "complete", specify.stepId], "STATUS: done\nSPEC_JSON: {}\nSPEC_CHECKS: ok");
+
+    const setup = JSON.parse(cli(["step", "claim", "workflow-dev_setup"]));
+    ordered.push("setup");
+    assert.ok(setup.input.includes("REPO: /repo"));
+    assert.ok(setup.input.includes("BRANCH: feature/x"));
+    cli(["step", "complete", setup.stepId], "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test\nBASELINE: clean");
+
+    const impl = JSON.parse(cli(["step", "claim", "workflow-dev_developer"]));
+    ordered.push("implement");
+    assert.ok(impl.input.includes("Story US-006"));
+    cli(["step", "complete", impl.stepId], "STATUS: done\nCHANGES: impl\nTESTS: tests");
+
+    ordered.push("verify");
+    cli(["step", "complete", stepIds.verify], "STATUS: done\nVERIFIED: pass");
+
+    const pr = JSON.parse(cli(["step", "claim", "workflow-dev_pr"]));
+    ordered.push("pr");
+    assert.ok(pr.input.includes("CHANGES: impl"));
+    cli(["step", "complete", pr.stepId], "STATUS: done\nPR: https://example/pr");
+
+    assert.deepEqual(ordered, ["plan", "specify", "setup", "implement", "verify", "pr"]);
+    const run = db.prepare("SELECT status, context FROM runs WHERE id = ?").get(runId) as { status: string; context: string };
+    assert.equal(run.status, "completed");
+    const ctx = JSON.parse(run.context);
+    for (const k of ["repo", "branch", "build_cmd", "test_cmd", "changes"]) assert.ok(ctx[k]);
+  });
+
+  it("supports retry transition from verify back to implement", async () => {
+    const { runId, stepIds } = await seedRun();
+    const plan = JSON.parse(cli(["step", "claim", "workflow-dev_planner"]));
+    cli(["step", "complete", plan.stepId], `STATUS: done\nREPO: /repo\nBRANCH: feature/x\nSTORIES_JSON: ${STORIES_JSON}`);
+    db.prepare("UPDATE runs SET context = json_set(context, '$.stories_json', ?) WHERE id = ?").run(STORIES_JSON, runId);
+    const specify = JSON.parse(cli(["step", "claim", "workflow-dev_architect"]));
+    cli(["step", "complete", specify.stepId], "STATUS: done\nSPEC_JSON: {}\nSPEC_CHECKS: ok");
+    const setup = JSON.parse(cli(["step", "claim", "workflow-dev_setup"]));
+    cli(["step", "complete", setup.stepId], "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test\nBASELINE: clean");
+
+    const impl1 = JSON.parse(cli(["step", "claim", "workflow-dev_developer"]));
+    cli(["step", "complete", impl1.stepId], "STATUS: done\nCHANGES: first\nTESTS: first");
+    cli(["step", "complete", stepIds.verify], "STATUS: retry\nISSUES: add retry assertion");
+
+    const stepState = db.prepare("SELECT status FROM steps WHERE id = ?").get(stepIds.implement) as { status: string };
+    assert.equal(stepState.status, "pending");
+
+    const impl2 = JSON.parse(cli(["step", "claim", "workflow-dev_developer"]));
+    assert.ok(impl2.input.includes("add retry assertion"));
+    cli(["step", "complete", impl2.stepId], "STATUS: done\nCHANGES: second\nTESTS: retry");
+    cli(["step", "complete", stepIds.verify], "STATUS: done\nVERIFIED: fixed");
+
+    const pr = JSON.parse(cli(["step", "claim", "workflow-dev_pr"]));
+    cli(["step", "complete", pr.stepId], "STATUS: done\nPR: https://example/pr2");
+
+    const run = db.prepare("SELECT status, context FROM runs WHERE id = ?").get(runId) as { status: string; context: string };
+    assert.equal(run.status, "completed");
+    assert.equal(JSON.parse(run.context).verify_feedback, undefined);
+  });
+});

--- a/tests/workflow-dev-scaffold.test.ts
+++ b/tests/workflow-dev-scaffold.test.ts
@@ -1,0 +1,26 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import { listBundledWorkflows } from "../dist/installer/workflow-fetch.js";
+import { loadWorkflowSpec } from "../dist/installer/workflow-spec.js";
+
+describe("workflow-dev scaffold", () => {
+  it("is discoverable as a bundled workflow", async () => {
+    const workflows = await listBundledWorkflows();
+    assert.ok(workflows.includes("workflow-dev"), "workflow-dev should be discoverable");
+  });
+
+  it("loads workflow.yml with required contract fields", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const spec = await loadWorkflowSpec(workflowDir);
+
+    assert.equal(spec.id, "workflow-dev");
+    assert.ok(spec.name?.length, "name should be set");
+    assert.ok(typeof spec.version === "number", "version should be numeric");
+    assert.ok(spec.description?.length, "description should be set");
+    assert.ok(Array.isArray(spec.agents) && spec.agents.length > 0, "agents should be defined");
+    assert.ok(Array.isArray(spec.steps) && spec.steps.length > 0, "steps should be defined");
+    assert.equal(spec.polling?.model, "default");
+    assert.equal(spec.polling?.timeoutSeconds, 120);
+  });
+});

--- a/tests/workflow-dev-scaffold.test.ts
+++ b/tests/workflow-dev-scaffold.test.ts
@@ -105,4 +105,24 @@ describe("workflow-dev scaffold", () => {
     assert.ok(implementStep?.input.includes("Do not overwrite existing files unless"));
     assert.ok(implementStep?.input.includes("preserve it and report it as preserved"));
   });
+
+  it("defines verification loop checks and bounded retry wiring", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const spec = await loadWorkflowSpec(workflowDir);
+
+    const verifyStep = spec.steps.find((step) => step.id === "verify");
+
+    assert.ok(verifyStep, "verify step should exist");
+    assert.ok(verifyStep?.input.includes("Generated `workflow.yml` parses as valid YAML"));
+    assert.ok(verifyStep?.input.includes("required top-level fields exist"));
+    assert.ok(verifyStep?.input.includes("every step has `id`, `agent`, and `input`"));
+    assert.ok(verifyStep?.input.includes("references a declared agent id"));
+    assert.ok(verifyStep?.input.includes("workspace.files"));
+    assert.ok(verifyStep?.input.includes("path traversal"));
+    assert.ok(verifyStep?.input.includes("STATUS: retry"));
+    assert.ok(verifyStep?.input.includes("ISSUES:"));
+
+    assert.equal(verifyStep?.on_fail?.retry_step, "implement");
+    assert.equal(verifyStep?.on_fail?.max_retries, 2);
+  });
 });

--- a/tests/workflow-dev-scaffold.test.ts
+++ b/tests/workflow-dev-scaffold.test.ts
@@ -1,6 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 import { listBundledWorkflows } from "../dist/installer/workflow-fetch.js";
 import { loadWorkflowSpec } from "../dist/installer/workflow-spec.js";
 
@@ -22,5 +23,66 @@ describe("workflow-dev scaffold", () => {
     assert.ok(Array.isArray(spec.steps) && spec.steps.length > 0, "steps should be defined");
     assert.equal(spec.polling?.model, "default");
     assert.equal(spec.polling?.timeoutSeconds, 120);
+  });
+
+  it("wires planner and architect workflow-local analysis agents", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const spec = await loadWorkflowSpec(workflowDir);
+
+    const planner = spec.agents.find((agent) => agent.id === "planner");
+    const architect = spec.agents.find((agent) => agent.id === "architect");
+
+    assert.ok(planner, "planner agent should exist");
+    assert.ok(architect, "architect agent should exist");
+    assert.equal(planner?.role, "analysis");
+    assert.equal(architect?.role, "analysis");
+
+    assert.equal(planner?.workspace.files["AGENTS.md"], "agents/planner/AGENTS.md");
+    assert.equal(architect?.workspace.files["AGENTS.md"], "agents/architect/AGENTS.md");
+
+    const localAgentFiles = [
+      "agents/planner/AGENTS.md",
+      "agents/planner/SOUL.md",
+      "agents/planner/IDENTITY.md",
+      "agents/architect/AGENTS.md",
+      "agents/architect/SOUL.md",
+      "agents/architect/IDENTITY.md",
+    ];
+
+    for (const relativeFile of localAgentFiles) {
+      assert.ok(existsSync(path.join(workflowDir, relativeFile)), `missing ${relativeFile}`);
+    }
+  });
+
+  it("enforces planner and architect KEY: value contracts and constraints in prompts", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const spec = await loadWorkflowSpec(workflowDir);
+
+    const planStep = spec.steps.find((step) => step.id === "plan");
+    const specifyStep = spec.steps.find((step) => step.id === "specify");
+
+    assert.ok(planStep?.input.includes("Reply using KEY: value lines only:"));
+    assert.ok(planStep?.input.includes("STORIES_JSON: [ ... JSON array of <=20 story objects ... ]"));
+    assert.ok(planStep?.input.includes("Keep dependency ordering explicit"));
+    assert.ok(planStep?.input.includes("mechanically verifiable acceptance criteria"));
+
+    assert.ok(specifyStep?.input.includes("Reply using KEY: value lines only:"));
+    assert.ok(specifyStep?.input.includes("SPEC_JSON:"));
+    assert.ok(specifyStep?.input.includes("SPEC_CHECKS:"));
+    assert.ok(specifyStep?.input.includes("Keep dependency ordering consistent"));
+    assert.ok(specifyStep?.input.includes("one session"));
+    assert.ok(specifyStep?.input.includes("mechanically verifiable acceptance criteria"));
+
+    const plannerPrompt = readFileSync(path.join(workflowDir, "agents/planner/AGENTS.md"), "utf-8");
+    const architectPrompt = readFileSync(path.join(workflowDir, "agents/architect/AGENTS.md"), "utf-8");
+
+    assert.ok(plannerPrompt.includes("Maximum 20 stories"));
+    assert.ok(plannerPrompt.includes("KEY: value"));
+    assert.ok(plannerPrompt.includes("docs/creating-workflows.md"));
+
+    assert.ok(architectPrompt.includes("KEY: value"));
+    assert.ok(architectPrompt.includes("docs/creating-workflows.md"));
+    assert.ok(architectPrompt.includes("dependency ordering"));
+    assert.ok(architectPrompt.includes("mechanically verifiable"));
   });
 });

--- a/tests/workflow-dev-scaffold.test.ts
+++ b/tests/workflow-dev-scaffold.test.ts
@@ -85,4 +85,24 @@ describe("workflow-dev scaffold", () => {
     assert.ok(architectPrompt.includes("dependency ordering"));
     assert.ok(architectPrompt.includes("mechanically verifiable"));
   });
+
+  it("defines implementation template for workflow and agent-file generation", async () => {
+    const workflowDir = path.resolve("workflows/workflow-dev");
+    const spec = await loadWorkflowSpec(workflowDir);
+
+    const implementStep = spec.steps.find((step) => step.id === "implement");
+
+    assert.ok(implementStep?.input.includes("Generate or update `workflow.yml`"));
+    assert.ok(implementStep?.input.includes("Generate per-agent workspace files"));
+    assert.ok(implementStep?.input.includes("`AGENTS.md`, `SOUL.md`, and `IDENTITY.md`"));
+
+    assert.ok(implementStep?.input.includes("Reply with KEY: value lines only:"));
+    assert.ok(implementStep?.input.includes("WORKFLOW_ID:"));
+    assert.ok(implementStep?.input.includes("CREATED_FILES:"));
+    assert.ok(implementStep?.input.includes("AGENTS_CREATED:"));
+
+    assert.ok(implementStep?.input.includes("Validate path correctness before writing"));
+    assert.ok(implementStep?.input.includes("Do not overwrite existing files unless"));
+    assert.ok(implementStep?.input.includes("preserve it and report it as preserved"));
+  });
 });

--- a/workflows/workflow-dev/agents/architect/AGENTS.md
+++ b/workflows/workflow-dev/agents/architect/AGENTS.md
@@ -1,0 +1,29 @@
+# Architect Agent
+
+You are the workflow architect/specifier for workflow development. Convert planned stories into an implementation-ready specification that coding agents can execute deterministically.
+
+## Responsibilities
+
+1. Read the task and planner output (`STORIES_JSON`)
+2. Produce a coherent workflow specification plan with explicit dependency ordering
+3. Preserve story sizing (one session per story) and verifiable acceptance criteria
+4. Enforce Antfarm conventions from `docs/creating-workflows.md`
+5. Define checks that are mechanically verifiable
+
+## Rules
+
+- Keep specification output machine-parseable and deterministic
+- Keep all replies in KEY: value format exactly as requested by the step prompt
+- Do not invent extra story scope that breaks one-session story size
+- Keep verifier/retry expectations explicit where relevant
+- Ensure conventions align with workflow contract fields and step IO patterns in docs
+
+## Output Contract
+
+When the step requests:
+
+- `STATUS: done`
+- `SPEC_JSON: {...}`
+- `SPEC_CHECKS: ...`
+
+Return those keys exactly in KEY: value format.

--- a/workflows/workflow-dev/agents/architect/IDENTITY.md
+++ b/workflows/workflow-dev/agents/architect/IDENTITY.md
@@ -1,0 +1,4 @@
+# Identity
+
+Name: Architect
+Role: Produces implementation-ready workflow specifications from planned stories

--- a/workflows/workflow-dev/agents/architect/SOUL.md
+++ b/workflows/workflow-dev/agents/architect/SOUL.md
@@ -1,0 +1,3 @@
+# Soul
+
+You are precise and systems-minded. You turn plans into clear, deterministic specs that implementation agents can execute without guesswork.

--- a/workflows/workflow-dev/agents/developer/AGENTS.md
+++ b/workflows/workflow-dev/agents/developer/AGENTS.md
@@ -1,0 +1,19 @@
+# Developer Agent
+
+You implement one workflow story per session.
+
+## Responsibilities
+
+1. Read the current story and progress log
+2. Implement only the current story
+3. Add tests for the story
+4. Run build/typecheck and tests
+5. Commit with the requested message format
+6. Rewrite progress-{{run_id}}.txt with updates and learnings
+
+## Standards
+
+- Follow repository workflow conventions
+- Reuse shared agents where possible
+- Keep changes scoped and complete
+- No TODO-only commits

--- a/workflows/workflow-dev/agents/developer/IDENTITY.md
+++ b/workflows/workflow-dev/agents/developer/IDENTITY.md
@@ -1,0 +1,4 @@
+# Identity
+
+Name: Developer
+Role: Implements workflow stories and writes tests

--- a/workflows/workflow-dev/agents/developer/SOUL.md
+++ b/workflows/workflow-dev/agents/developer/SOUL.md
@@ -1,0 +1,3 @@
+# Soul
+
+You're a practical builder. Implement clearly, test thoroughly, and keep changes focused.

--- a/workflows/workflow-dev/agents/planner/AGENTS.md
+++ b/workflows/workflow-dev/agents/planner/AGENTS.md
@@ -1,25 +1,31 @@
 # Planner Agent
 
-You are the planner for workflow development. Break a workflow request into ordered, one-session user stories for autonomous execution.
+You are the planner for workflow development. Break a workflow request into ordered, one-session user stories for deterministic execution.
 
 ## Responsibilities
 
 1. Explore the repository and existing workflow conventions
 2. Decompose the task into small, dependency-ordered stories
-3. Ensure each story has mechanical acceptance criteria
+3. Ensure each story has mechanically verifiable acceptance criteria
 4. Keep each story small enough for a single developer session
+5. Follow Antfarm workflow conventions from `docs/creating-workflows.md`
 
 ## Rules
 
-- Max 20 stories
-- Every story must include test criteria
-- End each story with "Typecheck passes"
-- Keep criteria objective and verifiable
+- Maximum 20 stories
+- Output MUST use KEY: value lines exactly as requested by the step prompt
+- Every story must include explicit test criteria
+- Every story must end with `Typecheck passes`
+- Story order must follow dependency flow (foundations before dependents)
+- Acceptance criteria must be objective and checkable
 
-## Output
+## Output Contract
 
-Reply with valid JSON in `STORIES_JSON` plus:
+When the step requests:
 
 - `STATUS: done`
-- `REPO: /path/to/repo`
-- `BRANCH: feature-branch-name`
+- `REPO: ...`
+- `BRANCH: ...`
+- `STORIES_JSON: [...]`
+
+Return those keys exactly in KEY: value format.

--- a/workflows/workflow-dev/agents/planner/AGENTS.md
+++ b/workflows/workflow-dev/agents/planner/AGENTS.md
@@ -1,0 +1,25 @@
+# Planner Agent
+
+You are the planner for workflow development. Break a workflow request into ordered, one-session user stories for autonomous execution.
+
+## Responsibilities
+
+1. Explore the repository and existing workflow conventions
+2. Decompose the task into small, dependency-ordered stories
+3. Ensure each story has mechanical acceptance criteria
+4. Keep each story small enough for a single developer session
+
+## Rules
+
+- Max 20 stories
+- Every story must include test criteria
+- End each story with "Typecheck passes"
+- Keep criteria objective and verifiable
+
+## Output
+
+Reply with valid JSON in `STORIES_JSON` plus:
+
+- `STATUS: done`
+- `REPO: /path/to/repo`
+- `BRANCH: feature-branch-name`

--- a/workflows/workflow-dev/agents/planner/IDENTITY.md
+++ b/workflows/workflow-dev/agents/planner/IDENTITY.md
@@ -1,0 +1,4 @@
+# Identity
+
+Name: Planner
+Role: Decomposes workflow requests into ordered, verifiable user stories

--- a/workflows/workflow-dev/agents/planner/SOUL.md
+++ b/workflows/workflow-dev/agents/planner/SOUL.md
@@ -1,0 +1,5 @@
+# Soul
+
+You are methodical and pragmatic. You optimize for small, executable stories with clear verification.
+
+You prefer clear dependency order over clever plans. If a story feels too large, split it.

--- a/workflows/workflow-dev/workflow.yml
+++ b/workflows/workflow-dev/workflow.yml
@@ -1,0 +1,192 @@
+# Ralph loop (https://github.com/snarktank/ralph) — fresh context per agent session
+id: workflow-dev
+name: Workflow Development Workflow
+version: 1
+description: |
+  Workflow authoring pipeline for creating or updating Antfarm workflows.
+  Planner decomposes workflow requirements into ordered stories.
+  Setup prepares branch and baseline. Developer implements each story.
+  Verifier confirms story acceptance criteria, then PR agent opens a pull request.
+
+polling:
+  model: default
+  timeoutSeconds: 120
+
+agents:
+  - id: planner
+    name: Planner
+    role: analysis
+    description: Breaks workflow requests into implementable stories.
+    workspace:
+      baseDir: agents/planner
+      files:
+        AGENTS.md: agents/planner/AGENTS.md
+        SOUL.md: agents/planner/SOUL.md
+        IDENTITY.md: agents/planner/IDENTITY.md
+
+  - id: setup
+    name: Setup
+    role: coding
+    description: Prepares environment, branch, and baseline checks.
+    workspace:
+      baseDir: agents/setup
+      files:
+        AGENTS.md: ../../agents/shared/setup/AGENTS.md
+        SOUL.md: ../../agents/shared/setup/SOUL.md
+        IDENTITY.md: ../../agents/shared/setup/IDENTITY.md
+
+  - id: developer
+    name: Developer
+    role: coding
+    description: Implements workflow stories and adds tests.
+    workspace:
+      baseDir: agents/developer
+      files:
+        AGENTS.md: agents/developer/AGENTS.md
+        SOUL.md: agents/developer/SOUL.md
+        IDENTITY.md: agents/developer/IDENTITY.md
+
+  - id: verifier
+    name: Verifier
+    role: verification
+    description: Verifies each story's acceptance criteria and tests.
+    workspace:
+      baseDir: agents/verifier
+      files:
+        AGENTS.md: ../../agents/shared/verifier/AGENTS.md
+        SOUL.md: ../../agents/shared/verifier/SOUL.md
+        IDENTITY.md: ../../agents/shared/verifier/IDENTITY.md
+
+  - id: pr
+    name: PR Creator
+    role: pr
+    description: Creates pull requests for completed workflow work.
+    workspace:
+      baseDir: agents/pr
+      files:
+        AGENTS.md: ../../agents/shared/pr/AGENTS.md
+        SOUL.md: ../../agents/shared/pr/SOUL.md
+        IDENTITY.md: ../../agents/shared/pr/IDENTITY.md
+
+steps:
+  - id: plan
+    agent: planner
+    input: |
+      Decompose the workflow request into ordered user stories.
+
+      TASK:
+      {{task}}
+
+      Reply with:
+      STATUS: done
+      REPO: /path/to/repo
+      BRANCH: feature-branch-name
+      STORIES_JSON: [ ... array of story objects ... ]
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: setup
+    agent: setup
+    input: |
+      Prepare the development environment for workflow changes.
+
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+
+      Reply with:
+      STATUS: done
+      BUILD_CMD: <build command>
+      TEST_CMD: <test command>
+      BASELINE: <baseline status>
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: implement
+    agent: developer
+    type: loop
+    loop:
+      over: stories
+      completion: all_done
+      fresh_session: true
+      verify_each: true
+      verify_step: verify
+    input: |
+      Implement the current workflow story.
+
+      TASK (overall):
+      {{task}}
+
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+      BUILD_CMD: {{build_cmd}}
+      TEST_CMD: {{test_cmd}}
+
+      CURRENT STORY:
+      {{current_story}}
+
+      VERIFY FEEDBACK (if retrying):
+      {{verify_feedback}}
+
+      Reply with:
+      STATUS: done
+      CHANGES: what you implemented
+      TESTS: what tests you wrote
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: verify
+    agent: verifier
+    input: |
+      Verify the developer's workflow story implementation.
+
+      TASK (overall):
+      {{task}}
+
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+      TEST_CMD: {{test_cmd}}
+      CHANGES: {{changes}}
+      CURRENT STORY:
+      {{current_story}}
+
+      Reply with:
+      STATUS: done
+      VERIFIED: What you confirmed
+
+      Or if incomplete:
+      STATUS: retry
+      ISSUES:
+      - What's missing or incomplete
+    expects: "STATUS: done"
+    on_fail:
+      retry_step: implement
+      max_retries: 2
+      on_exhausted:
+        escalate_to: human
+
+  - id: pr
+    agent: pr
+    input: |
+      Create a pull request for the completed workflow changes.
+
+      TASK:
+      {{task}}
+
+      REPO: {{repo}}
+      BRANCH: {{branch}}
+      CHANGES: {{changes}}
+
+      Use: gh pr create
+
+      Reply with:
+      STATUS: done
+      PR: URL to the pull request
+    expects: "STATUS: done"
+    on_fail:
+      escalate_to: human

--- a/workflows/workflow-dev/workflow.yml
+++ b/workflows/workflow-dev/workflow.yml
@@ -5,6 +5,7 @@ version: 1
 description: |
   Workflow authoring pipeline for creating or updating Antfarm workflows.
   Planner decomposes workflow requirements into ordered stories.
+  Architect converts stories into an implementation-ready workflow specification.
   Setup prepares branch and baseline. Developer implements each story.
   Verifier confirms story acceptance criteria, then PR agent opens a pull request.
 
@@ -23,6 +24,17 @@ agents:
         AGENTS.md: agents/planner/AGENTS.md
         SOUL.md: agents/planner/SOUL.md
         IDENTITY.md: agents/planner/IDENTITY.md
+
+  - id: architect
+    name: Architect
+    role: analysis
+    description: Produces implementation-ready workflow specs from planned stories.
+    workspace:
+      baseDir: agents/architect
+      files:
+        AGENTS.md: agents/architect/AGENTS.md
+        SOUL.md: agents/architect/SOUL.md
+        IDENTITY.md: agents/architect/IDENTITY.md
 
   - id: setup
     name: Setup
@@ -72,16 +84,51 @@ steps:
   - id: plan
     agent: planner
     input: |
-      Decompose the workflow request into ordered user stories.
+      Decompose the workflow request into dependency-ordered user stories.
 
       TASK:
       {{task}}
 
-      Reply with:
+      Follow Antfarm conventions from docs/creating-workflows.md:
+      1. Use valid workflow contract fields (id, name, version, description, agents, steps)
+      2. Use KEY: value outputs that can be parsed mechanically
+      3. Keep stories one-session in size and cap total stories at 20
+      4. Keep dependency ordering explicit (foundations before dependent stories)
+      5. Require mechanically verifiable acceptance criteria per story
+      6. Include explicit test criteria and end with "Typecheck passes"
+
+      Reply using KEY: value lines only:
       STATUS: done
       REPO: /path/to/repo
       BRANCH: feature-branch-name
-      STORIES_JSON: [ ... array of story objects ... ]
+      STORIES_JSON: [ ... JSON array of <=20 story objects ... ]
+    expects: "STATUS: done"
+    max_retries: 2
+    on_fail:
+      escalate_to: human
+
+  - id: specify
+    agent: architect
+    input: |
+      Convert the planned stories into an implementation-ready workflow specification.
+
+      TASK:
+      {{task}}
+
+      STORIES_JSON:
+      {{stories_json}}
+
+      Enforce Antfarm conventions from docs/creating-workflows.md:
+      1. Keep dependency ordering consistent with the plan
+      2. Keep each story implementation scope bounded to one session
+      3. Preserve mechanically verifiable acceptance criteria
+      4. Keep workflow step IO in KEY: value form for deterministic parsing
+      5. Ensure verifier loops and retry wiring are explicit where needed
+
+      Reply using KEY: value lines only:
+      STATUS: done
+      SPEC_JSON: { ... JSON object with workflow implementation plan ... }
+      SPEC_CHECKS: verifiable checks that prove the spec is implementation-ready
     expects: "STATUS: done"
     max_retries: 2
     on_fail:

--- a/workflows/workflow-dev/workflow.yml
+++ b/workflows/workflow-dev/workflow.yml
@@ -215,6 +215,20 @@ steps:
       CURRENT STORY:
       {{current_story}}
 
+      Validation checks (required):
+      1. Generated `workflow.yml` parses as valid YAML.
+      2. Workflow schema integrity matches bundled conventions from docs/creating-workflows.md:
+         - required top-level fields exist (`id`, `name`, `version`, `description`, `agents`, `steps`)
+         - every step has `id`, `agent`, and `input`
+         - each step `agent` references a declared agent id
+      3. Agent workspace file references are valid:
+         - each declared `workspace.files` path exists on disk
+         - paths resolve under the target repository/workflow directory (no path traversal)
+      4. Retry-loop contract is present:
+         - verify step can return `STATUS: retry`
+         - workflow `on_fail` retries from `verify` back to `implement` with bounded `max_retries`
+      5. Run verification tests and report outcome.
+
       Reply with:
       STATUS: done
       VERIFIED: What you confirmed

--- a/workflows/workflow-dev/workflow.yml
+++ b/workflows/workflow-dev/workflow.yml
@@ -178,8 +178,21 @@ steps:
       VERIFY FEEDBACK (if retrying):
       {{verify_feedback}}
 
-      Reply with:
+      For workflow-generation stories, execute these implementation phases explicitly:
+      1. Generate or update `workflow.yml` in the target workflow directory.
+      2. Generate per-agent workspace files under `agents/<agent-id>/`: `AGENTS.md`, `SOUL.md`, and `IDENTITY.md`.
+
+      Safeguards (required):
+      - Validate path correctness before writing: all generated files must resolve under the target repository and target workflow directory.
+      - Do not overwrite existing files unless the story explicitly requests overwrite behavior.
+      - If a file already exists and overwrite is not explicitly requested, preserve it and report it as preserved.
+
+      Reply with KEY: value lines only:
       STATUS: done
+      WORKFLOW_ID: generated workflow id
+      CREATED_FILES: [ ... list of new files created ... ]
+      PRESERVED_FILES: [ ... list of existing files left unchanged ... ]
+      AGENTS_CREATED: [ ... list of agent ids with generated workspace files ... ]
       CHANGES: what you implemented
       TESTS: what tests you wrote
     expects: "STATUS: done"


### PR DESCRIPTION
## Summary
- add and wire a built-in workflow to create Antfarm workflows end-to-end
- include generation, validation/retry, installer/runtime integration, docs, and final smoke-test coverage
- ensure workflow artifact correctness and agent workspace path-safety assertions across fixture-driven execution

## Why
This introduces a complete, validated path for generating new Antfarm workflows with guardrails and tests, reducing manual setup and integration risk.

## Testing
- npm run build
- fixture-driven smoke test executed end-to-end on branch feature/workflow-create-antfarm-workflow
- integration review for:
  - workflow.yml required fields
  - step-agent reference integrity
  - fixture template resolution
  - agent workspace mapping/path-safety assertions
