### PR TITLE
fix: verify_each verify step never claimed + case-insensitive key parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules/
 dist/
+.env
+*.key
+*.pem
 .DS_Store
 *.db
 *.sqlite

--- a/agents/shared/setup/AGENTS.md
+++ b/agents/shared/setup/AGENTS.md
@@ -17,7 +17,7 @@ You prepare the development environment. You create the branch, discover build/t
    - At minimum include: `.env`, `*.key`, `*.pem`, `*.secret`, `node_modules/`, `dist/`, `__pycache__/`, `.DS_Store`, `*.log`
    - For Node.js projects also add: `.env.local`, `.env.*.local`, `coverage/`, `.nyc_output/`
    - If `.env` exists but `.env.example` doesn't, create `.env.example` with placeholder values (no real credentials)
-6. Run the build command
+6. Run the build command if one exists. If no build/typecheck command exists, record `BUILD_CMD: none`.
 7. Run the test command
 8. Report results
 
@@ -28,11 +28,12 @@ STATUS: done
 BUILD_CMD: npm run build (or whatever you found)
 TEST_CMD: npm test (or whatever you found)
 CI_NOTES: brief notes about CI setup (or "none found")
-BASELINE: build passes / tests pass (or describe what failed)
+BASELINE: build passes / tests pass, or "no build command found; tests pass", or describe what failed
 ```
 
 ## Important Notes
 
+- If there is no build command, output `BUILD_CMD: none` and note that clearly in BASELINE
 - If the build or tests fail on main, note it in BASELINE — downstream agents need to know what's pre-existing
 - Look for lint/typecheck commands too, but BUILD_CMD and TEST_CMD are the priority
 - If there are no tests, say so clearly

--- a/agents/shared/verifier/AGENTS.md
+++ b/agents/shared/verifier/AGENTS.md
@@ -10,7 +10,7 @@ You verify that work is correct, complete, and doesn't introduce regressions. Yo
 4. **Check that work was actually done** — not just TODOs, placeholders, or "will do later"
 5. **Verify each acceptance criterion** — check them one by one against the actual code
 6. **Check tests were written** — if tests were expected, confirm they exist and test the right thing
-7. **Typecheck/build passes** — run the build/typecheck command
+7. **Typecheck/build passes** — run the build/typecheck command when `BUILD_CMD` is provided and not `none`; otherwise confirm there is no build command and continue
 8. **Check for side effects** — unintended changes, broken imports, removed functionality
 
 ## Security Checks

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antfarm",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antfarm",
-      "version": "0.4.1",
+      "version": "0.5.1",
       "dependencies": {
         "json5": "^2.2.3",
         "yaml": "^2.4.5"

--- a/skills/antfarm-workflows/SKILL.md
+++ b/skills/antfarm-workflows/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: antfarm-workflows
-description: "Multi-agent workflow orchestration for OpenClaw. Use when user mentions antfarm, asks to run a multi-step workflow (feature dev, bug fix, security audit), or wants to install/uninstall/check status of antfarm workflows."
-user-invocable: false
+description: Run durable multi-agent workflows in the local Antfarm repo when scope is already defined and the work should continue through a saved workflow like feature-dev, bug-fix, or security-audit. Triggers include requests like run the feature-dev workflow, use Antfarm for this bug, kick off the security-audit workflow, or continue this through a detached workflow. Not for requirement discovery, which belongs to `project-planner`, or simple one-off coding delegation, which belongs to `coding-agent`.
 ---
 
 # Antfarm
@@ -71,9 +70,9 @@ Get the user to confirm the plan and acceptance criteria before running.
 - Context passes between steps via KEY: value pairs in agent output
 - No central orchestrator — agents are autonomous
 
-## Force-Triggering Agents
+## Advancing Work Faster
 
-To skip the 15-min cron wait, use the `cron` tool with `action: "run"` and the agent's job ID. List crons to find them — they're named `antfarm/<workflow-id>/<agent-id>`.
+Some Antfarm installs rely on scheduled polling. If scheduler controls are not exposed in the current session, use the Antfarm CLI for status and log inspection, then let the installed scheduler advance the run or operate from inside the Antfarm repo where its local scripts are available.
 
 ## Workflow Management
 

--- a/src/db.ts
+++ b/src/db.ts
@@ -85,6 +85,9 @@ function migrate(db: DatabaseSync): void {
   if (!colNames.has("abandoned_count")) {
     db.exec("ALTER TABLE steps ADD COLUMN abandoned_count INTEGER DEFAULT 0");
   }
+  if (!colNames.has("timeout_seconds")) {
+    db.exec("ALTER TABLE steps ADD COLUMN timeout_seconds INTEGER");
+  }
 
   // Add columns to runs table for backwards compat
   const runCols = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;

--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -3,10 +3,9 @@ import type { WorkflowSpec } from "./types.js";
 import { resolveAntfarmCli } from "./paths.js";
 import { getDb } from "../db.js";
 import { readOpenClawConfig } from "./openclaw-config.js";
+import { getEffectiveAgentTimeoutSeconds } from "./install.js";
 
 const DEFAULT_EVERY_MS = 300_000; // 5 minutes
-const DEFAULT_AGENT_TIMEOUT_SECONDS = 30 * 60; // 30 minutes
-
 function buildAgentPrompt(workflowId: string, agentId: string): string {
   const fullAgentId = `${workflowId}_${agentId}`;
   const cli = resolveAntfarmCli();
@@ -26,14 +25,15 @@ Step 2 — If JSON is returned, it contains: {"stepId": "...", "runId": "...", "
 Save the stepId — you'll need it to report completion.
 The "input" field contains your FULLY RESOLVED task instructions. Read it carefully and DO the work.
 
-Step 3 — Do the work described in the input. Format your output with KEY: value lines as specified.
+Step 3 — Do the work described in the input. Format your output with the exact KEY: value lines required by the claimed step input.
 
 Step 4 — MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
 cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
+# Write the exact KEY: value lines required by the claimed step input.
+# Example only:
 STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
+# ...step-specific required keys go here...
 ANTFARM_EOF
 cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
 \`\`\`
@@ -63,14 +63,15 @@ The claimed step JSON is provided below. It contains: {"stepId": "...", "runId":
 Save the stepId — you'll need it to report completion.
 The "input" field contains your FULLY RESOLVED task instructions. Read it carefully and DO the work.
 
-Do the work described in the input. Format your output with KEY: value lines as specified.
+Do the work described in the input. Format your output with the exact KEY: value lines required by the claimed step input.
 
 MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
 cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
+# Write the exact KEY: value lines required by the claimed step input.
+# Example only:
 STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
+# ...step-specific required keys go here...
 ANTFARM_EOF
 cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
 \`\`\`
@@ -125,10 +126,11 @@ async function resolveAgentCronModel(agentId: string, requestedModel?: string): 
   return requestedModel;
 }
 
-export function buildPollingPrompt(workflowId: string, agentId: string, workModel?: string): string {
+export function buildPollingPrompt(workflowId: string, agentId: string, workModel?: string, workTimeoutSeconds?: number): string {
   const fullAgentId = `${workflowId}_${agentId}`;
   const cli = resolveAntfarmCli();
   const model = workModel ?? "default";
+  const runTimeoutSeconds = workTimeoutSeconds ?? DEFAULT_POLLING_TIMEOUT_SECONDS;
   const workPrompt = buildWorkPrompt(workflowId, agentId);
 
   return `Step 1 — Quick check for pending work (lightweight, no side effects):
