### PR TITLE
feat: add executable smoke test module

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && cp src/server/index.html dist/server/index.html && chmod +x dist/cli/cli.js && node scripts/inject-version.js",
-    "start": "node dist/cli/cli.js"
+    "start": "node dist/cli/cli.js",
+    "test": "node --test tests/smoke-test.test.js"
   },
   "dependencies": {
     "json5": "^2.2.3",

--- a/progress-76764fb6-4016-4d3d-b14d-2bcc858f851b.txt
+++ b/progress-76764fb6-4016-4d3d-b14d-2bcc858f851b.txt
@@ -1,0 +1,18 @@
+# Progress Log
+Run: 76764fb6-4016-4d3d-b14d-2bcc858f851b
+Task: 验证 src/smoke-test.js 文件存在并可执行。接受标准：文件存在，执行 node -e "import('/Users/zky/antfarm/src/smoke-test.js').then(m => m.run())" 输出 'Smoke test OK'
+Started: 2026-03-19 09:13 GMT+8
+
+## Codebase Patterns
+- The package uses ESM (`"type": "module"`), so source `.js` modules can be imported directly by absolute path in Node.
+- Story-specific smoke coverage can be kept focused with `node:test` and a narrow `npm test` script.
+
+---
+
+## 2026-03-19 09:15 GMT+8 - US-001: Ensure the smoke test module exists and satisfies the required execution contract
+- Verified `src/smoke-test.js` exists in source control as an ES module exporting `run()`.
+- Added automated test coverage that imports the module and checks the exact stdout produced by the required Node smoke command.
+- Added an `npm test` script so the requested test command runs the smoke test coverage for this story.
+- Files changed: `package.json`, `src/smoke-test.js`, `tests/smoke-test.test.js`
+- **Learnings:** executing the exact `node -e` import command inside a test is a reliable way to lock down command-level stdout behavior for source-level ESM entrypoints.
+---

--- a/src/smoke-test.js
+++ b/src/smoke-test.js
@@ -1,0 +1,3 @@
+export function run() {
+  console.log('Smoke test OK');
+}

--- a/tests/smoke-test.test.js
+++ b/tests/smoke-test.test.js
@@ -1,0 +1,29 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+
+const smokeTestModulePath = path.resolve(
+  import.meta.dirname,
+  "..",
+  "src",
+  "smoke-test.js",
+);
+
+describe("US-001: smoke test module", () => {
+  it("imports successfully and exports run()", async () => {
+    const module = await import(smokeTestModulePath);
+
+    assert.equal(typeof module.run, "function");
+  });
+
+  it("matches the required smoke command output", () => {
+    const output = execFileSync(
+      "node",
+      ["-e", `import(${JSON.stringify(smokeTestModulePath)}).then((m) => m.run())`],
+      { encoding: "utf8" },
+    );
+
+    assert.equal(output, "Smoke test OK\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add the source-level `src/smoke-test.js` ESM entrypoint with a `run()` export
- add focused smoke test coverage and wire `npm test` to run it
- record the implementation details in the story progress log

## Why
This gives the repo a stable smoke-test module that can be imported directly and confirms the required command prints the expected success message.

## Testing
- `npm run build`
- `npm test`
- `node -e "import('/Users/zky/antfarm/src/smoke-test.js').then(m => m.run())"`
