### PR TITLE
fix: make workflow stop not-found message explicit + add npm test script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/server/index.html dist/server/index.html && chmod +x dist/cli/cli.js && node scripts/inject-version.js",
+    "test": "npm run build && node --test dist/**/*.test.js",
     "start": "node dist/cli/cli.js"
   },
   "dependencies": {

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -66,7 +66,7 @@ export function getWorkflowStatus(query: string): WorkflowStatusResult {
       status: "not_found",
       message: available.length
         ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
-        : "No workflow runs found.",
+        : `No run matching "${query}". No workflow runs found.`,
     };
   }
 
@@ -100,7 +100,7 @@ export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
       status: "not_found",
       message: available.length
         ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
-        : "No workflow runs found.",
+        : `No run matching "${query}". No workflow runs found.`,
     };
   }
 


### PR DESCRIPTION
## Summary
- ensure not-found responses for workflow status/stop always include the user query (even when there are zero runs)
- add `npm test` script to standardize local/CI validation (`build` + Node test runner)

## Why
- baseline tests exposed a failing expectation: non-existent run message omitted the queried id when run history was empty
- repository had tests but no package test script

## Validation
- npm ci
- npm run build
- npm test
