### PR TITLE
fix: enforce required step output keys and tighten prompt guidance

### DIFF
--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -26,16 +26,18 @@ Step 2 — If JSON is returned, it contains: {"stepId": "...", "runId": "...", "
 Save the stepId — you'll need it to report completion.
 The "input" field contains your FULLY RESOLVED task instructions. Read it carefully and DO the work.
 
-Step 3 — Do the work described in the input. Format your output with KEY: value lines as specified.
+Step 3 — Do the work described in the input.
+Your final step output MUST follow the exact "Reply with:" schema inside the claimed input.
+Do NOT reuse output from previous steps or sessions.
+If the claimed input requires keys like BUILD_CMD / TEST_CMD (setup step), they are mandatory.
 
 Step 4 — MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
-cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
-STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
+# Save the EXACT final step output text from Step 3 (not a generic template).
+cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output-<stepId>.txt
+<PASTE EXACT STEP OUTPUT HERE>
 ANTFARM_EOF
-cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
+cat /tmp/antfarm-step-output-<stepId>.txt | node ${cli} step complete "<stepId>"
 \`\`\`
 
 If the work FAILED:
@@ -47,6 +49,9 @@ RULES:
 1. NEVER end your session without calling step complete or step fail
 2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. NEVER call subagents/subagents steer to report completion. Only use antfarm step complete/step fail.
+5. NEVER call step complete more than once for the same stepId.
+6. Run the file-write + step-complete command as one shell command for this stepId.
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }
@@ -63,16 +68,18 @@ The claimed step JSON is provided below. It contains: {"stepId": "...", "runId":
 Save the stepId — you'll need it to report completion.
 The "input" field contains your FULLY RESOLVED task instructions. Read it carefully and DO the work.
 
-Do the work described in the input. Format your output with KEY: value lines as specified.
+Do the work described in the input.
+Your final step output MUST follow the exact "Reply with:" schema inside the claimed input.
+Do NOT reuse output from previous steps or sessions.
+If the claimed input requires keys like BUILD_CMD / TEST_CMD (setup step), they are mandatory.
 
 MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
-cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
-STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
+# Save the EXACT final step output text from above (not a generic template).
+cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output-<stepId>.txt
+<PASTE EXACT STEP OUTPUT HERE>
 ANTFARM_EOF
-cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
+cat /tmp/antfarm-step-output-<stepId>.txt | node ${cli} step complete "<stepId>"
 \`\`\`
 
 If the work FAILED:
@@ -84,6 +91,9 @@ RULES:
 1. NEVER end your session without calling step complete or step fail
 2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. NEVER call subagents/subagents steer to report completion. Only use antfarm step complete/step fail.
+5. NEVER call step complete more than once for the same stepId.
+6. Run the file-write + step-complete command as one shell command for this stepId.
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }
@@ -153,6 +163,23 @@ Full work prompt to include in the spawned task:
 ---START WORK PROMPT---
 ${workPrompt}
 ---END WORK PROMPT---
+
+IMPORTANT RECOVERY (you are still responsible for reporting):
+1. Save the claimed stepId before spawning.
+2. When a later system message says the subagent finished, check whether the result includes a "STATUS:" block.
+3. If a STATUS block exists, write that exact step output to /tmp/antfarm-step-output-<stepId>.txt and report it yourself:
+\`\`\`
+cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output-<stepId>.txt
+<PASTE EXACT STATUS BLOCK HERE>
+ANTFARM_EOF
+cat /tmp/antfarm-step-output-<stepId>.txt | node ${cli} step complete "<stepId>"
+\`\`\`
+4. If the subagent returns no valid STATUS block, report failure yourself:
+\`\`\`
+node ${cli} step fail "<stepId>" "Subagent finished without valid step output"
+\`\`\`
+5. NEVER stop after subagent completion without calling step complete or step fail.
+6. Do NOT only summarize the subagent result.
 
 Reply with a short summary of what you spawned.`;
 }

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -436,6 +436,68 @@ function failStepWithMissingInputs(
   scheduleRunCronTeardown(runId);
 }
 
