### PR TITLE
fix: ensureWorkflowCrons creates missing crons instead of skipping all

### DIFF
--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -157,7 +157,7 @@ ${workPrompt}
 Reply with a short summary of what you spawned.`;
 }
 
-export async function setupAgentCrons(workflow: WorkflowSpec): Promise<void> {
+export async function setupAgentCrons(workflow: WorkflowSpec, onlyAgentIds?: Set<string>): Promise<void> {
   const agents = workflow.agents;
   // Allow per-workflow cron interval via cron.interval_ms in workflow.yml
   const everyMs = (workflow as any).cron?.interval_ms ?? DEFAULT_EVERY_MS;
@@ -168,6 +168,8 @@ export async function setupAgentCrons(workflow: WorkflowSpec): Promise<void> {
 
   for (let i = 0; i < agents.length; i++) {
     const agent = agents[i];
+    // Skip agents that already have crons when creating only missing ones
+    if (onlyAgentIds && !onlyAgentIds.has(agent.id)) continue;
     const anchorMs = i * 60_000; // stagger by 1 minute each
     const cronName = `antfarm/${workflow.id}/${agent.id}`;
     const agentId = `${workflow.id}_${agent.id}`;
@@ -214,21 +216,32 @@ function countActiveRuns(workflowId: string): number {
 }
 
 /**
- * Check if crons already exist for a workflow.
+ * Return the set of agent IDs that already have crons for a workflow.
+ * Cron names follow the pattern: antfarm/{workflowId}/{agentId}
  */
-async function workflowCronsExist(workflowId: string): Promise<boolean> {
+async function getExistingCronAgentIds(workflowId: string): Promise<Set<string>> {
   const result = await listCronJobs();
-  if (!result.ok || !result.jobs) return false;
+  if (!result.ok || !result.jobs) return new Set();
   const prefix = `antfarm/${workflowId}/`;
-  return result.jobs.some((j) => j.name.startsWith(prefix));
+  const ids = new Set<string>();
+  for (const job of result.jobs) {
+    if (job.name.startsWith(prefix)) {
+      ids.add(job.name.slice(prefix.length));
+    }
+  }
+  return ids;
 }
 
 /**
  * Start crons for a workflow when a run begins.
- * No-ops if crons already exist (another run of the same workflow is active).
+ * Checks that ALL expected agent crons exist and creates only missing ones.
  */
 export async function ensureWorkflowCrons(workflow: WorkflowSpec): Promise<void> {
-  if (await workflowCronsExist(workflow.id)) return;
+  const existingAgentIds = await getExistingCronAgentIds(workflow.id);
+  const expectedAgentIds = workflow.agents.map((a) => a.id);
+  const missingAgentIds = expectedAgentIds.filter((id) => !existingAgentIds.has(id));
+
+  if (missingAgentIds.length === 0) return;
 
   // Preflight: verify cron tool is accessible before attempting to create jobs
   const preflight = await checkCronToolAvailable();
@@ -236,7 +249,7 @@ export async function ensureWorkflowCrons(workflow: WorkflowSpec): Promise<void>
     throw new Error(preflight.error!);
   }
 
-  await setupAgentCrons(workflow);
+  await setupAgentCrons(workflow, new Set(missingAgentIds));
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #322 — `ensureWorkflowCrons` now creates only missing agent crons instead of skipping all creation when any cron exists.

## Problem

`workflowCronsExist()` used `.some()` to check if **any** cron existed for a workflow. If some crons were deleted during troubleshooting but others survived, the function returned `true` and `ensureWorkflowCrons()` skipped creating **all** crons. Missing agent crons were never recreated, causing workflow steps to get stuck at "pending" forever.

This was observed on a `competitive-intel-scanner` workflow (8 agents) where the `landscaper` cron was missing but `product-scanner` still existed.

## Changes

- **Replace `workflowCronsExist()`** with `getExistingCronAgentIds()` that returns the set of agent IDs that already have crons
- **`ensureWorkflowCrons()`** now compares expected agent IDs (from the workflow spec) against existing cron agent IDs and creates only the missing ones
- **`setupAgentCrons()`** accepts an optional `onlyAgentIds` filter set so it can skip agents that already have crons while preserving the original index-based stagger timing

## Testing

- Verified the project compiles cleanly with `npm run build`
- The fix is minimal and backward-compatible: when no crons exist, all are created as before; when all exist, none are created; when some are missing, only those are created
