### PR TITLE
chore: ignore local artifact backups and progress dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist/
 *.sqlite3
 progress.txt
 progress*.txt
+
+# local/generated artifacts
+*.bak
+progress/


### PR DESCRIPTION
## Summary
- ignore generated backup artifacts (`*.bak`)
- ignore local runtime output directory (`progress/`)

## Why
- keeps working tree clean after local build/tooling runs
- reduces accidental commits of machine-local artifacts

## Validation
- npm ci
- npm run build
- node --test tests/*.ts