+function failStepWithInvalidOutput(
+  stepDbId: string,
+  stepPublicId: string,
+  runId: string,
+  missingKeys: string[],
+): void {
+  const db = getDb();
+  const wfId = getWorkflowId(runId);
+  const message = `Step output is incomplete: missing required key(s) ${missingKeys.join(", ")}`;
+
+  db.prepare(
+    "UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?"
+  ).run(message, stepDbId);
+  db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(runId);
+
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "step.failed",
+    runId,
+    workflowId: wfId,
+    stepId: stepPublicId,
+    detail: message,
+  });
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "run.failed",
+    runId,
+    workflowId: wfId,
+    detail: message,
+  });
+  scheduleRunCronTeardown(runId);
+}
+
+function parseExpectedOutputKeys(expects: string | null | undefined): string[] {
+  if (!expects) return [];
+  const keys: string[] = [];
+  const seen = new Set<string>();
+  for (const line of expects.split("\n")) {
+    const match = line.trim().match(/^([A-Z_]+)\s*:/);
+    if (!match) continue;
+    const key = match[1].toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    keys.push(key);
+  }
+  return keys;
+}
+
+function missingRequiredOutputKeys(
+  stepPublicId: string,
+  parsedOutput: Record<string, string>,
+  expects?: string | null,
+): string[] {
+  // Step-specific output keys required by downstream templates.
+  const requiredByStep: Record<string, string[]> = {
+    plan: ["repo", "branch"],
+    setup: ["build_cmd", "test_cmd"],
+  };
+  const required = [...parseExpectedOutputKeys(expects), ...(requiredByStep[stepPublicId] ?? [])];
+  return required.filter((key) => !parsedOutput[key] || parsedOutput[key].trim().length === 0);
+}
+
 function runHasStories(runId: string): boolean {
   const db = getDb();
   const total = db.prepare(
@@ -680,8 +742,17 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
+    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id, expects FROM steps WHERE id = ?"
+  ).get(stepId) as {
+    id: string;
+    run_id: string;
+    step_id: string;
+    step_index: number;
+    type: string;
+    loop_config: string | null;
+    current_story_id: string | null;
+    expects: string | null;
+  } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
 
@@ -697,6 +768,12 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
 
   // Parse KEY: value lines and merge into context
   const parsed = parseOutputKeyValues(output);
+  const missingOutputKeys = missingRequiredOutputKeys(step.step_id, parsed, step.expects);
+  if (missingOutputKeys.length > 0) {
+    failStepWithInvalidOutput(step.id, step.step_id, step.run_id, missingOutputKeys);
+    return { advanced: false, runCompleted: false };
+  }
+
   for (const [key, value] of Object.entries(parsed)) {
     context[key] = value;
   }

--- a/tests/polling-prompt.test.ts
+++ b/tests/polling-prompt.test.ts
@@ -43,8 +43,26 @@ describe("buildPollingPrompt", () => {
     const prompt = buildPollingPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("step complete"), "should include step complete from work prompt");
     assert.ok(prompt.includes("step fail"), "should include step fail from work prompt");
+    assert.ok(
+      prompt.includes("/tmp/antfarm-step-output-<stepId>.txt"),
+      "should use step-scoped temp output path in recovery/work prompts"
+    );
     assert.ok(prompt.includes("---START WORK PROMPT---"), "should delimit work prompt");
     assert.ok(prompt.includes("---END WORK PROMPT---"), "should delimit work prompt");
+  });
+
+  it("includes file-write before step complete in recovery snippet", () => {
+    const prompt = buildPollingPrompt("feature-dev", "developer");
+    const recoveryStart = prompt.indexOf("IMPORTANT RECOVERY");
+    const recovery = recoveryStart >= 0 ? prompt.slice(recoveryStart) : prompt;
+    assert.ok(
+      recovery.includes("cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output-<stepId>.txt"),
+      "recovery snippet should write step output file before piping to step complete"
+    );
+    assert.ok(
+      recovery.includes("cat /tmp/antfarm-step-output-<stepId>.txt | node"),
+      "recovery snippet should pipe written file to step complete"
+    );
   });
 
   it("specifies the full model for the spawned task", () => {

--- a/tests/step-ops-idempotency.test.ts
+++ b/tests/step-ops-idempotency.test.ts
@@ -1,0 +1,132 @@
+import { after, before, beforeEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+type Db = {
+  prepare: (sql: string) => {
+    run: (...args: unknown[]) => void;
+    get: (...args: unknown[]) => unknown;
+  };
+};
+
+type DbModule = { getDb: () => Db };
+type StepOpsModule = {
+  completeStep: (stepId: string, output: string) => { advanced: boolean; runCompleted: boolean };
+};
+
+const STEP_OPS_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/installer/step-ops.js")).href;
+const DB_URL = pathToFileURL(path.resolve(import.meta.dirname, "../dist/db.js")).href;
+
+let originalHome: string | undefined;
+let tmpHome: string;
+let dbModule: DbModule;
+let stepOpsModule: StepOpsModule;
+let sqlite: Db;
+
+async function loadFreshModules(): Promise<void> {
+  const nonce = `${Date.now()}-${Math.random()}`;
+  dbModule = await import(`${DB_URL}?v=${nonce}`) as DbModule;
+  stepOpsModule = await import(`${STEP_OPS_URL}?v=${nonce}`) as StepOpsModule;
+  sqlite = dbModule.getDb();
+}
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+describe("step-ops output validation guards", () => {
+  before(async () => {
+    originalHome = process.env.HOME;
+    tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-idempotency-"));
+    process.env.HOME = tmpHome;
+    await loadFreshModules();
+  });
+
+  beforeEach(() => {
+    sqlite.prepare("DELETE FROM stories").run();
+    sqlite.prepare("DELETE FROM steps").run();
+    sqlite.prepare("DELETE FROM runs").run();
+  });
+
+  after(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    fs.rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  it("fails setup completion early when BUILD_CMD/TEST_CMD are missing", () => {
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = now();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'feature-dev', 'task', 'running', '{\"repo\":\"/tmp/repo\",\"branch\":\"feature/x\"}', ?, ?)"
+    ).run(runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'setup', 'feature-dev_setup', 1, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepId, runId, t, t);
+
+    const result = stepOpsModule.completeStep(stepId, "STATUS: done\nCI_NOTES: baseline checked");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const step = sqlite.prepare("SELECT status, output FROM steps WHERE id = ?").get(stepId) as { status: string; output: string };
+    assert.equal(step.status, "failed");
+    assert.match(step.output, /missing required key\(s\) build_cmd, test_cmd/);
+
+    const run = sqlite.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "failed");
+  });
+
+  it("fails completion when output is empty and required STATUS key is missing", () => {
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = now();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'feature-dev', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan', 'feature-dev_planner', 0, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepId, runId, t, t);
+
+    const result = stepOpsModule.completeStep(stepId, "");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const step = sqlite.prepare("SELECT status, output FROM steps WHERE id = ?").get(stepId) as { status: string; output: string };
+    assert.equal(step.status, "failed");
+    assert.match(step.output, /missing required key\(s\) status/);
+
+    const run = sqlite.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "failed");
+  });
+
+  it("fails plan completion when REPO/BRANCH keys are missing", () => {
+    const runId = crypto.randomUUID();
+    const stepId = crypto.randomUUID();
+    const t = now();
+
+    sqlite.prepare(
+      "INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at) VALUES (?, 'feature-dev', 'task', 'running', '{}', ?, ?)"
+    ).run(runId, t, t);
+    sqlite.prepare(
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, type, created_at, updated_at) VALUES (?, ?, 'plan', 'feature-dev_planner', 0, 'input', 'STATUS: done', 'running', 'single', ?, ?)"
+    ).run(stepId, runId, t, t);
+
+    const result = stepOpsModule.completeStep(stepId, "STATUS: done");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const step = sqlite.prepare("SELECT status, output FROM steps WHERE id = ?").get(stepId) as { status: string; output: string };
+    assert.equal(step.status, "failed");
+    assert.match(step.output, /missing required key\(s\) repo, branch/);
+
+    const run = sqlite.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "failed");
+  });
+});

