### PR TITLE
fix(cli): use --timeout-seconds for cron payload timeout

### DIFF
--- a/src/installer/gateway-api.ts
+++ b/src/installer/gateway-api.ts
@@ -149,7 +149,7 @@ export async function createAgentCronJob(job: {
     }
 
     if (job.payload?.timeoutSeconds) {
-      args.push("--timeout", `${job.payload.timeoutSeconds}`);
+      args.push("--timeout-seconds", `${job.payload.timeoutSeconds}`);
     }
 
     if (job.payload?.model) {


### PR DESCRIPTION
## Summary
Fix CLI fallback timeout flag when creating cron jobs from `ensure-crons`.

## Problem
Antfarm maps `job.payload.timeoutSeconds` to OpenClaw CLI `--timeout`, but OpenClaw interprets that flag as gateway/client timeout in **milliseconds**.

This means a value like `120` (intended seconds) becomes `120ms`, causing failures such as:
- `gateway timeout after 120ms`
- `gateway client stopped`

## Fix
Use `--timeout-seconds` instead of `--timeout` when passing `job.payload.timeoutSeconds`.

## Validation
- Reproduced failure with `--timeout 120`
- Verified success with `--timeout-seconds 120`
- Verified `antfarm workflow ensure-crons wedding-speech-research` recreates all expected jobs

Closes #307