@@ -143,10 +145,12 @@ node ${cli} step claim "${fullAgentId}"
 \`\`\`
 If output is "NO_WORK", reply HEARTBEAT_OK and stop.
 
-If JSON is returned, parse it to extract stepId, runId, and input fields.
+If JSON is returned, parse it to extract stepId, runId, input, and cwd fields.
 Then call sessions_spawn with these parameters:
 - agentId: "${fullAgentId}"
 - model: "${model}"
+- runTimeoutSeconds: ${runTimeoutSeconds}
+- cwd: the claimed step cwd field when present, otherwise keep the current workspace
 - task: The full work prompt below, followed by "\\n\\nCLAIMED STEP JSON:\\n" and the exact JSON output from step claim.
 
 Full work prompt to include in the spawned task:
@@ -177,7 +181,8 @@ export async function setupAgentCrons(workflow: WorkflowSpec): Promise<void> {
     const pollingModel = await resolveAgentCronModel(agentId, requestedPollingModel);
     const requestedWorkModel = agent.model ?? workflowPollingModel;
     const workModel = await resolveAgentCronModel(agentId, requestedWorkModel);
-    const prompt = buildPollingPrompt(workflow.id, agent.id, workModel);
+    const workTimeoutSeconds = getEffectiveAgentTimeoutSeconds(agent.id, agent.timeoutSeconds);
+    const prompt = buildPollingPrompt(workflow.id, agent.id, workModel, workTimeoutSeconds);
     const timeoutSeconds = workflowPollingTimeout;
 
     const result = await createAgentCronJob({

--- a/src/installer/agent-provision.ts
+++ b/src/installer/agent-provision.ts
@@ -102,24 +102,18 @@ export async function provisionAgents(params: {
 }
 
 /**
- * Resolve the source directory for an external skill by checking user skill directories.
+ * Resolve the source directory for an external skill from the canonical user skill library.
  * Returns the path if found, or null if not found.
  */
 async function resolveExternalSkillSource(skillName: string): Promise<string | null> {
   const home = process.env.HOME || process.env.USERPROFILE || "";
-  const candidates = [
-    path.join(home, ".openclaw", "workspace", "skills", skillName),
-    path.join(home, ".openclaw", "skills", skillName),
-  ];
-  for (const candidate of candidates) {
-    try {
-      await fs.access(candidate);
-      return candidate;
-    } catch {
-      // not found, try next
-    }
+  const candidate = path.join(home, ".openclaw", "skills", skillName);
+  try {
+    await fs.access(candidate);
+    return candidate;
+  } catch {
+    return null;
   }
-  return null;
 }
 
 /**

--- a/src/installer/events.ts
+++ b/src/installer/events.ts
@@ -9,7 +9,7 @@ const MAX_EVENTS_SIZE = 10 * 1024 * 1024; // 10MB
 
 export type EventType =
   | "run.started" | "run.completed" | "run.failed"
-  | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout"
+  | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout" | "step.retry"
   | "story.started" | "story.done" | "story.verified" | "story.retry" | "story.failed"
   | "pipeline.advanced";
 

--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -149,7 +149,7 @@ export async function createAgentCronJob(job: {
     }
 
     if (job.payload?.timeoutSeconds) {
-      args.push("--timeout", `${job.payload.timeoutSeconds}`);
+      args.push("--timeout-seconds", `${job.payload.timeoutSeconds}`);
     }
 
     if (job.payload?.model) {

--- a/src/installer/install.ts
+++ b/src/installer/install.ts
@@ -153,13 +153,19 @@ export function getMaxRoleTimeoutSeconds(): number {
   return Math.max(...Object.values(ROLE_POLICIES).map(r => r.timeoutSeconds));
 }
 
-const SUBAGENT_POLICY = { allowAgents: [] as string[] };
+export function getRoleTimeoutSeconds(role: AgentRole): number {
+  return ROLE_POLICIES[role].timeoutSeconds;
+}
+
+function buildSubagentPolicy(agentId: string): Record<string, unknown> {
+  return { allowAgents: [agentId] };
+}
 
 /**
  * Infer an agent's role from its id when not explicitly set in workflow YAML.
  * Matches common agent id patterns across all bundled workflows.
  */
-function inferRole(agentId: string): AgentRole {
+export function inferRole(agentId: string): AgentRole {
   const id = agentId.toLowerCase();
   if (id.includes("planner") || id.includes("prioritizer") || id.includes("reviewer")
       || id.includes("investigator") || id.includes("triager")) return "analysis";
@@ -169,6 +175,10 @@ function inferRole(agentId: string): AgentRole {
   if (id === "pr" || id.includes("/pr")) return "pr";
   // developer, fixer, setup → coding
   return "coding";
+}
+
+export function getEffectiveAgentTimeoutSeconds(agentId: string, explicitTimeoutSeconds?: number): number {
+  return explicitTimeoutSeconds ?? getRoleTimeoutSeconds(inferRole(agentId));
 }
 
 function buildToolsConfig(role: AgentRole): Record<string, unknown> {
@@ -219,7 +229,7 @@ function upsertAgent(
     workspace: agent.workspaceDir,
     agentDir: agent.agentDir,
     tools: buildToolsConfig(agent.role),
-    subagents: SUBAGENT_POLICY,
+    subagents: buildSubagentPolicy(agent.id),
   };
   if (agent.model) payload.model = agent.model;
   // Note: timeoutSeconds is NOT written to the agent config entry because

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -1,10 +1,21 @@
 import crypto from "node:crypto";
+import { execFileSync } from "node:child_process";
 import { loadWorkflowSpec } from "./workflow-spec.js";
 import { resolveWorkflowDir } from "./paths.js";
 import { getDb, nextRunNumber } from "../db.js";
 import { logger } from "../lib/logger.js";
 import { ensureWorkflowCrons } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
+import { getEffectiveAgentTimeoutSeconds } from "./install.js";
+
+function tryCommand(command: string, args: string[], cwd: string): string | undefined {
+  try {
+    const result = execFileSync(command, args, { cwd, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }).trim();
+    return result || undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 export async function runWorkflow(params: {
   workflowId: string;
@@ -18,10 +29,20 @@ export async function runWorkflow(params: {
   const runId = crypto.randomUUID();
   const runNumber = nextRunNumber();
 
+  const launchCwd = process.cwd();
+  const repo = tryCommand("git", ["rev-parse", "--show-toplevel"], launchCwd) ?? launchCwd;
+  const launchBranch = tryCommand("git", ["branch", "--show-current"], launchCwd) ?? "";
+
   const initialContext: Record<string, string> = {
     task: params.taskTitle,
+    cwd: launchCwd,
+    repo,
     ...workflow.context,
   };
+
+  if (launchBranch) {
+    initialContext.launch_branch = launchBranch;
+  }
 
   db.exec("BEGIN");
   try {
@@ -32,18 +53,20 @@ export async function runWorkflow(params: {
     insertRun.run(runId, runNumber, workflow.id, params.taskTitle, JSON.stringify(initialContext), notifyUrl, now, now);
 
     const insertStep = db.prepare(
-      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, max_retries, type, loop_config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
+      "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, max_retries, type, loop_config, timeout_seconds, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"
     );
 
     for (let i = 0; i < workflow.steps.length; i++) {
       const step = workflow.steps[i];
       const stepUuid = crypto.randomUUID();
       const agentId = `${workflow.id}_${step.agent}`;
+      const workflowAgent = workflow.agents.find((agent) => agent.id === step.agent);
       const status = i === 0 ? "pending" : "waiting";
       const maxRetries = step.max_retries ?? step.on_fail?.max_retries ?? 2;
       const stepType = step.type ?? "single";
       const loopConfig = step.loop ? JSON.stringify(step.loop) : null;
-      insertStep.run(stepUuid, runId, step.id, agentId, i, step.input, step.expects, status, maxRetries, stepType, loopConfig, now, now);
+      const timeoutSeconds = getEffectiveAgentTimeoutSeconds(step.agent, workflowAgent?.timeoutSeconds);
+      insertStep.run(stepUuid, runId, step.id, agentId, i, step.input, step.expects, status, maxRetries, stepType, loopConfig, timeoutSeconds, now, now);
     }
 
     db.exec("COMMIT");

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -85,10 +85,12 @@ function getWorkflowId(runId: string): string | undefined {
  * Resolve {{key}} placeholders in a template against a context object.
  */
 export function resolveTemplate(template: string, context: Record<string, string>): string {
-  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, key: string) => {
+  // Supports {{key}} and {{key|default}} syntax
+  return template.replace(/\{\{(\w+(?:\.\w+)*)(?:\|([^}]*))?\}\}/g, (_match, key: string, defaultValue?: string) => {
     if (key in context) return context[key];
     const lower = key.toLowerCase();
     if (lower in context) return context[lower];
+    if (defaultValue !== undefined) return defaultValue;
     return `[missing: ${key}]`;
   });
 }
@@ -99,7 +101,9 @@ export function resolveTemplate(template: string, context: Record<string, string
 function findMissingTemplateKeys(template: string, context: Record<string, string>): string[] {
   const missing: string[] = [];
   const seen = new Set<string>();
-  template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, key: string) => {
+  // Supports {{key}} and {{key|default}} — keys with defaults are never missing
+  template.replace(/\{\{(\w+(?:\.\w+)*)(?:\|([^}]*))?\}\}/g, (_match, key: string, defaultValue?: string) => {
+    if (defaultValue !== undefined) return ""; // has default, skip
     const lower = key.toLowerCase();
     const hasExact = Object.prototype.hasOwnProperty.call(context, key);
     const hasLower = Object.prototype.hasOwnProperty.call(context, lower);

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -36,7 +36,9 @@ export function parseOutputKeyValues(output: string): Record<string, string> {
   }
 
   for (const line of lines) {
-    const match = line.match(/^([A-Z_]+):\s*(.*)$/);
+    // Match KEY: or Key: or key: — normalize to lowercase for context storage.
+    // ALL_CAPS convention is preferred but LLMs sometimes output mixed case.
+    const match = line.match(/^([A-Za-z_]+):\s*(.*)$/);
     if (match) {
       // New KEY: line found — flush previous key
       commitPending();
@@ -502,6 +504,12 @@ export function claimStep(agentId: string): ClaimResult {
          WHERE prev.run_id = s.run_id
            AND prev.step_index < s.step_index
            AND prev.status NOT IN ('done', 'skipped')
+           -- verify_each: allow verify step to be claimed when its owning loop step is running
+           AND NOT (
+             prev.type = 'loop'
+             AND prev.status = 'running'
+             AND json_extract(prev.loop_config, '$.verifyStep') = s.step_id
+           )
        )
     ORDER BY s.step_index ASC, s.step_id ASC
      LIMIT 1`

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -684,7 +684,7 @@ export function claimStep(agentId: string): ClaimResult {
 /**
  * Complete a step: save output, merge context, advance pipeline.
  */
-export function completeStep(stepId: string, output: string): { advanced: boolean; runCompleted: boolean } {
+export async function completeStep(stepId: string, output: string): Promise<{ advanced: boolean; runCompleted: boolean }> {
   const db = getDb();
 
   const step = db.prepare(
@@ -769,6 +769,58 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
     if (lc.verifyEach && lc.verifyStep === step.step_id) {
       return handleVerifyEachCompletion(step, loopStepRow.id, output, context);
     }
+  }
+
+  // Single step: check for retry signal before marking done
+  const statusValue = context["status"]?.toLowerCase();
+  if (statusValue === "retry") {
+    // Agent signaled retry — look up on_fail policy to find retry_step
+    const policy = await getOnFailPolicy(step.run_id, step.step_id);
+    if (policy?.retry_step) {
+      // Find the step to retry and reset it to pending
+      const retryTarget = db.prepare(
+        "SELECT id FROM steps WHERE run_id = ? AND step_id = ? LIMIT 1"
+      ).get(step.run_id, policy.retry_step) as { id: string } | undefined;
+
+      if (retryTarget) {
+        const retryCount = (db.prepare(
+          "SELECT retry_count FROM steps WHERE id = ?"
+        ).get(retryTarget.id) as { retry_count: number })?.retry_count ?? 0;
+        const maxRetries = policy.max_retries ?? 2;
+
+        if (retryCount >= maxRetries) {
+          // Retries exhausted — fail
+          db.prepare("UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+          db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+          const wfId = getWorkflowId(step.run_id);
+          emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: "Retry exhausted after verify rejection" });
+          emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Retry exhausted after verify rejection" });
+          scheduleRunCronTeardown(step.run_id);
+          await notifyFailureExhausted(step.run_id, step.step_id, context["issues"] ?? output);
+          return { advanced: false, runCompleted: false };
+        }
+
+        // Store verify feedback for the retry step
+        context["verify_feedback"] = context["issues"] ?? output;
+        db.prepare("UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?").run(JSON.stringify(context), step.run_id);
+
+        // Reset verify step to waiting, retry target to pending
+        db.prepare("UPDATE steps SET status = 'waiting', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+        db.prepare("UPDATE steps SET status = 'pending', retry_count = retry_count + 1, updated_at = datetime('now') WHERE id = ?").run(retryTarget.id);
+        const wfId = getWorkflowId(step.run_id);
+        emitEvent({ ts: new Date().toISOString(), event: "step.retry", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: context["issues"] ?? "Verify requested retry" });
+        logger.info(`Verify step ${step.step_id} requested retry of ${policy.retry_step}`, { runId: step.run_id });
+        return { advanced: false, runCompleted: false };
+      }
+    }
+    // No retry_step configured — treat retry as failure
+    db.prepare("UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+    db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+    const wfId = getWorkflowId(step.run_id);
+    emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: "STATUS: retry but no retry_step configured" });
+    emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "STATUS: retry but no retry_step configured" });
+    scheduleRunCronTeardown(step.run_id);
+    return { advanced: false, runCompleted: false };
   }
 
   // Single step: mark done and advance

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -37,7 +37,9 @@ export function parseOutputKeyValues(output: string): Record<string, string> {
   }
 
   for (const line of lines) {
-    const match = line.match(/^([A-Z_]+):\s*(.*)$/);
+    // Match KEY: or Key: or key: — normalize to lowercase for context storage.
+    // ALL_CAPS convention is preferred but LLMs sometimes output mixed case.
+    const match = line.match(/^([A-Za-z_]+):\s*(.*)$/);
     if (match) {
       // New KEY: line found — flush previous key
       commitPending();
@@ -84,10 +86,12 @@ function getWorkflowId(runId: string): string | undefined {
  * Resolve {{key}} placeholders in a template against a context object.
  */
 export function resolveTemplate(template: string, context: Record<string, string>): string {
-  return template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, key: string) => {
+  // Supports {{key}} and {{key|default}} syntax
+  return template.replace(/\{\{(\w+(?:\.\w+)*)(?:\|([^}]*))?\}\}/g, (_match, key: string, defaultValue?: string) => {
     if (key in context) return context[key];
     const lower = key.toLowerCase();
     if (lower in context) return context[lower];
+    if (defaultValue !== undefined) return defaultValue;
     return `[missing: ${key}]`;
   });
 }
@@ -98,7 +102,9 @@ export function resolveTemplate(template: string, context: Record<string, string
 function findMissingTemplateKeys(template: string, context: Record<string, string>): string[] {
   const missing: string[] = [];
   const seen = new Set<string>();
-  template.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_match, key: string) => {
+  // Supports {{key}} and {{key|default}} — keys with defaults are never missing
+  template.replace(/\{\{(\w+(?:\.\w+)*)(?:\|([^}]*))?\}\}/g, (_match, key: string, defaultValue?: string) => {
+    if (defaultValue !== undefined) return ""; // has default, skip
     const lower = key.toLowerCase();
     const hasExact = Object.prototype.hasOwnProperty.call(context, key);
     const hasLower = Object.prototype.hasOwnProperty.call(context, lower);
@@ -678,6 +684,12 @@ export function claimStep(agentId: string): ClaimResult {
          WHERE prev.run_id = s.run_id
            AND prev.step_index < s.step_index
            AND prev.status NOT IN ('done', 'skipped')
+           -- verify_each: allow verify step to be claimed when its owning loop step is running
+           AND NOT (
+             prev.type = 'loop'
+             AND prev.status = 'running'
+             AND json_extract(prev.loop_config, '$.verifyStep') = s.step_id
+           )
        )
     ORDER BY s.step_index ASC, s.step_id ASC
      LIMIT 1`
@@ -865,7 +877,7 @@ export function claimStep(agentId: string): ClaimResult {
 /**
  * Complete a step: save output, merge context, advance pipeline.
  */
-export function completeStep(stepId: string, output: string): { advanced: boolean; runCompleted: boolean } {
+export async function completeStep(stepId: string, output: string): Promise<{ advanced: boolean; runCompleted: boolean }> {
   const db = getDb();
 
   const step = db.prepare(
@@ -1020,6 +1032,58 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
     if (lc.verifyEach && lc.verifyStep === step.step_id) {
       return handleVerifyEachCompletion(step, loopStepRow.id, output, context);
     }
+  }
+
+  // Single step: check for retry signal before marking done
+  const statusValue = context["status"]?.toLowerCase();
+  if (statusValue === "retry") {
+    // Agent signaled retry — look up on_fail policy to find retry_step
+    const policy = await getOnFailPolicy(step.run_id, step.step_id);
+    if (policy?.retry_step) {
+      // Find the step to retry and reset it to pending
+      const retryTarget = db.prepare(
+        "SELECT id FROM steps WHERE run_id = ? AND step_id = ? LIMIT 1"
+      ).get(step.run_id, policy.retry_step) as { id: string } | undefined;
+
+      if (retryTarget) {
+        const retryCount = (db.prepare(
+          "SELECT retry_count FROM steps WHERE id = ?"
+        ).get(retryTarget.id) as { retry_count: number })?.retry_count ?? 0;
+        const maxRetries = policy.max_retries ?? 2;
+
+        if (retryCount >= maxRetries) {
+          // Retries exhausted — fail
+          db.prepare("UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+          db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+          const wfId = getWorkflowId(step.run_id);
+          emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: "Retry exhausted after verify rejection" });
+          emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Retry exhausted after verify rejection" });
+          scheduleRunCronTeardown(step.run_id);
+          await notifyFailureExhausted(step.run_id, step.step_id, context["issues"] ?? output);
+          return { advanced: false, runCompleted: false };
+        }
+
+        // Store verify feedback for the retry step
+        context["verify_feedback"] = context["issues"] ?? output;
+        db.prepare("UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?").run(JSON.stringify(context), step.run_id);
+
+        // Reset verify step to waiting, retry target to pending
+        db.prepare("UPDATE steps SET status = 'waiting', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+        db.prepare("UPDATE steps SET status = 'pending', retry_count = retry_count + 1, updated_at = datetime('now') WHERE id = ?").run(retryTarget.id);
+        const wfId = getWorkflowId(step.run_id);
+        emitEvent({ ts: new Date().toISOString(), event: "step.retry", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: context["issues"] ?? "Verify requested retry" });
+        logger.info(`Verify step ${step.step_id} requested retry of ${policy.retry_step}`, { runId: step.run_id });
+        return { advanced: false, runCompleted: false };
+      }
+    }
+    // No retry_step configured — treat retry as failure
+    db.prepare("UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?").run(output, stepId);
+    db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+    const wfId = getWorkflowId(step.run_id);
+    emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: "STATUS: retry but no retry_step configured" });
+    emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "STATUS: retry but no retry_step configured" });
+    scheduleRunCronTeardown(step.run_id);
+    return { advanced: false, runCompleted: false };
   }
 
   // Single step: mark done and advance

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import crypto from "node:crypto";
+import YAML from "yaml";
 import { execSync, execFileSync } from "node:child_process";
 import { teardownWorkflowCronsIfIdle } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
@@ -13,7 +14,7 @@ import { getMaxRoleTimeoutSeconds } from "./install.js";
 import { loadWorkflowSpec } from "./workflow-spec.js";
 import { resolveWorkflowDir } from "./paths.js";
 import { isFrontendChange } from "../lib/frontend-detect.js";
-import type { WorkflowStepFailure } from "./types.js";
+import type { WorkflowSpec, WorkflowStepFailure } from "./types.js";
 
 /**
  * Parse KEY: value lines from step output with support for multi-line values.
@@ -263,7 +264,7 @@ function parseAndInsertStories(output: string, runId: string): void {
 
 // ── Abandoned Step Cleanup ──────────────────────────────────────────
 
-const ABANDONED_THRESHOLD_MS = (getMaxRoleTimeoutSeconds() + 5 * 60) * 1000; // max role timeout + 5 min buffer
+const DEFAULT_ABANDONED_TIMEOUT_MS = (getMaxRoleTimeoutSeconds() + 5 * 60) * 1000; // fallback for legacy rows
 const MAX_ABANDON_RESETS = 5; // abandoned steps get more chances than explicit failures
 
 /**
@@ -274,12 +275,12 @@ const MAX_ABANDON_RESETS = 5; // abandoned steps get more chances than explicit 
 export function cleanupAbandonedSteps(): void {
   const db = getDb();
   // Use numeric comparison so mixed timestamp formats don't break ordering.
-  const thresholdMs = ABANDONED_THRESHOLD_MS;
+  const defaultThresholdMs = DEFAULT_ABANDONED_TIMEOUT_MS;
 
   // Find running steps that haven't been updated recently
   const abandonedSteps = db.prepare(
-    "SELECT id, step_id, run_id, retry_count, max_retries, type, current_story_id, loop_config, abandoned_count FROM steps WHERE status = 'running' AND (julianday('now') - julianday(updated_at)) * 86400000 > ?"
-  ).all(thresholdMs) as { id: string; step_id: string; run_id: string; retry_count: number; max_retries: number; type: string; current_story_id: string | null; loop_config: string | null; abandoned_count: number }[];
+    "SELECT id, step_id, run_id, retry_count, max_retries, type, current_story_id, loop_config, abandoned_count, timeout_seconds FROM steps WHERE status = 'running' AND (julianday('now') - julianday(updated_at)) * 86400000 > COALESCE((timeout_seconds + 300) * 1000, ?)"
+  ).all(defaultThresholdMs) as { id: string; step_id: string; run_id: string; retry_count: number; max_retries: number; type: string; current_story_id: string | null; loop_config: string | null; abandoned_count: number; timeout_seconds: number | null }[];
 
   for (const step of abandonedSteps) {
     if (step.type === "loop" && !step.current_story_id && step.loop_config) {
@@ -353,7 +354,7 @@ export function cleanupAbandonedSteps(): void {
   // Don't increment retry_count for abandonment; only explicit failStep() counts against retries
   const abandonedStories = db.prepare(
     "SELECT id, retry_count, max_retries, run_id FROM stories WHERE status = 'running' AND (julianday('now') - julianday(updated_at)) * 86400000 > ?"
-  ).all(thresholdMs) as { id: string; retry_count: number; max_retries: number; run_id: string }[];
+  ).all(defaultThresholdMs) as { id: string; retry_count: number; max_retries: number; run_id: string }[];
 
   for (const story of abandonedStories) {
     // Simply reset to pending without incrementing retry_count
@@ -390,17 +391,191 @@ export function cleanupAbandonedSteps(): void {
  * Returns 'true' or 'false' as a string for template context.
  */
 export function computeHasFrontendChanges(repo: string, branch: string): string {
+  if (!branch || branch === "main") {
+    return "false";
+  }
+
   try {
     const output = execFileSync("git", ["diff", "--name-only", `main..${branch}`], {
       cwd: repo,
       encoding: "utf-8",
       timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
     });
     const files = output.trim().split("\n").filter(f => f.length > 0);
     return isFrontendChange(files) ? "true" : "false";
   } catch {
     return "false";
   }
+}
+
+function getRepoCurrentBranch(repo: string): string | undefined {
+  try {
+    const branch = execFileSync("git", ["branch", "--show-current"], {
+      cwd: repo,
+      encoding: "utf-8",
+      timeout: 10_000,
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    return branch || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function inferRepoCommands(repo: string): { buildCmd?: string; testCmd?: string } {
+  try {
+    const packageJsonPath = path.join(repo, "package.json");
+    const makefilePath = path.join(repo, "Makefile");
+    const cargoTomlPath = path.join(repo, "Cargo.toml");
+    const pyprojectPath = path.join(repo, "pyproject.toml");
+    const requirementsPath = path.join(repo, "requirements.txt");
+    const goModPath = path.join(repo, "go.mod");
+
+    if (fs.existsSync(packageJsonPath)) {
+      const pkg = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8")) as {
+        scripts?: Record<string, string>;
+      };
+
+      const hasPnpm = fs.existsSync(path.join(repo, "pnpm-lock.yaml"));
+      const hasYarn = fs.existsSync(path.join(repo, "yarn.lock"));
+      const hasBun = fs.existsSync(path.join(repo, "bun.lockb")) || fs.existsSync(path.join(repo, "bun.lock"));
+      const runner = hasPnpm ? "pnpm" : hasYarn ? "yarn" : hasBun ? "bun" : "npm";
+
+      return {
+        buildCmd: pkg.scripts?.build ? (runner === "npm" ? "npm run build" : `${runner} build`) : undefined,
+        testCmd: pkg.scripts?.test ? (runner === "npm" ? "npm test" : `${runner} test`) : undefined,
+      };
+    }
+
+    if (fs.existsSync(makefilePath)) {
+      const makefile = fs.readFileSync(makefilePath, "utf-8");
+      return {
+        buildCmd: /^build\s*:/m.test(makefile) ? "make build" : undefined,
+        testCmd: /^test\s*:/m.test(makefile) ? "make test" : undefined,
+      };
+    }
+
+    if (fs.existsSync(cargoTomlPath)) {
+      return { buildCmd: "cargo build", testCmd: "cargo test" };
+    }
+
+    if (fs.existsSync(goModPath)) {
+      return { buildCmd: "go build ./...", testCmd: "go test ./..." };
+    }
+
+    if (fs.existsSync(pyprojectPath) || fs.existsSync(requirementsPath)) {
+      return { buildCmd: undefined, testCmd: "pytest" };
+    }
+
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+function backfillContextFromRepo(context: Record<string, string>): void {
+  const repo = context["repo"];
+  if (!repo) return;
+
+  const currentBranch = getRepoCurrentBranch(repo);
+  if (currentBranch) {
+    context["branch"] = currentBranch;
+  }
+
+  const inferred = inferRepoCommands(repo);
+  if (!context["build_cmd"] && inferred.buildCmd) {
+    context["build_cmd"] = inferred.buildCmd;
+  }
+  if (!context["test_cmd"] && inferred.testCmd) {
+    context["test_cmd"] = inferred.testCmd;
+  }
+}
+
+function findFutureRequiredKeys(runId: string, currentStepIndex: number, candidateKeys: string[]): string[] {
+  const db = getDb();
+  const laterSteps = db.prepare(
+    "SELECT input_template FROM steps WHERE run_id = ? AND step_index > ? ORDER BY step_index ASC"
+  ).all(runId, currentStepIndex) as { input_template: string }[];
+
+  const required = new Set<string>();
+  for (const step of laterSteps) {
+    for (const key of candidateKeys) {
+      if (step.input_template.includes(`{{${key}}}`)) {
+        required.add(key);
+      }
+    }
+  }
+  return [...required];
+}
+
+function handleInvalidCompletion(
+  step: { id: string; run_id: string; step_id: string; retry_count: number; max_retries: number },
+  context: Record<string, string>,
+  detail: string,
+): { advanced: boolean; runCompleted: boolean } {
+  const db = getDb();
+  const wfId = getWorkflowId(step.run_id);
+  const newRetryCount = step.retry_count + 1;
+
+  if (newRetryCount > step.max_retries) {
+    db.prepare(
+      "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(detail, newRetryCount, step.id);
+    db.prepare(
+      "UPDATE runs SET status = 'failed', context = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(JSON.stringify(context), step.run_id);
+    emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail });
+    emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Invalid step completion exhausted retries" });
+    scheduleRunCronTeardown(step.run_id);
+    return { advanced: false, runCompleted: false };
+  }
+
+  db.prepare(
+    "UPDATE steps SET status = 'pending', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+  ).run(detail, newRetryCount, step.id);
+  db.prepare(
+    "UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?"
+  ).run(JSON.stringify(context), step.run_id);
+  emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail });
+  return { advanced: false, runCompleted: false };
+}
+
+function validateStepCompletion(
+  step: { run_id: string; step_id: string; step_index: number; expects?: string },
+  output: string,
+  mergedContext: Record<string, string>,
+  status: string | undefined,
+  allowsRetry: boolean,
+): string | null {
+  const normalizedStatus = status?.toLowerCase();
+
+  if (!normalizedStatus) {
+    return "Invalid step completion: missing STATUS line";
+  }
+
+  if (normalizedStatus !== "done" && !(normalizedStatus === "retry" && allowsRetry)) {
+    return `Invalid step completion: unsupported STATUS ${status}`;
+  }
+
+  if (step.expects && !output.includes(step.expects) && !(normalizedStatus === "retry" && allowsRetry)) {
+    return `Invalid step completion: output did not satisfy expects contract (${step.expects})`;
+  }
+
+  if (step.step_id === "setup") {
+    const branch = mergedContext["branch"]?.trim();
+    if (!branch || branch === "main" || branch === "master") {
+      return "Invalid setup completion: branch was not established on a non-main branch";
+    }
+
+    const futureKeys = findFutureRequiredKeys(step.run_id, step.step_index, ["build_cmd", "test_cmd"]);
+    const missingFutureKeys = futureKeys.filter((key) => !mergedContext[key]);
+    if (missingFutureKeys.length > 0) {
+      return `Invalid setup completion: missing required context for downstream steps (${missingFutureKeys.join(", ")})`;
+    }
+  }
+
+  return null;
 }
 
 function failStepWithMissingInputs(
@@ -471,6 +646,7 @@ interface ClaimResult {
   stepId?: string;
   runId?: string;
   resolvedInput?: string;
+  cwd?: string;
 }
 
 /**
@@ -520,6 +696,8 @@ export function claimStep(agentId: string): ClaimResult {
   // Get run context
   const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string } | undefined;
   const context: Record<string, string> = run ? JSON.parse(run.context) : {};
+
+  backfillContextFromRepo(context);
 
   // Always inject run_id so templates can use {{run_id}} (e.g. for scoped progress files)
   context["run_id"] = step.run_id;
@@ -636,7 +814,13 @@ export function claimStep(agentId: string): ClaimResult {
       db.prepare("UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?").run(JSON.stringify(context), step.run_id);
 
       const resolvedInput = resolveTemplate(step.input_template, context);
-      return { found: true, stepId: step.id, runId: step.run_id, resolvedInput };
+      return {
+        found: true,
+        stepId: step.id,
+        runId: step.run_id,
+        resolvedInput,
+        cwd: context["repo"] || context["cwd"],
+      };
     }
   }
 
@@ -655,6 +839,10 @@ export function claimStep(agentId: string): ClaimResult {
     context["progress"] = readProgressFile(step.run_id);
   }
 
+  if (!context["verify_feedback"]) {
+    context["verify_feedback"] = "";
+  }
+
   const missingKeys = findMissingTemplateKeys(step.input_template, context);
   if (missingKeys.length > 0) {
     failStepWithMissingInputs(step.id, step.step_id, step.run_id, missingKeys);
@@ -668,6 +856,7 @@ export function claimStep(agentId: string): ClaimResult {
     stepId: step.id,
     runId: step.run_id,
     resolvedInput,
+    cwd: context["repo"] || context["cwd"],
   };
 }
 
@@ -680,25 +869,95 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
+    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id, retry_count, max_retries, status, expects FROM steps WHERE id = ?"
+  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null; retry_count: number; max_retries: number; status: string; expects: string } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
 
-  // Guard: don't process completions for failed runs
+  if (step.status !== "running") {
+    logger.warn(`Ignoring late completion for non-running step: ${step.step_id} (${step.status})`, { runId: step.run_id, stepId: step.step_id });
+    return { advanced: false, runCompleted: false };
+  }
+
+  // Guard: don't process completions for failed/cancelled runs
   const runCheck = db.prepare("SELECT status FROM runs WHERE id = ?").get(step.run_id) as { status: string } | undefined;
-  if (runCheck?.status === "failed") {
+  if (runCheck?.status === "failed" || runCheck?.status === "cancelled") {
     return { advanced: false, runCompleted: false };
   }
 
   // Merge KEY: value lines into run context
   const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(step.run_id) as { context: string };
-  const context: Record<string, string> = JSON.parse(run.context);
+  const baseContext: Record<string, string> = JSON.parse(run.context);
+  const context: Record<string, string> = { ...baseContext };
 
   // Parse KEY: value lines and merge into context
   const parsed = parseOutputKeyValues(output);
   for (const [key, value] of Object.entries(parsed)) {
     context[key] = value;
+  }
+
+  backfillContextFromRepo(context);
+
+  const status = parsed["status"]?.toLowerCase();
+  const onFailPolicy = status === "retry" ? getOnFailPolicySync(step.run_id, step.step_id) : null;
+  const validationError = validateStepCompletion(step, output, context, status, !!onFailPolicy?.retry_step);
+  if (validationError) {
+    return handleInvalidCompletion(step, baseContext, validationError);
+  }
+
+  if (status === "retry" && onFailPolicy?.retry_step) {
+    const issues = parsed["issues"] ?? output;
+    context["verify_feedback"] = issues;
+
+    const newRetryCount = step.retry_count + 1;
+    if (newRetryCount > step.max_retries) {
+      db.prepare(
+        "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(output, newRetryCount, stepId);
+      db.prepare(
+        "UPDATE runs SET status = 'failed', context = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(JSON.stringify(context), step.run_id);
+      const wfId = getWorkflowId(step.run_id);
+      emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: issues });
+      emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail: "Step retries exhausted" });
+      scheduleRunCronTeardown(step.run_id);
+      void notifyFailureExhausted(step.run_id, step.step_id, issues);
+      return { advanced: false, runCompleted: false };
+    }
+
+    const retryStep = db.prepare(
+      "SELECT id FROM steps WHERE run_id = ? AND step_id = ? LIMIT 1"
+    ).get(step.run_id, onFailPolicy.retry_step) as { id: string } | undefined;
+
+    if (!retryStep) {
+      const wfId = getWorkflowId(step.run_id);
+      const detail = `Invalid workflow retry target: ${onFailPolicy.retry_step}`;
+      db.prepare(
+        "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(detail, newRetryCount, stepId);
+      db.prepare(
+        "UPDATE runs SET status = 'failed', context = ?, updated_at = datetime('now') WHERE id = ?"
+      ).run(JSON.stringify(context), step.run_id);
+      emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail });
+      emitEvent({ ts: new Date().toISOString(), event: "run.failed", runId: step.run_id, workflowId: wfId, detail });
+      scheduleRunCronTeardown(step.run_id);
+      return { advanced: false, runCompleted: false };
+    }
+
+    db.prepare(
+      "UPDATE runs SET context = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(JSON.stringify(context), step.run_id);
+    db.prepare(
+      "UPDATE steps SET status = 'waiting', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(output, newRetryCount, stepId);
+    if (retryStep) {
+      db.prepare(
+        "UPDATE steps SET status = 'pending', updated_at = datetime('now') WHERE id = ?"
+      ).run(retryStep.id);
+    }
+
+    logger.info(`Step requested retry: ${step.step_id} -> ${onFailPolicy.retry_step}`, { runId: step.run_id, stepId: step.step_id });
+    return { advanced: false, runCompleted: false };
   }
 
   db.prepare(
@@ -792,6 +1051,9 @@ function handleVerifyEachCompletion(
 
   if (status !== "retry") {
     // Verify passed
+    const verifiedValue = context["verified"] ?? output;
+    const verifiedKey = getStepOutputKeyName(verifyStep.run_id, verifyStep.step_id, "verified");
+    context[verifiedKey] = verifiedValue;
     emitEvent({ ts: new Date().toISOString(), event: "story.verified", runId: verifyStep.run_id, workflowId: getWorkflowId(verifyStep.run_id), stepId: verifyStep.step_id });
   }
 
@@ -968,6 +1230,56 @@ function resolveEscalationTarget(policy: WorkflowStepFailure | null): string | n
   return null;
 }
 
+function getWorkflowSpecSync(workflowId: string): WorkflowSpec | null {
+  try {
+    const workflowDir = resolveWorkflowDir(workflowId);
+    const filePath = path.join(workflowDir, "workflow.yml");
+    const raw = fs.readFileSync(filePath, "utf-8");
+    return YAML.parse(raw) as WorkflowSpec;
+  } catch {
+    return null;
+  }
+}
+
+function getOnFailPolicySync(runId: string, stepId: string): WorkflowStepFailure | null {
+  try {
+    const db = getDb();
+    const run = db.prepare("SELECT workflow_id FROM runs WHERE id = ?").get(runId) as { workflow_id: string } | undefined;
+    if (!run) return null;
+
+    const workflow = getWorkflowSpecSync(run.workflow_id);
+    const step = workflow?.steps?.find((s) => s.id === stepId);
+    return step?.on_fail ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function getStepOutputKeyName(runId: string, stepId: string, preferredKey: string): string {
+  try {
+    const db = getDb();
+    const run = db.prepare("SELECT workflow_id FROM runs WHERE id = ?").get(runId) as { workflow_id: string } | undefined;
+    if (!run) return preferredKey.toLowerCase();
+
+    const workflow = getWorkflowSpecSync(run.workflow_id);
+    const step = workflow?.steps?.find((s) => s.id === stepId);
+    const input = step?.input ?? "";
+    const placeholders = Array.from(input.matchAll(/\{\{(\w+(?:\.\w+)*)\}\}/g)).map((m) => m[1].toLowerCase());
+    const normalizedPreferred = preferredKey.toLowerCase();
+
+    if (placeholders.includes(normalizedPreferred)) return normalizedPreferred;
+
+    if (stepId === "verify") {
+      if (placeholders.includes("verified")) return "verified";
+      if (placeholders.includes("issues")) return "issues";
+    }
+
+    return normalizedPreferred;
+  } catch {
+    return preferredKey.toLowerCase();
+  }
+}
+
 async function getOnFailPolicy(runId: string, stepId: string): Promise<WorkflowStepFailure | null> {
   try {
     const db = getDb();
@@ -1036,7 +1348,7 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT run_id, step_id, retry_count, max_retries, type, current_story_id FROM steps WHERE id = ?"
+    "SELECT run_id, step_id, retry_count, max_retries, type, current_story_id, status FROM steps WHERE id = ?"
   ).get(stepId) as {
     run_id: string;
     step_id: string;
@@ -1044,9 +1356,15 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
     max_retries: number;
     type: string;
     current_story_id: string | null;
+    status: string;
   } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
+
+  if (step.status !== "running") {
+    logger.warn(`Ignoring late failure for non-running step: ${step.step_id} (${step.status})`, { runId: step.run_id, stepId: step.step_id });
+    return { retrying: false, runFailed: false };
+  }
 
   // T9: Loop step failure — per-story retry
   if (step.type === "loop" && step.current_story_id) {

--- a/src/medic/checks.ts
+++ b/src/medic/checks.ts
@@ -25,7 +25,7 @@ export interface MedicFinding {
 
 // ── Check: Stuck Steps ──────────────────────────────────────────────
 
-const MAX_ROLE_TIMEOUT_MS = (getMaxRoleTimeoutSeconds() + 5 * 60) * 1000;
+const DEFAULT_TIMEOUT_THRESHOLD_MS = (getMaxRoleTimeoutSeconds() + 5 * 60) * 1000;
 
 /**
  * Find steps that have been "running" longer than the max role timeout.
@@ -37,15 +37,15 @@ export function checkStuckSteps(): MedicFinding[] {
 
   const stuck = db.prepare(`
     SELECT s.id, s.step_id, s.run_id, s.agent_id, s.updated_at, s.abandoned_count,
-           r.workflow_id, r.task
+           s.timeout_seconds, r.workflow_id, r.task
     FROM steps s
     JOIN runs r ON r.id = s.run_id
     WHERE s.status = 'running'
       AND r.status = 'running'
-      AND (julianday('now') - julianday(s.updated_at)) * 86400000 > ?
-  `).all(MAX_ROLE_TIMEOUT_MS) as Array<{
+      AND (julianday('now') - julianday(s.updated_at)) * 86400000 > COALESCE((s.timeout_seconds + 300) * 1000, ?)
+  `).all(DEFAULT_TIMEOUT_THRESHOLD_MS) as Array<{
     id: string; step_id: string; run_id: string; agent_id: string;
-    updated_at: string; abandoned_count: number; workflow_id: string; task: string;
+    updated_at: string; abandoned_count: number; timeout_seconds: number | null; workflow_id: string; task: string;
   }>;
 
   for (const step of stuck) {
@@ -68,8 +68,6 @@ export function checkStuckSteps(): MedicFinding[] {
 
 // ── Check: Stalled Runs ─────────────────────────────────────────────
 
-const STALL_THRESHOLD_MS = MAX_ROLE_TIMEOUT_MS * 2;
-
 /**
  * Find runs where no step has transitioned in 2x the max role timeout.
  * This catches systemic issues (all agents broken, crons failing, etc).
@@ -81,20 +79,23 @@ export function checkStalledRuns(): MedicFinding[] {
   // Get running runs where the most recent step update is stale
   const stalled = db.prepare(`
     SELECT r.id, r.workflow_id, r.task, r.updated_at,
-           MAX(s.updated_at) as last_step_update
+           MAX(s.updated_at) as last_step_update,
+           MAX(COALESCE(s.timeout_seconds, ?)) as max_timeout_seconds
     FROM runs r
     JOIN steps s ON s.run_id = r.id
     WHERE r.status = 'running'
     GROUP BY r.id
-    HAVING (julianday('now') - julianday(MAX(s.updated_at))) * 86400000 > ?
-  `).all(STALL_THRESHOLD_MS) as Array<{
+  `).all(getMaxRoleTimeoutSeconds()) as Array<{
     id: string; workflow_id: string; task: string;
-    updated_at: string; last_step_update: string;
+    updated_at: string; last_step_update: string; max_timeout_seconds: number;
   }>;
 
   for (const run of stalled) {
+    const ageMs = Date.now() - new Date(run.last_step_update).getTime();
+    const stallThresholdMs = (run.max_timeout_seconds + 5 * 60) * 1000 * 2;
+    if (ageMs <= stallThresholdMs) continue;
     const ageMin = Math.round(
-      (Date.now() - new Date(run.last_step_update).getTime()) / 60000
+      ageMs / 60000
     );
     findings.push({
       check: "stalled_runs",

--- a/tests/cron-payload-polling-model.test.ts
+++ b/tests/cron-payload-polling-model.test.ts
@@ -161,4 +161,75 @@ describe("cron payload includes polling model (regression #121)", () => {
     assert.equal(capturedJobs[0].payload.timeoutSeconds, 120,
       "cron payload should include timeoutSeconds from workflow polling config");
   });
+
+  it("polling prompt carries per-agent work-session timeout into sessions_spawn", async () => {
+    const { setupAgentCrons } = await import("../dist/installer/agent-cron.js");
+
+    const fakeWorkflow = {
+      id: "test-work-timeout",
+      name: "Test Work Timeout",
+      version: 1,
+      polling: {
+        model: "claude-sonnet-4-20250514",
+        timeoutSeconds: 120,
+      },
+      agents: [
+        {
+          id: "slow-verifier",
+          name: "Slow Verifier",
+          timeoutSeconds: 1800,
+          workspace: { baseDir: "agents/slow", files: {} },
+        },
+      ],
+      steps: [
+        { id: "verify", agent: "slow-verifier", input: "verify", expects: "STATUS: done" },
+      ],
+    };
+
+    await setupAgentCrons(fakeWorkflow as any);
+
+    assert.match(
+      capturedJobs[0].payload.message,
+      /runTimeoutSeconds: 1800/,
+      "sessions_spawn instructions should carry the agent's work timeout"
+    );
+    assert.equal(
+      capturedJobs[0].payload.timeoutSeconds,
+      120,
+      "polling cron itself should stay on the lightweight workflow polling timeout"
+    );
+  });
+
+  it("polling prompt falls back to inferred role timeout when agent timeout is omitted", async () => {
+    const { setupAgentCrons } = await import("../dist/installer/agent-cron.js");
+
+    const fakeWorkflow = {
+      id: "test-default-work-timeout",
+      name: "Test Default Work Timeout",
+      version: 1,
+      polling: {
+        model: "claude-sonnet-4-20250514",
+        timeoutSeconds: 120,
+      },
+      agents: [
+        {
+          id: "fixer",
+          name: "Fixer",
+          workspace: { baseDir: "agents/fixer", files: {} },
+        },
+      ],
+      steps: [
+        { id: "fix", agent: "fixer", input: "fix", expects: "STATUS: done" },
+      ],
+    };
+
+    await setupAgentCrons(fakeWorkflow as any);
+
+    assert.match(
+      capturedJobs[0].payload.message,
+      /runTimeoutSeconds: 1800/,
+      "coding agents without explicit timeout should inherit the role default"
+    );
+    assert.equal(capturedJobs[0].payload.timeoutSeconds, 120);
+  });
 });

--- a/tests/external-skills.test.ts
+++ b/tests/external-skills.test.ts
@@ -16,12 +16,11 @@ describe("External skill installation", () => {
   beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "antfarm-skill-test-"));
     fakeHome = path.join(tmpDir, "home");
-    await fs.mkdir(path.join(fakeHome, ".openclaw", "workspace", "skills", "agent-browser"), { recursive: true });
+    await fs.mkdir(path.join(fakeHome, ".openclaw", "skills", "agent-browser"), { recursive: true });
     await fs.writeFile(
-      path.join(fakeHome, ".openclaw", "workspace", "skills", "agent-browser", "SKILL.md"),
+      path.join(fakeHome, ".openclaw", "skills", "agent-browser", "SKILL.md"),
       "# Agent Browser Skill\nTest content"
     );
-    // Also create a skill in the alternate location
     await fs.mkdir(path.join(fakeHome, ".openclaw", "skills", "alt-skill"), { recursive: true });
     await fs.writeFile(
       path.join(fakeHome, ".openclaw", "skills", "alt-skill", "SKILL.md"),
@@ -30,13 +29,12 @@ describe("External skill installation", () => {
     origHome = process.env.HOME || "";
     process.env.HOME = fakeHome;
   });
-
   afterEach(async () => {
     process.env.HOME = origHome;
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("resolves skill from ~/.openclaw/workspace/skills/", async () => {
+  it("resolves skill from ~/.openclaw/skills/", async () => {
     // Import after setting HOME
     const mod = await import("../dist/installer/agent-provision.js");
     // We can't directly test resolveExternalSkillSource since it's not exported,
@@ -73,7 +71,7 @@ describe("External skill installation", () => {
     assert.ok(content.includes("Agent Browser Skill"), "Skill SKILL.md should be copied");
   });
 
-  it("resolves skill from ~/.openclaw/skills/ (fallback)", async () => {
+  it("resolves another skill from ~/.openclaw/skills/", async () => {
     const mod = await import("../dist/installer/agent-provision.js");
     const workflowDir = path.join(tmpDir, "workflow");
     await fs.mkdir(workflowDir, { recursive: true });

--- a/tests/fixtures/smoke-task.txt
+++ b/tests/fixtures/smoke-task.txt
@@ -1,0 +1,6 @@
+Smoke test: fix add() in the sample repo.
+Acceptance criteria:
+- add(2,3)=5
+- tests pass
+- build command passes if present
+- regression test remains explicit

--- a/tests/frontend-e2e.test.ts
+++ b/tests/frontend-e2e.test.ts
@@ -161,4 +161,60 @@ describe("E2E: frontend change detection in verify flow", () => {
     assert.ok(result.found);
     assert.ok(result.resolvedInput!.includes("Has frontend changes: false"));
   });
+
+  it("keeps step claim CLI output as clean JSON on the main branch", () => {
+    insertTestRun(tmpDir, "main");
+    const output = execSync(`node ${path.join(process.cwd(), "dist/cli/cli.js")} step claim "${testAgentId}"`, {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    }).trim();
+
+    const parsed = JSON.parse(output) as { stepId: string; runId: string; input: string };
+    assert.ok(parsed.stepId, "should include stepId");
+    assert.ok(parsed.runId, "should include runId");
+    assert.ok(parsed.input.includes("Has frontend changes: false"));
+  });
+
+  it("treats verify_feedback as optional for first-pass single steps", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const now = new Date().toISOString();
+    const context = JSON.stringify({
+      repo: tmpDir,
+      branch: "main",
+      task: "fix the bug",
+      test_cmd: "npm test",
+      build_cmd: "npm run build",
+      affected_area: "math.ts",
+      root_cause: "bad addition",
+      fix_approach: "return a + b",
+      problem_statement: "add() is wrong",
+    });
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'test-workflow', 'test task', 'running', ?, ?, ?)`
+    ).run(runId, context, now, now);
+
+    const stepId = randomUUID();
+    db.prepare(
+      `INSERT INTO steps (id, step_id, run_id, agent_id, step_index, input_template, expects, status, created_at, updated_at, type)
+       VALUES (?, 'fix', ?, ?, 0, ?, 'STATUS: done', 'pending', ?, ?, 'single')`
+    ).run(
+      stepId,
+      runId,
+      testAgentId,
+      `Implement the fix.\n\nVERIFY FEEDBACK (if retrying):\n{{verify_feedback}}\n\nROOT_CAUSE: {{root_cause}}`,
+      now,
+      now,
+    );
+
+    testRunIds.push(runId);
+    const result = claimStep(testAgentId);
+
+    assert.ok(result.found, "Should find a step to claim");
+    assert.ok(result.resolvedInput, "Should have resolved input");
+    assert.ok(!result.resolvedInput!.includes("[missing: verify_feedback]"), "verify_feedback should resolve to empty string on first pass");
+    assert.ok(result.resolvedInput!.includes("ROOT_CAUSE: bad addition"), "other context keys should still resolve normally");
+  });
 });

--- a/tests/non-running-step-guards.test.ts
+++ b/tests/non-running-step-guards.test.ts
@@ -16,7 +16,7 @@ describe("non-running step guards", () => {
     testRunIds.length = 0;
   });
 
-  it("ignores duplicate completion on an already-done step", () => {
+  it("ignores duplicate completion on an already-done step", async () => {
     const db = getDb();
     const runId = randomUUID();
     const stepId = randomUUID();
@@ -46,7 +46,7 @@ describe("non-running step guards", () => {
 
     testRunIds.push(runId);
 
-    const first = completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
+    const first = await completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
     assert.deepEqual(first, { advanced: true, runCompleted: false });
 
     let fixStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(nextStepId) as { status: string };
@@ -54,7 +54,7 @@ describe("non-running step guards", () => {
     assert.equal(fixStep.status, "pending");
     assert.equal(verifyStep.status, "waiting");
 
-    const duplicate = completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
+    const duplicate = await completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
     assert.deepEqual(duplicate, { advanced: false, runCompleted: false });
 
     fixStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(nextStepId) as { status: string };

--- a/tests/non-running-step-guards.test.ts
+++ b/tests/non-running-step-guards.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { completeStep, failStep } from "../dist/installer/step-ops.js";
+
+describe("non-running step guards", () => {
+  const testRunIds: string[] = [];
+
+  afterEach(() => {
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+  });
+
+  it("ignores duplicate completion on an already-done step", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const stepId = randomUUID();
+    const nextStepId = randomUUID();
+    const laterStepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', '{}', ?, ?)`
+    ).run(runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 0, 'fix', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(stepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 1, 'verify', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(nextStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'pr', 'bug-fix_pr', 2, 'pr', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(laterStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const first = completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
+    assert.deepEqual(first, { advanced: true, runCompleted: false });
+
+    let fixStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(nextStepId) as { status: string };
+    let verifyStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(laterStepId) as { status: string };
+    assert.equal(fixStep.status, "pending");
+    assert.equal(verifyStep.status, "waiting");
+
+    const duplicate = completeStep(stepId, "STATUS: done\nBUILD_CMD: npm run build\nTEST_CMD: npm test");
+    assert.deepEqual(duplicate, { advanced: false, runCompleted: false });
+
+    fixStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(nextStepId) as { status: string };
+    verifyStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(laterStepId) as { status: string };
+    assert.equal(fixStep.status, "pending");
+    assert.equal(verifyStep.status, "waiting");
+  });
+
+  it("ignores late failStep on an already-done step", async () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const stepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', '{}', ?, ?)`
+    ).run(runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 0, 'fix', 'STATUS: done', 'done', 0, 2, ?, ?, 'single')`
+    ).run(stepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = await failStep(stepId, 'late failure');
+    assert.deepEqual(result, { retrying: false, runFailed: false });
+
+    const step = db.prepare("SELECT status, retry_count FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number };
+    const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(step.status, 'done');
+    assert.equal(step.retry_count, 0);
+    assert.equal(run.status, 'running');
+  });
+});

--- a/tests/peek-step-polling.test.ts
+++ b/tests/peek-step-polling.test.ts
@@ -287,4 +287,11 @@ describe("polling prompt includes step peek", () => {
     const prompt = buildPollingPrompt("bug-fix", "fixer");
     assert.ok(prompt.includes("sessions_spawn"), "should still include sessions_spawn");
   });
+
+  it("instructs agents to pass claimed cwd into sessions_spawn", async () => {
+    const { buildPollingPrompt } = await import("../dist/installer/agent-cron.js");
+    const prompt = buildPollingPrompt("bug-fix", "triager");
+    assert.ok(prompt.includes("cwd fields"), "should mention cwd in claimed step JSON");
+    assert.ok(prompt.includes("cwd: the claimed step cwd field"), "should instruct passing cwd into sessions_spawn");
+  });
 });

--- a/tests/polling-config.test.ts
+++ b/tests/polling-config.test.ts
@@ -112,6 +112,14 @@ describe("polling config", () => {
     assert.equal(spec.polling.timeoutSeconds, 30);
   });
 
+  it("preserves 120s as the real workflow timeout standard, not the old 30s value", async () => {
+    const bundled = ["bug-fix", "feature-dev", "security-audit"];
+    for (const workflowId of bundled) {
+      const spec = await loadWorkflowSpec(path.resolve(import.meta.dirname, "..", "workflows", workflowId));
+      assert.equal(spec.polling?.timeoutSeconds, 120, `${workflowId} should use polling.timeoutSeconds=120`);
+    }
+  });
+
   it("parses per-agent pollingModel", async () => {
     const dir = path.join(tmpDir, "agent-polling");
     await fs.mkdir(dir, { recursive: true });

--- a/tests/setup-branch-context.test.ts
+++ b/tests/setup-branch-context.test.ts
@@ -26,7 +26,7 @@ describe("setup step branch context sync", () => {
     tempRepos.length = 0;
   });
 
-  it("captures the actual checked-out branch after setup completes", () => {
+  it("captures the actual checked-out branch after setup completes", async () => {
     const repo = mkdtempSync(path.join(tmpdir(), "antfarm-setup-branch-"));
     tempRepos.push(repo);
 
@@ -59,7 +59,7 @@ describe("setup step branch context sync", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(setupStepId, [
+    const result = await completeStep(setupStepId, [
       "STATUS: done",
       "BUILD_CMD: npm run build",
       "TEST_CMD: npm test",
@@ -73,7 +73,7 @@ describe("setup step branch context sync", () => {
     assert.equal(context.branch, "bugfix/main");
   });
 
-  it("backfills build and test commands from package.json when setup output omits them", () => {
+  it("backfills build and test commands from package.json when setup output omits them", async () => {
     const repo = mkdtempSync(path.join(tmpdir(), "antfarm-setup-fallback-"));
     tempRepos.push(repo);
 
@@ -113,7 +113,7 @@ describe("setup step branch context sync", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(setupStepId, "STATUS: done");
+    const result = await completeStep(setupStepId, "STATUS: done");
     assert.deepEqual(result, { advanced: true, runCompleted: false });
 
     const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };

--- a/tests/setup-branch-context.test.ts
+++ b/tests/setup-branch-context.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { completeStep } from "../dist/installer/step-ops.js";
+
+describe("setup step branch context sync", () => {
+  const testRunIds: string[] = [];
+  const tempRepos: string[] = [];
+
+  afterEach(() => {
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+
+    for (const repo of tempRepos) {
+      rmSync(repo, { recursive: true, force: true });
+    }
+    tempRepos.length = 0;
+  });
+
+  it("captures the actual checked-out branch after setup completes", () => {
+    const repo = mkdtempSync(path.join(tmpdir(), "antfarm-setup-branch-"));
+    tempRepos.push(repo);
+
+    writeFileSync(path.join(repo, "package.json"), JSON.stringify({ name: "setup-branch-test", version: "1.0.0" }));
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "package.json"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-b", "bugfix/main"], { cwd: repo, stdio: "ignore" });
+
+    const db = getDb();
+    const runId = randomUUID();
+    const setupStepId = randomUUID();
+    const fixStepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo, branch: "main" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'setup', 'bug-fix_setup', 2, 'setup', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(setupStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 3, 'fix', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(fixStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(setupStepId, [
+      "STATUS: done",
+      "BUILD_CMD: npm run build",
+      "TEST_CMD: npm test",
+      "BASELINE: build passes; tests fail on bugfix branch",
+    ].join("\n"));
+
+    assert.deepEqual(result, { advanced: true, runCompleted: false });
+
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };
+    const context = JSON.parse(run.context) as Record<string, string>;
+    assert.equal(context.branch, "bugfix/main");
+  });
+
+  it("backfills build and test commands from package.json when setup output omits them", () => {
+    const repo = mkdtempSync(path.join(tmpdir(), "antfarm-setup-fallback-"));
+    tempRepos.push(repo);
+
+    writeFileSync(path.join(repo, "package.json"), JSON.stringify({
+      name: "setup-fallback-test",
+      version: "1.0.0",
+      scripts: {
+        build: "node -e \"console.log('build ok')\"",
+        test: "node --test test.js",
+      },
+    }, null, 2));
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "package.json"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-b", "bugfix/setup-fallback"], { cwd: repo, stdio: "ignore" });
+
+    const db = getDb();
+    const runId = randomUUID();
+    const setupStepId = randomUUID();
+    const fixStepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo, branch: "main", status: "done" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'setup', 'bug-fix_setup', 2, 'setup', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(setupStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 3, 'fix {{build_cmd}} {{test_cmd}}', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(fixStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(setupStepId, "STATUS: done");
+    assert.deepEqual(result, { advanced: true, runCompleted: false });
+
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };
+    const context = JSON.parse(run.context) as Record<string, string>;
+    assert.equal(context.branch, "bugfix/setup-fallback");
+    assert.equal(context.build_cmd, "npm run build");
+    assert.equal(context.test_cmd, "npm test");
+
+    const fix = db.prepare("SELECT status FROM steps WHERE id = ?").get(fixStepId) as { status: string };
+    assert.equal(fix.status, "pending");
+  });
+});

--- a/tests/single-step-retry.test.ts
+++ b/tests/single-step-retry.test.ts
@@ -29,7 +29,7 @@ describe("single-step retry_step flow", () => {
     testRunIds.length = 0;
   });
 
-  it("routes STATUS: retry back to the configured retry_step instead of advancing", () => {
+  it("routes STATUS: retry back to the configured retry_step instead of advancing", async () => {
     const db = getDb();
     const runId = randomUUID();
     const now = new Date().toISOString();
@@ -70,7 +70,7 @@ describe("single-step retry_step flow", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(verifyStepId, [
+    const result = await completeStep(verifyStepId, [
       'STATUS: retry',
       'ISSUES: verifier found a mismatch',
     ].join('\n'));

--- a/tests/single-step-retry.test.ts
+++ b/tests/single-step-retry.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { randomUUID } from "node:crypto";
+import { execSync } from "node:child_process";
+import { getDb } from "../dist/db.js";
+import { completeStep } from "../dist/installer/step-ops.js";
+
+describe("single-step retry_step flow", () => {
+  let tmpDir: string;
+  const testRunIds: string[] = [];
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-retry-"));
+    execSync("git init && git checkout -b main", { cwd: tmpDir, stdio: "ignore" });
+    fs.writeFileSync(path.join(tmpDir, "package.json"), JSON.stringify({ name: "retry-test", scripts: { test: "node --test" } }, null, 2));
+    execSync("git add . && git commit -m 'init'", { cwd: tmpDir, stdio: "ignore" });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+  });
+
+  it("routes STATUS: retry back to the configured retry_step instead of advancing", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const now = new Date().toISOString();
+    const fixStepId = randomUUID();
+    const verifyStepId = randomUUID();
+    const prStepId = randomUUID();
+
+    const context = JSON.stringify({
+      repo: tmpDir,
+      branch: "bugfix/test-retry",
+      task: "fix bug",
+      changes: "updated math.js",
+      regression_test: "added regression test",
+      root_cause: "bad operator",
+      problem_statement: "add subtracts",
+      test_cmd: "npm test",
+    });
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, context, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 3, 'fix', 'STATUS: done', 'done', 0, 2, ?, ?, 'single')`
+    ).run(fixStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 4, 'verify', 'STATUS: done', 'running', 0, 3, ?, ?, 'single')`
+    ).run(verifyStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'pr', 'bug-fix_pr', 5, 'pr', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(prStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(verifyStepId, [
+      'STATUS: retry',
+      'ISSUES: verifier found a mismatch',
+    ].join('\n'));
+
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const fix = db.prepare("SELECT status FROM steps WHERE id = ?").get(fixStepId) as { status: string };
+    const verify = db.prepare("SELECT status, retry_count FROM steps WHERE id = ?").get(verifyStepId) as { status: string; retry_count: number };
+    const pr = db.prepare("SELECT status FROM steps WHERE id = ?").get(prStepId) as { status: string };
+    const run = db.prepare("SELECT status, context FROM runs WHERE id = ?").get(runId) as { status: string; context: string };
+    const updatedContext = JSON.parse(run.context) as Record<string, string>;
+
+    assert.equal(fix.status, "pending");
+    assert.equal(verify.status, "waiting");
+    assert.equal(verify.retry_count, 1);
+    assert.equal(pr.status, "waiting");
+    assert.equal(run.status, "running");
+    assert.equal(updatedContext.verify_feedback, "verifier found a mismatch");
+    assert.equal(updatedContext.status, "retry");
+  });
+});

--- a/tests/smoke-task-contract.test.ts
+++ b/tests/smoke-task-contract.test.ts
@@ -31,7 +31,7 @@ describe("workflow task contract guidance", () => {
   });
 
   it("smoke task keeps the no-build edge case explicit", () => {
-    const smokeTask = fs.readFileSync(path.join(ROOT, "tmp", "smoke-task.txt"), "utf8");
+    const smokeTask = fs.readFileSync(path.join(ROOT, "tests", "fixtures", "smoke-task.txt"), "utf8");
     assert.match(smokeTask, /build command passes if present/i);
   });
 });

--- a/tests/smoke-task-contract.test.ts
+++ b/tests/smoke-task-contract.test.ts
@@ -1,0 +1,37 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import fs from "node:fs";
+import { loadWorkflowSpec } from "../dist/installer/workflow-spec.js";
+
+const ROOT = path.resolve(import.meta.dirname, "..");
+
+describe("workflow task contract guidance", () => {
+  for (const workflowId of ["bug-fix", "feature-dev", "security-audit"]) {
+    it(`${workflowId} docs mention acceptance criteria in operator guidance`, async () => {
+      const spec = await loadWorkflowSpec(path.join(ROOT, "workflows", workflowId));
+      const joined = spec.steps.map((s) => s.input).join("\n\n").toLowerCase();
+      assert.match(joined, /acceptance criteria|regression test|verify|verified/);
+    });
+  }
+
+  for (const workflowId of ["bug-fix", "feature-dev", "security-audit"]) {
+    it(`${workflowId} verifier step carries BUILD_CMD when it asks for build/typecheck`, async () => {
+      const spec = await loadWorkflowSpec(path.join(ROOT, "workflows", workflowId));
+      const verifyStep = spec.steps.find((step) => step.id === "verify");
+      assert.ok(verifyStep, `${workflowId} should define a verify step`);
+      assert.match(verifyStep!.input, /BUILD_CMD: \{\{build_cmd\}\}/);
+    });
+  }
+
+  it("shared setup guidance tolerates repos without a build command", () => {
+    const setupGuidance = fs.readFileSync(path.join(ROOT, "agents", "shared", "setup", "AGENTS.md"), "utf8");
+    assert.match(setupGuidance, /BUILD_CMD: none/i);
+    assert.match(setupGuidance, /no build command found/i);
+  });
+
+  it("smoke task keeps the no-build edge case explicit", () => {
+    const smokeTask = fs.readFileSync(path.join(ROOT, "tmp", "smoke-task.txt"), "utf8");
+    assert.match(smokeTask, /build command passes if present/i);
+  });
+});

--- a/tests/step-contract-validation.test.ts
+++ b/tests/step-contract-validation.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { claimStep, completeStep } from "../dist/installer/step-ops.js";
+
+describe("step contract validation", () => {
+  const testRunIds: string[] = [];
+  const tempRepos: string[] = [];
+
+  afterEach(() => {
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+
+    for (const repo of tempRepos) {
+      rmSync(repo, { recursive: true, force: true });
+    }
+    tempRepos.length = 0;
+  });
+
+  it("does not advance a step when completion omits STATUS", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const setupStepId = randomUUID();
+    const fixStepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo: "/tmp/repo", branch: "bugfix/test" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'setup', 'bug-fix_setup', 2, 'setup', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(setupStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', 'bug-fix_fixer', 3, 'fix {{build_cmd}} {{test_cmd}}', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(fixStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(setupStepId, "BUILD_CMD: npm run build\nTEST_CMD: npm test");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const setup = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(setupStepId) as { status: string; retry_count: number; output: string };
+    const fix = db.prepare("SELECT status FROM steps WHERE id = ?").get(fixStepId) as { status: string };
+    const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+
+    assert.equal(setup.status, "pending");
+    assert.equal(setup.retry_count, 1);
+    assert.match(setup.output, /missing STATUS/i);
+    assert.equal(fix.status, "waiting");
+    assert.equal(run.status, "running");
+  });
+
+  it("rejects missing STATUS even when prior run context already has status=done", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const stepId = randomUUID();
+    const nextStepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo: "/tmp/repo", branch: "bugfix/test", status: "done", verified: "old value" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(stepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'pr', 'bug-fix_pr', 1, 'pr', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(nextStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(stepId, "VERIFIED: current output but no status");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const step = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; output: string };
+    const next = db.prepare("SELECT status FROM steps WHERE id = ?").get(nextStepId) as { status: string };
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };
+    const context = JSON.parse(run.context) as Record<string, string>;
+
+    assert.equal(step.status, "pending");
+    assert.equal(step.retry_count, 1);
+    assert.match(step.output, /missing STATUS/i);
+    assert.equal(next.status, "waiting");
+    assert.equal(context.status, "done");
+    assert.equal(context.verified, "old value");
+  });
+
+  it("fails closed when retry_step target is missing", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const stepId = randomUUID();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo: "/tmp/repo", branch: "bugfix/test" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, ?, ?, 'single')`
+    ).run(stepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(stepId, "STATUS: retry\nISSUES: not good");
+    assert.deepEqual(result, { advanced: false, runCompleted: false });
+
+    const step = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; output: string };
+    const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+
+    assert.equal(step.status, "failed");
+    assert.equal(step.retry_count, 1);
+    assert.match(step.output, /Invalid workflow retry target/i);
+    assert.equal(run.status, "failed");
+  });
+
+  it("backfills build and test commands during claimStep before template resolution", () => {
+    const repo = mkdtempSync(path.join(tmpdir(), "antfarm-claim-backfill-"));
+    tempRepos.push(repo);
+
+    writeFileSync(path.join(repo, "package.json"), JSON.stringify({
+      name: "claim-backfill-test",
+      version: "1.0.0",
+      scripts: {
+        build: "node -e \"console.log('build ok')\"",
+        test: "node --test",
+      },
+    }, null, 2));
+    execFileSync("git", ["init", "-b", "main"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["add", "package.json"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"], { cwd: repo, stdio: "ignore" });
+    execFileSync("git", ["checkout", "-b", "bugfix/claim-backfill"], { cwd: repo, stdio: "ignore" });
+
+    const db = getDb();
+    const runId = randomUUID();
+    const fixStepId = randomUUID();
+    const fixerAgentId = `test-fixer-${randomUUID().slice(0, 8)}`;
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, JSON.stringify({ repo, branch: "main" }), now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'fix', ?, 3, 'BUILD={{build_cmd}} TEST={{test_cmd}}', 'STATUS: done', 'pending', 0, 2, ?, ?, 'single')`
+    ).run(fixStepId, runId, fixerAgentId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = claimStep(fixerAgentId);
+    assert.equal(result.found, true);
+    assert.match(result.resolvedInput ?? "", /BUILD=npm run build/);
+    assert.match(result.resolvedInput ?? "", /TEST=npm test/);
+    assert.equal(result.cwd, repo);
+  });
+});

--- a/tests/step-contract-validation.test.ts
+++ b/tests/step-contract-validation.test.ts
@@ -26,7 +26,7 @@ describe("step contract validation", () => {
     tempRepos.length = 0;
   });
 
-  it("does not advance a step when completion omits STATUS", () => {
+  it("does not advance a step when completion omits STATUS", async () => {
     const db = getDb();
     const runId = randomUUID();
     const setupStepId = randomUUID();
@@ -50,7 +50,7 @@ describe("step contract validation", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(setupStepId, "BUILD_CMD: npm run build\nTEST_CMD: npm test");
+    const result = await completeStep(setupStepId, "BUILD_CMD: npm run build\nTEST_CMD: npm test");
     assert.deepEqual(result, { advanced: false, runCompleted: false });
 
     const setup = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(setupStepId) as { status: string; retry_count: number; output: string };
@@ -64,7 +64,7 @@ describe("step contract validation", () => {
     assert.equal(run.status, "running");
   });
 
-  it("rejects missing STATUS even when prior run context already has status=done", () => {
+  it("rejects missing STATUS even when prior run context already has status=done", async () => {
     const db = getDb();
     const runId = randomUUID();
     const stepId = randomUUID();
@@ -88,7 +88,7 @@ describe("step contract validation", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(stepId, "VERIFIED: current output but no status");
+    const result = await completeStep(stepId, "VERIFIED: current output but no status");
     assert.deepEqual(result, { advanced: false, runCompleted: false });
 
     const step = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; output: string };
@@ -104,7 +104,7 @@ describe("step contract validation", () => {
     assert.equal(context.verified, "old value");
   });
 
-  it("fails closed when retry_step target is missing", () => {
+  it("fails closed when retry_step target is missing", async () => {
     const db = getDb();
     const runId = randomUUID();
     const stepId = randomUUID();
@@ -122,7 +122,7 @@ describe("step contract validation", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(stepId, "STATUS: retry\nISSUES: not good");
+    const result = await completeStep(stepId, "STATUS: retry\nISSUES: not good");
     assert.deepEqual(result, { advanced: false, runCompleted: false });
 
     const step = db.prepare("SELECT status, retry_count, output FROM steps WHERE id = ?").get(stepId) as { status: string; retry_count: number; output: string };

--- a/tests/timeout-thresholds.test.ts
+++ b/tests/timeout-thresholds.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { cleanupAbandonedSteps } from "../dist/installer/step-ops.js";
+import { checkStalledRuns, checkStuckSteps } from "../dist/medic/checks.js";
+
+describe("per-step timeout thresholds", () => {
+  const testRunIds: string[] = [];
+
+  afterEach(() => {
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM stories WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+  });
+
+  it("cleanupAbandonedSteps respects timeout_seconds per step", () => {
+    const db = getDb();
+    const now = new Date();
+    const stale = new Date(now.getTime() - 11 * 60 * 1000).toISOString();
+
+    const fastRunId = randomUUID();
+    const slowRunId = randomUUID();
+    const fastStepId = randomUUID();
+    const slowStepId = randomUUID();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fast timeout', 'running', '{}', ?, ?)`
+    ).run(fastRunId, stale, stale);
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'slow timeout', 'running', '{}', ?, ?)`
+    ).run(slowRunId, stale, stale);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, timeout_seconds, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, 60, ?, ?, 'single')`
+    ).run(fastStepId, fastRunId, stale, stale);
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, timeout_seconds, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, 1800, ?, ?, 'single')`
+    ).run(slowStepId, slowRunId, stale, stale);
+
+    testRunIds.push(fastRunId, slowRunId);
+
+    cleanupAbandonedSteps();
+
+    const fast = db.prepare("SELECT status, abandoned_count FROM steps WHERE id = ?").get(fastStepId) as { status: string; abandoned_count: number };
+    const slow = db.prepare("SELECT status, abandoned_count FROM steps WHERE id = ?").get(slowStepId) as { status: string; abandoned_count: number };
+
+    assert.equal(fast.status, "pending");
+    assert.equal(fast.abandoned_count, 1);
+    assert.equal(slow.status, "running");
+    assert.equal(slow.abandoned_count, 0);
+  });
+
+  it("medic checks use timeout_seconds instead of one global max", () => {
+    const db = getDb();
+    const now = new Date();
+    const stale30m = new Date(now.getTime() - 30 * 60 * 1000).toISOString();
+
+    const fastRunId = randomUUID();
+    const slowRunId = randomUUID();
+    const fastStepId = randomUUID();
+    const slowStepId = randomUUID();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fast medic timeout', 'running', '{}', ?, ?)`
+    ).run(fastRunId, stale30m, stale30m);
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'slow medic timeout', 'running', '{}', ?, ?)`
+    ).run(slowRunId, stale30m, stale30m);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, timeout_seconds, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, 300, ?, ?, 'single')`
+    ).run(fastStepId, fastRunId, stale30m, stale30m);
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, timeout_seconds, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 0, 'verify', 'STATUS: done', 'running', 0, 2, 1800, ?, ?, 'single')`
+    ).run(slowStepId, slowRunId, stale30m, stale30m);
+
+    testRunIds.push(fastRunId, slowRunId);
+
+    const stuck = checkStuckSteps();
+    const stalled = checkStalledRuns();
+
+    assert.ok(stuck.some((finding) => finding.runId === fastRunId), "short-timeout step should be flagged stuck");
+    assert.ok(!stuck.some((finding) => finding.runId === slowRunId), "long-timeout step should not be flagged stuck yet");
+    assert.ok(stalled.some((finding) => finding.runId === fastRunId), "short-timeout run should be flagged stalled");
+    assert.ok(!stalled.some((finding) => finding.runId === slowRunId), "long-timeout run should not be flagged stalled yet");
+  });
+});

--- a/tests/verify-output-context.test.ts
+++ b/tests/verify-output-context.test.ts
@@ -16,7 +16,7 @@ describe("verify output context propagation", () => {
     testRunIds.length = 0;
   });
 
-  it("stores VERIFIED output in run context so downstream PR steps can resolve it", () => {
+  it("stores VERIFIED output in run context so downstream PR steps can resolve it", async () => {
     const db = getDb();
     const runId = randomUUID();
     const now = new Date().toISOString();
@@ -50,7 +50,7 @@ describe("verify output context propagation", () => {
 
     testRunIds.push(runId);
 
-    const result = completeStep(verifyStepId, [
+    const result = await completeStep(verifyStepId, [
       "STATUS: done",
       "VERIFIED: confirmed fix matches root cause and regression test fails without it",
     ].join("\n"));

--- a/tests/verify-output-context.test.ts
+++ b/tests/verify-output-context.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { completeStep } from "../dist/installer/step-ops.js";
+
+describe("verify output context propagation", () => {
+  const testRunIds: string[] = [];
+
+  afterEach(() => {
+    const db = getDb();
+    for (const runId of testRunIds) {
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    testRunIds.length = 0;
+  });
+
+  it("stores VERIFIED output in run context so downstream PR steps can resolve it", () => {
+    const db = getDb();
+    const runId = randomUUID();
+    const now = new Date().toISOString();
+    const verifyStepId = randomUUID();
+    const prStepId = randomUUID();
+
+    const context = JSON.stringify({
+      repo: "/tmp/repo",
+      branch: "bugfix/test",
+      test_cmd: "npm test",
+      changes: "updated math.js",
+      regression_test: "added regression test",
+      root_cause: "bad operator",
+      problem_statement: "add subtracts",
+    });
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'bug-fix', 'fix bug', 'running', ?, ?, ?)`
+    ).run(runId, context, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'verify', 'bug-fix_verifier', 4, 'verify', 'STATUS: done', 'running', 0, 3, ?, ?, 'single')`
+    ).run(verifyStepId, runId, now, now);
+
+    db.prepare(
+      `INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, retry_count, max_retries, created_at, updated_at, type)
+       VALUES (?, ?, 'pr', 'bug-fix_pr', 5, 'VERIFIED: {{verified}}', 'STATUS: done', 'waiting', 0, 2, ?, ?, 'single')`
+    ).run(prStepId, runId, now, now);
+
+    testRunIds.push(runId);
+
+    const result = completeStep(verifyStepId, [
+      "STATUS: done",
+      "VERIFIED: confirmed fix matches root cause and regression test fails without it",
+    ].join("\n"));
+
+    assert.deepEqual(result, { advanced: true, runCompleted: false });
+
+    const run = db.prepare("SELECT context FROM runs WHERE id = ?").get(runId) as { context: string };
+    const updatedContext = JSON.parse(run.context) as Record<string, string>;
+    assert.equal(
+      updatedContext.verified,
+      "confirmed fix matches root cause and regression test fails without it",
+    );
+  });
+});

--- a/tests/work-prompt.test.ts
+++ b/tests/work-prompt.test.ts
@@ -30,6 +30,13 @@ describe("buildWorkPrompt", () => {
     assert.ok(!prompt.includes("NO_WORK"));
   });
 
+  it("does not hardcode workflow-conflicting output keys", () => {
+    const prompt = buildWorkPrompt("bug-fix", "triager");
+    assert.ok(!prompt.includes("CHANGES: what you did"));
+    assert.ok(!prompt.includes("TESTS: what tests you ran"));
+    assert.ok(prompt.includes("exact KEY: value lines required by the claimed step input"));
+  });
+
   it("works with different workflow/agent ids without errors", () => {
     const p1 = buildWorkPrompt("security-audit", "scanner");
     const p2 = buildWorkPrompt("bug-fix", "fixer");

--- a/tests/workflow-smoke-e2e.test.ts
+++ b/tests/workflow-smoke-e2e.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, it, mock } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { getDb } from "../dist/db.js";
+import { runWorkflow } from "../dist/installer/run.js";
+import { claimStep, completeStep } from "../dist/installer/step-ops.js";
+import { getWorkflowStatus } from "../dist/installer/status.js";
+
+const WORKFLOW_ID = `smoke-${randomUUID().slice(0, 8)}`;
+const WORKFLOW_DIR = path.join(os.homedir(), ".openclaw", "antfarm", "workflows", WORKFLOW_ID);
+
+describe("workflow smoke e2e", () => {
+  let repoDir: string;
+  let originalCwd: string;
+  let originalFetch: typeof globalThis.fetch;
+  let capturedJobs: any[];
+  const createdRunIds: string[] = [];
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    capturedJobs = [];
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = mock.fn(async (_url: any, opts: any) => {
+      const body = JSON.parse(opts.body);
+      if (body.args?.job) capturedJobs.push(body.args.job);
+      return {
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, result: { id: `job-${capturedJobs.length}` } }),
+        text: async () => "ok",
+      };
+    }) as any;
+
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-smoke-repo-"));
+    execFileSync("git", ["init", "-b", "main"], { cwd: repoDir, stdio: "ignore" });
+    fs.writeFileSync(path.join(repoDir, "README.md"), "# smoke test\n");
+    fs.writeFileSync(
+      path.join(repoDir, "package.json"),
+      JSON.stringify({
+        name: "antfarm-smoke-repo",
+        version: "1.0.0",
+        scripts: {
+          test: "node --test",
+        },
+      }, null, 2),
+    );
+    execFileSync("git", ["add", "."], { cwd: repoDir, stdio: "ignore" });
+    execFileSync(
+      "git",
+      ["-c", "user.name=Test", "-c", "user.email=test@example.com", "commit", "-m", "init"],
+      { cwd: repoDir, stdio: "ignore" },
+    );
+    execFileSync("git", ["checkout", "-b", "smoke/e2e"], { cwd: repoDir, stdio: "ignore" });
+
+    fs.mkdirSync(WORKFLOW_DIR, { recursive: true });
+    fs.writeFileSync(
+      path.join(WORKFLOW_DIR, "workflow.yml"),
+      `id: ${WORKFLOW_ID}
+name: Smoke E2E
+version: 1
+polling:
+  model: default
+  timeoutSeconds: 120
+agents:
+  - id: starter
+    workspace:
+      baseDir: agents/starter
+      files:
+        AGENTS.md: ./workflow.yml
+  - id: finisher
+    workspace:
+      baseDir: agents/finisher
+      files:
+        AGENTS.md: ./workflow.yml
+steps:
+  - id: start
+    agent: starter
+    input: |
+      Start the smoke run.
+
+      TASK: {{task}}
+      REPO: {{repo}}
+
+      Reply with:
+      STATUS: done
+      NOTE: smoke started
+    expects: "STATUS: done"
+  - id: finish
+    agent: finisher
+    input: |
+      Finish the smoke run.
+
+      TASK: {{task}}
+      NOTE: {{note}}
+
+      Reply with:
+      STATUS: done
+      VERIFIED: smoke finished
+    expects: "STATUS: done"
+`,
+    );
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    globalThis.fetch = originalFetch;
+
+    const db = getDb();
+    for (const runId of createdRunIds) {
+      db.prepare("DELETE FROM stories WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM steps WHERE run_id = ?").run(runId);
+      db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
+    }
+    createdRunIds.length = 0;
+
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(WORKFLOW_DIR, { recursive: true, force: true });
+  });
+
+  it("runs a tiny workflow from run -> claim -> complete -> completed", async () => {
+    process.chdir(repoDir);
+
+    const run = await runWorkflow({
+      workflowId: WORKFLOW_ID,
+      taskTitle: "smoke e2e workflow",
+    });
+    createdRunIds.push(run.id);
+
+    assert.equal(run.status, "running");
+    assert.equal(capturedJobs.length, 2, "should create one cron per workflow agent");
+
+    const firstClaim = claimStep(`${WORKFLOW_ID}_starter`);
+    assert.equal(firstClaim.found, true, "starter step should be claimable");
+    assert.match(firstClaim.resolvedInput ?? "", /TASK: smoke e2e workflow/);
+    assert.equal(fs.realpathSync(firstClaim.cwd!), fs.realpathSync(repoDir));
+
+    const firstComplete = completeStep(firstClaim.stepId!, "STATUS: done\nNOTE: smoke started");
+    assert.deepEqual(firstComplete, { advanced: true, runCompleted: false });
+
+    const secondClaim = claimStep(`${WORKFLOW_ID}_finisher`);
+    assert.equal(secondClaim.found, true, "finisher step should be claimable after pipeline advance");
+    assert.match(secondClaim.resolvedInput ?? "", /NOTE: smoke started/);
+
+    const secondComplete = completeStep(secondClaim.stepId!, "STATUS: done\nVERIFIED: smoke finished");
+    assert.deepEqual(secondComplete, { advanced: false, runCompleted: true });
+
+    const status = getWorkflowStatus(run.id);
+    assert.equal(status.status, "ok");
+    if (status.status !== "ok") throw new Error("run status missing");
+    assert.equal(status.run.status, "completed");
+    assert.deepEqual(status.steps.map((step) => step.status), ["done", "done"]);
+  });
+});

--- a/tests/workflow-smoke-e2e.test.ts
+++ b/tests/workflow-smoke-e2e.test.ts
@@ -138,14 +138,14 @@ steps:
     assert.match(firstClaim.resolvedInput ?? "", /TASK: smoke e2e workflow/);
     assert.equal(fs.realpathSync(firstClaim.cwd!), fs.realpathSync(repoDir));
 
-    const firstComplete = completeStep(firstClaim.stepId!, "STATUS: done\nNOTE: smoke started");
+    const firstComplete = await completeStep(firstClaim.stepId!, "STATUS: done\nNOTE: smoke started");
     assert.deepEqual(firstComplete, { advanced: true, runCompleted: false });
 
     const secondClaim = claimStep(`${WORKFLOW_ID}_finisher`);
     assert.equal(secondClaim.found, true, "finisher step should be claimable after pipeline advance");
     assert.match(secondClaim.resolvedInput ?? "", /NOTE: smoke started/);
 
-    const secondComplete = completeStep(secondClaim.stepId!, "STATUS: done\nVERIFIED: smoke finished");
+    const secondComplete = await completeStep(secondClaim.stepId!, "STATUS: done\nVERIFIED: smoke finished");
     assert.deepEqual(secondComplete, { advanced: false, runCompleted: true });
 
     const status = getWorkflowStatus(run.id);

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -186,9 +186,6 @@ steps:
       FIX_APPROACH: {{fix_approach}}
       PROBLEM_STATEMENT: {{problem_statement}}
 
-      VERIFY FEEDBACK (if retrying):
-      {{verify_feedback}}
-
       Instructions:
       1. cd into the repo, checkout the branch
       2. Implement the fix based on the root cause and fix approach
@@ -200,7 +197,7 @@ steps:
       Reply with:
       STATUS: done
       CHANGES: what was changed
-      REGRESSION_TEST: what test was added
+      REGRESSION_TEST: what test was added (or "N/A" if not applicable)
     expects: "STATUS: done"
     max_retries: 2
     on_fail:
@@ -219,7 +216,7 @@ steps:
       BUILD_CMD: {{build_cmd}}
       TEST_CMD: {{test_cmd}}
       CHANGES: {{changes}}
-      REGRESSION_TEST: {{regression_test}}
+      REGRESSION_TEST: {{regression_test|N/A — not applicable}}
       ROOT_CAUSE: {{root_cause}}
       PROBLEM_STATEMENT: {{problem_statement}}
 
@@ -269,7 +266,7 @@ steps:
       SEVERITY: {{severity}}
       ROOT_CAUSE: {{root_cause}}
       CHANGES: {{changes}}
-      REGRESSION_TEST: {{regression_test}}
+      REGRESSION_TEST: {{regression_test|N/A — not applicable}}
       VERIFIED: {{verified}}
 
       PR title format: fix: brief description of what was fixed
@@ -288,7 +285,7 @@ steps:
       {{changes}}
 
       ## Regression Test
-      {{regression_test}}
+      {{regression_test|N/A — not applicable}}
 
       ## Verification
       {{verified}}

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -209,7 +209,7 @@ steps:
       BRANCH: {{branch}}
       TEST_CMD: {{test_cmd}}
       CHANGES: {{changes}}
-      REGRESSION_TEST: {{regression_test}}
+      REGRESSION_TEST: {{regression_test|N/A — not applicable}}
       ROOT_CAUSE: {{root_cause}}
       PROBLEM_STATEMENT: {{problem_statement}}
 
@@ -258,7 +258,7 @@ steps:
       SEVERITY: {{severity}}
       ROOT_CAUSE: {{root_cause}}
       CHANGES: {{changes}}
-      REGRESSION_TEST: {{regression_test}}
+      REGRESSION_TEST: {{regression_test|N/A — not applicable}}
       VERIFIED: {{verified}}
 
       PR title format: fix: brief description of what was fixed
@@ -277,7 +277,7 @@ steps:
       {{changes}}
 
       ## Regression Test
-      {{regression_test}}
+      {{regression_test|N/A — not applicable}}
 
       ## Verification
       {{verified}}

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -9,7 +9,7 @@ description: |
   PR agent creates the pull request.
 
 polling:
-  model: default
+  model: anthropic/claude-sonnet-4-20250514
   timeoutSeconds: 120
 
 agents:
@@ -147,7 +147,7 @@ steps:
 
       Instructions:
       1. cd into the repo
-      2. Create the bugfix branch (git checkout -b {{branch}} from main)
+      2. Create a git worktree: git worktree add {{repo}}-{{branch}} -b {{branch}} main (if branch exists: git worktree add {{repo}}-{{branch}} {{branch}}). All work happens in the worktree dir, NOT the original repo. Copy .env if it exists. Run npm install. Include WORKTREE_DIR in output.
       3. Read package.json, CI config, test config to understand build/test setup
       4. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
       5. Run the build to establish a baseline
@@ -180,13 +180,10 @@ steps:
       FIX_APPROACH: {{fix_approach}}
       PROBLEM_STATEMENT: {{problem_statement}}
 
-      VERIFY FEEDBACK (if retrying):
-      {{verify_feedback}}
-
       Instructions:
       1. cd into the repo, checkout the branch
       2. Implement the fix based on the root cause and fix approach
-      3. Write a regression test that would have caught this bug
+      3. Write a regression test that would have caught this bug (if applicable — for refactors/removals, skip this)
       4. Run {{build_cmd}} to verify the build passes
       5. Run {{test_cmd}} to verify all tests pass
       6. Commit: fix: brief description of the fix
@@ -194,7 +191,7 @@ steps:
       Reply with:
       STATUS: done
       CHANGES: what was changed
-      REGRESSION_TEST: what test was added
+      REGRESSION_TEST: what test was added (or "N/A" if not applicable)
     expects: "STATUS: done"
     max_retries: 2
     on_fail:

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -88,17 +88,21 @@ steps:
       BUG REPORT:
       {{task}}
 
+      REPO:
+      {{repo}}
+
       Instructions:
       1. Read the bug report carefully
-      2. Explore the codebase to find the affected area
-      3. Attempt to reproduce: run tests, check for failing cases, read error logs/stack traces
-      4. Classify severity (critical/high/medium/low)
-      5. Document findings
+      2. Use {{repo}} as the target repository for all code exploration and reproduction commands
+      3. Explore the codebase to find the affected area
+      4. Attempt to reproduce: run tests, check for failing cases, read error logs/stack traces
+      5. Classify severity (critical/high/medium/low)
+      6. Document findings
 
       Reply with:
       STATUS: done
-      REPO: /path/to/repo
-      BRANCH: bugfix-branch-name
+      REPO: {{repo}}
+      BRANCH: bugfix-branch-name (must be a new non-main branch name, never "main" or "master")
       SEVERITY: critical|high|medium|low
       AFFECTED_AREA: what files/modules are affected
       REPRODUCTION: how to reproduce the bug
@@ -147,15 +151,17 @@ steps:
 
       Instructions:
       1. cd into the repo
-      2. Create the bugfix branch (git checkout -b {{branch}} from main)
-      3. Read package.json, CI config, test config to understand build/test setup
-      4. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
-      5. Run the build to establish a baseline
-      6. Run the tests to establish a baseline
+      2. Determine the actual bugfix branch to use. If {{branch}} is empty, "main", or "master", generate a new descriptive branch name like bugfix/fix-add-implementation.
+      3. Check out that bugfix branch from main. Never do bug-fix work on main/master.
+      4. Read package.json, CI config, test config to understand build/test setup
+      5. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
+      6. Run the build/typecheck command to establish a baseline if one exists. If not, record BUILD_CMD as none.
+      7. Run the tests to establish a baseline
 
       Reply with:
       STATUS: done
-      BUILD_CMD: <build command>
+      BRANCH: <actual bugfix branch checked out>
+      BUILD_CMD: <build command or none>
       TEST_CMD: <test command>
       BASELINE: <baseline status>
     expects: "STATUS: done"
@@ -187,7 +193,7 @@ steps:
       1. cd into the repo, checkout the branch
       2. Implement the fix based on the root cause and fix approach
       3. Write a regression test that would have caught this bug
-      4. Run {{build_cmd}} to verify the build passes
+      4. If {{build_cmd}} is not "none", run it to verify the build/typecheck passes. Otherwise note that no build command exists.
       5. Run {{test_cmd}} to verify all tests pass
       6. Commit: fix: brief description of the fix
 
@@ -210,6 +216,7 @@ steps:
 
       REPO: {{repo}}
       BRANCH: {{branch}}
+      BUILD_CMD: {{build_cmd}}
       TEST_CMD: {{test_cmd}}
       CHANGES: {{changes}}
       REGRESSION_TEST: {{regression_test}}
@@ -218,10 +225,11 @@ steps:
 
       Instructions:
       1. Run the full test suite with {{test_cmd}}
-      2. Confirm the regression test exists and tests the right thing
-      3. Review the fix to confirm it addresses the root cause
-      4. Check for unintended side effects
-      5. Verify the regression test would fail without the fix (review the diff logic)
+      2. If {{build_cmd}} is not "none", run the build/typecheck with {{build_cmd}}. Otherwise confirm the repo has no build command.
+      3. Confirm the regression test exists and tests the right thing
+      4. Review the fix to confirm it addresses the root cause
+      5. Check for unintended side effects
+      6. Verify the regression test would fail without the fix (review the diff logic)
 
       MANDATORY first step:
       - Run `git diff main..{{branch}} --stat` and `git diff main..{{branch}}`

--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -130,7 +130,7 @@ steps:
 
       Instructions:
       1. cd into the repo
-      2. Create the feature branch (git checkout -b {{branch}})
+      2. Create a git worktree: git worktree add {{repo}}-{{branch}} -b {{branch}} main (if branch exists: git worktree add {{repo}}-{{branch}} {{branch}}). All work happens in the worktree dir, NOT the original repo. Copy .env if it exists. Run npm install. Include WORKTREE_DIR in output.
       3. Read package.json, CI config, test config to understand the build/test setup
       4. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
       5. Run the build/typecheck command to establish a baseline if one exists. If not, record BUILD_CMD as none.

--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -10,7 +10,7 @@ description: |
   Then integration/E2E testing, PR creation, and code review.
 
 polling:
-  model: default
+  model: anthropic/claude-sonnet-4-20250514
   timeoutSeconds: 120
 
 agents:
@@ -126,7 +126,7 @@ steps:
 
       Instructions:
       1. cd into the repo
-      2. Create the feature branch (git checkout -b {{branch}})
+      2. Create a git worktree: git worktree add {{repo}}-{{branch}} -b {{branch}} main (if branch exists: git worktree add {{repo}}-{{branch}} {{branch}}). All work happens in the worktree dir, NOT the original repo. Copy .env if it exists. Run npm install. Include WORKTREE_DIR in output.
       3. Read package.json, CI config, test config to understand the build/test setup
       4. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
       5. Run the build to establish a baseline

--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -93,19 +93,23 @@ steps:
       TASK:
       {{task}}
 
+      REPO:
+      {{repo}}
+
       Instructions:
-      1. Explore the codebase to understand the stack, conventions, and patterns
-      2. Break the task into small user stories (max 20)
-      3. Order by dependency: schema/DB first, backend, frontend, integration
-      4. Each story must fit in one developer session (one context window)
-      5. Every acceptance criterion must be mechanically verifiable
-      6. Always include "Typecheck passes" as the last criterion in every story
-      7. Every story MUST include test criteria — "Tests for [feature] pass"
-      8. The developer is expected to write tests as part of each story
+      1. Use {{repo}} as the target repository for all code exploration
+      2. Explore the codebase to understand the stack, conventions, and patterns
+      3. Break the task into small user stories (max 20)
+      4. Order by dependency: schema/DB first, backend, frontend, integration
+      5. Each story must fit in one developer session (one context window)
+      6. Every acceptance criterion must be mechanically verifiable
+      7. Always include "Typecheck passes" as the last criterion in every story
+      8. Every story MUST include test criteria — "Tests for [feature] pass"
+      9. The developer is expected to write tests as part of each story
 
       Reply with:
       STATUS: done
-      REPO: /path/to/repo
+      REPO: {{repo}}
       BRANCH: feature-branch-name
       STORIES_JSON: [ ... array of story objects ... ]
     expects: "STATUS: done"
@@ -129,13 +133,13 @@ steps:
       2. Create the feature branch (git checkout -b {{branch}})
       3. Read package.json, CI config, test config to understand the build/test setup
       4. Ensure .gitignore exists — if missing, create one appropriate for the detected stack (must include .env, node_modules/, *.key, *.pem at minimum)
-      5. Run the build to establish a baseline
+      5. Run the build/typecheck command to establish a baseline if one exists. If not, record BUILD_CMD as none.
       6. Run the tests to establish a baseline
       7. Report what you found
 
       Reply with:
       STATUS: done
-      BUILD_CMD: <build command>
+      BUILD_CMD: <build command or none>
       TEST_CMD: <test command>
       CI_NOTES: <brief CI notes>
       BASELINE: <baseline status>
@@ -183,7 +187,7 @@ steps:
       2. Pull latest on the branch
       3. Implement this story only
       4. Write tests for this story's functionality
-      5. Run typecheck / build
+      5. If {{build_cmd}} is not "none", run typecheck/build. Otherwise note that no build command exists.
       6. Run tests to confirm they pass
       7. Commit: feat: {{current_story_id}} - {{current_story_title}}
       8. Rewrite progress-{{run_id}}.txt with updated story results and patterns
@@ -209,6 +213,7 @@ steps:
       REPO: {{repo}}
       BRANCH: {{branch}}
       CHANGES: {{changes}}
+      BUILD_CMD: {{build_cmd}}
       TEST_CMD: {{test_cmd}}
 
       CURRENT STORY:
@@ -223,7 +228,7 @@ steps:
       3. Tests were written for this story's functionality
       4. Tests pass (run {{test_cmd}})
       5. No obvious incomplete work
-      6. Typecheck passes
+      6. If {{build_cmd}} is not "none", build/typecheck passes (run {{build_cmd}}). Otherwise confirm there is no build command.
 
       ## Visual Verification (Frontend Changes)
       Has frontend changes: {{has_frontend_changes}}

--- a/workflows/security-audit/workflow.yml
+++ b/workflows/security-audit/workflow.yml
@@ -9,7 +9,7 @@ description: |
   Verifier confirms each fix. Tester runs final integration validation. PR agent creates the pull request.
 
 polling:
-  model: default
+  model: anthropic/claude-sonnet-4-20250514
   timeoutSeconds: 120
 
 agents:
@@ -179,10 +179,19 @@ steps:
 
       Instructions:
       1. cd into the repo
-      2. Create the security branch (git checkout -b {{branch}} from main)
-      3. Read package.json, CI config, test config to understand build/test setup
-      4. Run the build to establish a baseline
-      5. Run the tests to establish a baseline
+      2. Create a git worktree for this workflow:
+         - WORKTREE_DIR = {{repo}}-{{branch}} (e.g., /Users/moltbot/projects/boss-security-fixes)
+         - Run: git worktree add {{repo}}-{{branch}} -b {{branch}} main
+         - If the branch already exists: git worktree add {{repo}}-{{branch}} {{branch}}
+         - All subsequent work happens in the WORKTREE_DIR, NOT the original repo
+      3. cd into the worktree directory
+      4. If a .env file exists in the original repo, copy it: cp {{repo}}/.env {{repo}}-{{branch}}/.env
+      5. Run npm install (or equivalent) in the worktree
+      6. Read package.json, CI config, test config to understand build/test setup
+      7. Run the build to establish a baseline
+      8. Run the tests to establish a baseline
+      
+      IMPORTANT: Include WORKTREE_DIR in your output so subsequent steps know where to work.
 
       Reply with:
       STATUS: done

--- a/workflows/security-audit/workflow.yml
+++ b/workflows/security-audit/workflow.yml
@@ -99,12 +99,16 @@ steps:
       TASK:
       {{task}}
 
+      REPO:
+      {{repo}}
+
       Instructions:
-      1. Explore the codebase — understand the stack, framework, dependencies
-      2. Run `npm audit` (or equivalent) if a package manager is present
-      3. Scan for hardcoded secrets: API keys, passwords, tokens, private keys in source
-      4. Check for .env files committed to the repo
-      5. Scan for common vulnerabilities:
+      1. Use {{repo}} as the target repository for all audit commands and code exploration
+      2. Explore the codebase — understand the stack, framework, dependencies
+      3. Run `npm audit` (or equivalent) if a package manager is present
+      4. Scan for hardcoded secrets: API keys, passwords, tokens, private keys in source
+      5. Check for .env files committed to the repo
+      6. Scan for common vulnerabilities:
          - SQL injection (raw queries, string concatenation in queries)
          - XSS (unescaped user input in templates/responses)
          - CSRF (missing CSRF tokens on state-changing endpoints)
@@ -115,13 +119,13 @@ steps:
          - Missing input validation on API endpoints
          - Insecure file permissions
          - Exposed environment variables
-      6. Review auth/session handling (token expiry, session fixation, cookie flags)
-      7. Check security headers (CORS, CSP, HSTS, X-Frame-Options)
+      7. Review auth/session handling (token expiry, session fixation, cookie flags)
+      8. Check security headers (CORS, CSP, HSTS, X-Frame-Options)
       8. Document every finding with severity, file, line, and description
 
       Reply with:
       STATUS: done
-      REPO: /path/to/repo
+      REPO: {{repo}}
       BRANCH: security-audit-YYYY-MM-DD
       VULNERABILITY_COUNT: <number>
       FINDINGS: <detailed list of each vulnerability>
@@ -181,12 +185,12 @@ steps:
       1. cd into the repo
       2. Create the security branch (git checkout -b {{branch}} from main)
       3. Read package.json, CI config, test config to understand build/test setup
-      4. Run the build to establish a baseline
+      4. Run the build/typecheck command to establish a baseline if one exists. If not, record BUILD_CMD as none.
       5. Run the tests to establish a baseline
 
       Reply with:
       STATUS: done
-      BUILD_CMD: <build command>
+      BUILD_CMD: <build command or none>
       TEST_CMD: <test command>
       BASELINE: <baseline status>
     expects: "STATUS: done"
@@ -233,7 +237,7 @@ steps:
       2. Read the vulnerability description carefully
       3. Implement the fix — minimal, targeted changes only
       4. Write a regression test that verifies the vulnerability is patched
-      5. Run {{build_cmd}} to verify the build passes
+      5. If {{build_cmd}} is not "none", run it to verify the build/typecheck passes. Otherwise note that no build command exists.
       6. Run {{test_cmd}} to verify all tests pass
       7. Commit: fix(security): brief description
       8. Rewrite progress-{{run_id}}.txt with updated story results and patterns
@@ -254,6 +258,7 @@ steps:
 
       REPO: {{repo}}
       BRANCH: {{branch}}
+      BUILD_CMD: {{build_cmd}}
       TEST_CMD: {{test_cmd}}
       CHANGES: {{changes}}
       REGRESSION_TEST: {{regression_test}}
@@ -266,10 +271,11 @@ steps:
 
       Instructions:
       1. Run the full test suite with {{test_cmd}}
-      2. Confirm the regression test exists and tests the right thing
-      3. Review the fix — does it actually address the vulnerability?
-      4. Check for unintended side effects
-      5. Verify the regression test would fail without the fix
+      2. If {{build_cmd}} is not "none", run the build/typecheck with {{build_cmd}}. Otherwise confirm the repo has no build command.
+      3. Confirm the regression test exists and tests the right thing
+      4. Review the fix — does it actually address the vulnerability?
+      5. Check for unintended side effects
+      6. Verify the regression test would fail without the fix
 
       Security-specific verification — think about bypass scenarios:
       - SQL Injection: Does it handle all query patterns, not just the one found?
@@ -314,9 +320,9 @@ steps:
 
       Instructions:
       1. Run the full test suite ({{test_cmd}}) — all tests must pass
-      2. Run the build ({{build_cmd}}) — must succeed
+      2. If {{build_cmd}} is not "none", run the build/typecheck ({{build_cmd}}) — it must succeed. Otherwise confirm there is no build command.
       3. Run `npm audit` (or equivalent) again — compare before/after
-      4. Quick smoke test: does the app still start and work?
+      4. Quick smoke test if the repo has an obvious start command or documented local run path
       5. Verify no regressions from the security fixes
       6. Summarize: what improved, what remains
 


### PR DESCRIPTION
## Bug Reports & Fixes

### Bug 1: verify_each verify step is never claimed by the verifier agent

**Symptoms:** In workflows using `verify_each: true` (e.g. feature-dev), the developer step loops through stories but verification never runs. The loop step times out repeatedly (medic resets it up to 5x) then the run fails with `Medic: step abandoned too many times`. Each story gets 'done' but is never verified.

**Root cause:** The `claimStep` SQL query has a `NOT EXISTS` guard that prevents claiming any step if there's a prior step (lower `step_index`) that isn't `done` or `skipped`. In the YAML, the `verify` step is listed **after** `implement`, giving it a higher `step_index`. The loop step (`implement`) is in `running` status while iterating stories — so the guard always blocks the `verify` step from being claimed. The verifier cron always returns `NO_WORK`.

The `verify_each` mechanism sets the verify step to `pending` directly via DB manipulation after a story completes, bypassing normal pipeline ordering. But `claimStep` doesn't know about this special case.

**Fix:** Add an exemption to the `NOT EXISTS` guard: a step can be claimed even if a prior step is `running`, as long as that prior step is a `loop` type whose `loop_config.verifyStep` references this step.

```sql
AND NOT (
  prev.type = 'loop'
  AND prev.status = 'running'
  AND json_extract(prev.loop_config, '$.verifyStep') = s.step_id
)
```

---

### Bug 2: `verified` context key missing → PR step crashes

**Symptoms:** In bug-fix workflow, verifier runs and completes but the subsequent `pr` step immediately fails with:
`Step input is not ready: missing required template key(s) verified`

**Root cause:** `parseOutputKeyValues` uses regex `/^([A-Z_]+):\s*(.*)$/` which only matches ALL_CAPS keys. The verifier LLM sometimes outputs `Verified:` (mixed case) instead of `VERIFIED:`. When mixed case, the line doesn't match and `context["verified"]` is never set. The `pr` step template requires `{{verified}}`, so it crashes.

**Fix:** Relax the key regex from `[A-Z_]+` to `[A-Za-z_]+`. Keys are lowercased on storage (already the case), so the context lookup is unaffected. This makes the parser robust to mixed-case LLM output while the ALL_CAPS convention remains preferred.

---

## Impact

Both bugs caused cascading run failures requiring manual SQLite cleanup and re-runs. Bug 1 in particular is a silent correctness issue — work was being done but never verified before advancing to the next story.