--- a/tests/work-prompt.test.ts
+++ b/tests/work-prompt.test.ts
@@ -6,6 +6,14 @@ describe("buildWorkPrompt", () => {
   it("contains step complete instructions", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("step complete"));
+    assert.ok(
+      prompt.includes("/tmp/antfarm-step-output-<stepId>.txt"),
+      "should use step-scoped temp output file"
+    );
+    assert.ok(
+      prompt.includes('exact "Reply with:" schema'),
+      "should require using the claimed step output schema"
+    );
   });
 
   it("contains step fail instructions", () => {


### PR DESCRIPTION
## Summary

This PR hardens Antfarm workflow reliability by preventing "false success" step completions and tightening agent reporting behavior.

## Problem

We observed runs advancing even when step output was incomplete or empty (especially around planner/setup handoff), which later caused downstream failures such as missing required template keys (`repo`, `branch`, `build_cmd`, `test_cmd`).

In addition, generic output templates and shared temp output paths increased the chance of invalid or mismatched step completion payloads.

## What changed

### 1) Enforce required output keys in step completion
- Added output validation in `completeStep()` before merging context or advancing pipeline.
- Required keys are now derived from:
  - step `expects` schema (parsed from `KEY:` lines), and
  - step-specific required keys:
    - `plan`: `repo`, `branch`
    - `setup`: `build_cmd`, `test_cmd`
- If keys are missing, the step and run fail immediately with a clear error.

### 2) Strengthen cron/work prompts for completion reporting
- Updated agent prompts to require using the exact `Reply with:` schema from claimed input.
- Explicitly forbid reusing stale/generic output.
- Added stricter rules around completion/failure reporting.
- Switched temp output file guidance to a step-scoped path:
  - `/tmp/antfarm-step-output-<stepId>.txt`
  to reduce cross-step collisions.

### 3) Add regression coverage
- Added/updated tests to ensure:
  - setup fails when `BUILD_CMD`/`TEST_CMD` are missing
  - completion fails when required `STATUS` is missing
  - plan fails when `REPO`/`BRANCH` are missing
  - prompt text includes step-scoped output file guidance

## Impact

- Prevents pipelines from silently advancing with invalid step output.
- Surfaces failures at the source step instead of failing later with confusing downstream errors.
- Improves determinism and debuggability for multi-agent workflow runs.

## Notes

- This is a behavior-tightening fix: invalid completions now fail fast by design.
