### PR TITLE
feat: serialize coding steps per repo checkout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antfarm",
-  "version": "0.4.1",
+  "version": "0.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antfarm",
-      "version": "0.4.1",
+      "version": "0.5.1",
       "dependencies": {
         "json5": "^2.2.3",
         "yaml": "^2.4.5"

--- a/src/cli/cli.test.ts
+++ b/src/cli/cli.test.ts
@@ -31,9 +31,12 @@ describe("workflow stop CLI", () => {
     }
     const resumeIndex = output.indexOf("workflow resume");
     const stopIndex = output.indexOf("workflow stop");
+    const archiveIndex = output.indexOf("workflow archive");
     assert.ok(resumeIndex !== -1, "Help text should include 'workflow resume'");
     assert.ok(stopIndex !== -1, "Help text should include 'workflow stop'");
+    assert.ok(archiveIndex !== -1, "Help text should include 'workflow archive'");
     assert.ok(stopIndex > resumeIndex, "'workflow stop' should appear after 'workflow resume'");
+    assert.ok(archiveIndex > stopIndex, "'workflow archive' should appear after 'workflow stop'");
   });
 
   it("'workflow stop' with no run-id prints error and exits with code 1", () => {
@@ -64,6 +67,22 @@ describe("workflow stop CLI", () => {
       assert.ok(
         (err.stderr ?? "").length > 0,
         "Should print error to stderr",
+      );
+    }
+  });
+
+  it("'workflow archive' with no run-id prints error and exits with code 1", () => {
+    try {
+      execFileSync("node", [cliPath, "workflow", "archive"], {
+        encoding: "utf-8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+      assert.fail("Should have exited with code 1");
+    } catch (err: any) {
+      assert.equal(err.status, 1, "Should exit with code 1");
+      assert.ok(
+        (err.stderr ?? "").includes("Missing run-id"),
+        "Should print 'Missing run-id' to stderr",
       );
     }
   });

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -18,6 +18,7 @@ try {
 import { installWorkflow } from "../installer/install.js";
 import { uninstallAllWorkflows, uninstallWorkflow, checkActiveRuns } from "../installer/uninstall.js";
 import { archiveWorkflow, getWorkflowStatus, listRuns, pauseWorkflow, resumeWorkflow, stopWorkflow } from "../installer/status.js";
+import { formatStepStatusLine } from "../installer/repo-visibility.js";
 import { runWorkflow } from "../installer/run.js";
 import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
@@ -586,7 +587,7 @@ async function main() {
       `Updated: ${run.updated_at}`,
       "",
       "Steps:",
-      ...steps.map((s) => `  [${s.status}] ${s.step_id} (${s.agent_id})`),
+      ...steps.map((s) => formatStepStatusLine(s, s.queue)),
     ];
     const stories = getStories(run.id);
     if (stories.length > 0) {

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -17,7 +17,7 @@ try {
 
 import { installWorkflow } from "../installer/install.js";
 import { uninstallAllWorkflows, uninstallWorkflow, checkActiveRuns } from "../installer/uninstall.js";
-import { archiveWorkflow, getWorkflowStatus, listRuns, stopWorkflow } from "../installer/status.js";
+import { archiveWorkflow, getWorkflowStatus, listRuns, pauseWorkflow, resumeWorkflow, stopWorkflow } from "../installer/status.js";
 import { runWorkflow } from "../installer/run.js";
 import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
@@ -102,7 +102,8 @@ function printUsage() {
       "antfarm workflow run <name> <task>   Start a workflow run",
       "antfarm workflow status <query>      Check run status (task substring, run ID prefix)",
       "antfarm workflow runs [--all|--archived]  List workflow runs (active by default)",
-      "antfarm workflow resume <run-id>     Resume a failed run from where it left off",
+      "antfarm workflow resume <run-id>     Resume a paused or failed run",
+      "antfarm workflow pause <run-id>       Pause a running workflow (cooperative)",
       "antfarm workflow stop <run-id>        Stop/cancel a running workflow",
       "antfarm workflow archive <run-id>     Archive a completed, failed, or cancelled run",
       "antfarm workflow ensure-crons <name>  Recreate agent crons for a workflow",
@@ -601,121 +602,26 @@ async function main() {
     return;
   }
 
+  if (action === "pause") {
+    if (!target) { process.stderr.write("Missing run-id.\n"); printUsage(); process.exit(1); }
+    const result = await pauseWorkflow(target);
+    if (result.status === "not_found") { process.stderr.write(`${result.message}\n`); process.exit(1); }
+    if (result.status === "already_paused") { process.stderr.write(`${result.message}\n`); process.exit(1); }
+    if (result.status === "not_pausable") { process.stderr.write(`${result.message}\n`); process.exit(1); }
+    if (result.mode === "requested") {
+      console.log(`Pause requested for run ${result.runId.slice(0, 8)} — a step is running and will settle between steps.`);
+    } else {
+      console.log(`Paused run ${result.runId.slice(0, 8)}.`);
+    }
+    return;
+  }
+
   if (action === "resume") {
     if (!target) { process.stderr.write("Missing run-id.\n"); printUsage(); process.exit(1); }
-    const db = (await import("../db.js")).getDb();
-
-    // Find the run (support prefix match)
-    // Support run number lookup in addition to UUID prefix
-    let run: { id: string; run_number: number | null; workflow_id: string; status: string } | undefined;
-    if (/^\d+$/.test(target)) {
-      run = db.prepare(
-        "SELECT id, run_number, workflow_id, status FROM runs WHERE run_number = ?"
-      ).get(parseInt(target, 10)) as typeof run;
-    }
-    if (!run) {
-      run = db.prepare(
-        "SELECT id, run_number, workflow_id, status FROM runs WHERE id = ? OR id LIKE ?"
-      ).get(target, `${target}%`) as typeof run;
-    }
-
-    if (!run) { process.stderr.write(`Run not found: ${target}\n`); process.exit(1); }
-    if (run.status !== "failed") {
-      process.stderr.write(`Run ${run.id.slice(0, 8)} is "${run.status}", not "failed". Nothing to resume.\n`);
-      process.exit(1);
-    }
-
-    // Find the failed step (or first non-done step)
-    const failedStep = db.prepare(
-      "SELECT id, step_id, type, current_story_id FROM steps WHERE run_id = ? AND status = 'failed' ORDER BY step_index ASC LIMIT 1"
-    ).get(run.id) as { id: string; step_id: string; type: string; current_story_id: string | null } | undefined;
-
-    if (!failedStep) {
-      process.stderr.write(`No failed step found in run ${run.id.slice(0, 8)}.\n`);
-      process.exit(1);
-    }
-
-    // If it's a loop step with a failed story, reset that story to pending
-    if (failedStep.type === "loop") {
-      const failedStory = db.prepare(
-        "SELECT id FROM stories WHERE run_id = ? AND status = 'failed' ORDER BY story_index ASC LIMIT 1"
-      ).get(run.id) as { id: string } | undefined;
-      if (failedStory) {
-        db.prepare(
-          "UPDATE stories SET status = 'pending', updated_at = datetime('now') WHERE id = ?"
-        ).run(failedStory.id);
-      }
-      db.prepare(
-        "UPDATE steps SET retry_count = 0 WHERE run_id = ? AND type = 'loop'"
-      ).run(run.id);
-    }
-
-    // Check if the failed step is a verify step linked to a loop step's verify_each
-    const loopStep = db.prepare(
-      "SELECT id, loop_config FROM steps WHERE run_id = ? AND type = 'loop' AND status IN ('running', 'failed') LIMIT 1"
-    ).get(run.id) as { id: string; loop_config: string | null } | undefined;
-
-    if (loopStep?.loop_config) {
-      const lc = JSON.parse(loopStep.loop_config);
-      if (lc.verifyEach && lc.verifyStep === failedStep.step_id) {
-        // Reset the loop step (developer) to pending so it re-claims the story and populates context
-        db.prepare(
-          "UPDATE steps SET status = 'pending', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?"
-        ).run(loopStep.id);
-        // Reset verify step to waiting (fires after developer completes)
-        db.prepare(
-          "UPDATE steps SET status = 'waiting', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?"
-        ).run(failedStep.id);
-        // Reset any failed stories to pending
-        db.prepare(
-          "UPDATE stories SET status = 'pending', updated_at = datetime('now') WHERE run_id = ? AND status = 'failed'"
-        ).run(run.id);
-
-        // Reset run to running
-        db.prepare(
-          "UPDATE runs SET status = 'running', updated_at = datetime('now') WHERE id = ?"
-        ).run(run.id);
-
-        // Ensure crons are running for this workflow
-        const { loadWorkflowSpec } = await import("../installer/workflow-spec.js");
-        const { resolveWorkflowDir } = await import("../installer/paths.js");
-        const { ensureWorkflowCrons } = await import("../installer/agent-cron.js");
-        try {
-          const workflowDir = resolveWorkflowDir(run.workflow_id);
-          const workflow = await loadWorkflowSpec(workflowDir);
-          await ensureWorkflowCrons(workflow);
-        } catch (err) {
-          process.stderr.write(`Warning: Could not start crons: ${err instanceof Error ? err.message : String(err)}\n`);
-        }
-
-        console.log(`Resumed run ${run.id.slice(0, 8)} — reset loop step "${loopStep.id.slice(0, 8)}" to pending, verify step "${failedStep.step_id}" to waiting`);
-        process.exit(0);
-      }
-    }
-
-    // Reset step to pending
-    db.prepare(
-      "UPDATE steps SET status = 'pending', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?"
-    ).run(failedStep.id);
-
-    // Reset run to running
-    db.prepare(
-      "UPDATE runs SET status = 'running', updated_at = datetime('now') WHERE id = ?"
-    ).run(run.id);
-
-    // Ensure crons are running for this workflow
-    const { loadWorkflowSpec } = await import("../installer/workflow-spec.js");
-    const { resolveWorkflowDir } = await import("../installer/paths.js");
-    const { ensureWorkflowCrons } = await import("../installer/agent-cron.js");
-    try {
-      const workflowDir = resolveWorkflowDir(run.workflow_id);
-      const workflow = await loadWorkflowSpec(workflowDir);
-      await ensureWorkflowCrons(workflow);
-    } catch (err) {
-      process.stderr.write(`Warning: Could not start crons: ${err instanceof Error ? err.message : String(err)}\n`);
-    }
-
-    console.log(`Resumed run ${run.id.slice(0, 8)} from step "${failedStep.step_id}"`);
+    const result = await resumeWorkflow(target);
+    if (result.status === "not_found") { process.stderr.write(`${result.message}\n`); process.exit(1); }
+    if (result.status === "not_resumable") { process.stderr.write(`${result.message}\n`); process.exit(1); }
+    console.log(`Resumed run ${result.runId.slice(0, 8)}${result.detail ? ` — ${result.detail}` : ""}`);
     return;
   }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -17,7 +17,7 @@ try {
 
 import { installWorkflow } from "../installer/install.js";
 import { uninstallAllWorkflows, uninstallWorkflow, checkActiveRuns } from "../installer/uninstall.js";
-import { getWorkflowStatus, listRuns, stopWorkflow } from "../installer/status.js";
+import { archiveWorkflow, getWorkflowStatus, listRuns, stopWorkflow } from "../installer/status.js";
 import { runWorkflow } from "../installer/run.js";
 import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
@@ -55,6 +55,7 @@ function formatEventLabel(evt: AntfarmEvent): string {
     "run.started": "Run started",
     "run.completed": "Run completed",
     "run.failed": "Run failed",
+    "run.archived": "Run archived",
     "step.pending": "Step pending",
     "step.running": "Claimed step",
     "step.done": "Step completed",
@@ -95,9 +96,10 @@ function printUsage() {
       "antfarm workflow uninstall --all     Uninstall all workflows (--force to override)",
       "antfarm workflow run <name> <task>   Start a workflow run",
       "antfarm workflow status <query>      Check run status (task substring, run ID prefix)",
-      "antfarm workflow runs                List all workflow runs",
+      "antfarm workflow runs [--all|--archived]  List workflow runs (active by default)",
       "antfarm workflow resume <run-id>     Resume a failed run from where it left off",
       "antfarm workflow stop <run-id>        Stop/cancel a running workflow",
+      "antfarm workflow archive <run-id>     Archive a completed, failed, or cancelled run",
       "antfarm workflow ensure-crons <name>  Recreate agent crons for a workflow",
       "",
       "antfarm dashboard [start] [--port N]   Start dashboard daemon (default: 3333)",
@@ -107,6 +109,7 @@ function printUsage() {
       "antfarm step peek <agent-id>        Lightweight check for pending work (HAS_WORK or NO_WORK)",
       "antfarm step claim <agent-id>       Claim pending step, output resolved input as JSON",
       "antfarm step complete <step-id>      Complete step (reads output from stdin)",
+      "antfarm step complete-file <step-id> <file>  Complete step using output read from a file",
       "antfarm step fail <step-id> <error>  Fail step with retry logic",
       "antfarm step stories <run-id>       List stories for a run",
       "",
@@ -395,6 +398,16 @@ async function main() {
       process.stdout.write(JSON.stringify(result) + "\n");
       return;
     }
+    if (action === "complete-file") {
+      if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
+      const filePath = args[3];
+      if (!filePath) { process.stderr.write("Missing output-file path.\n"); process.exit(1); }
+      const { readFileSync } = await import("node:fs");
+      const output = readFileSync(filePath, "utf-8").trim();
+      const result = completeStep(target, output);
+      process.stdout.write(JSON.stringify(result) + "\n");
+      return;
+    }
     if (action === "fail") {
       if (!target) { process.stderr.write("Missing step-id.\n"); process.exit(1); }
       const error = args.slice(3).join(" ").trim() || "Unknown error";
@@ -453,12 +466,15 @@ async function main() {
   if (group !== "workflow") { printUsage(); process.exit(1); }
 
   if (action === "runs") {
-    const runs = listRuns();
+    const onlyArchived = args.includes("--archived");
+    const includeArchived = args.includes("--all");
+    const runs = listRuns({ includeArchived, onlyArchived });
     if (runs.length === 0) { console.log("No workflow runs found."); return; }
     console.log("Workflow runs:");
     for (const r of runs) {
       const num = r.run_number != null ? `#${r.run_number}` : r.id.slice(0, 8);
-      console.log(`  [${r.status.padEnd(9)}] ${num.padEnd(6)} ${r.id.slice(0, 8)}  ${r.workflow_id.padEnd(14)}  ${r.task.slice(0, 50)}${r.task.length > 50 ? "..." : ""}`);
+      const archivedMark = r.archived_at ? " (archived)" : "";
+      console.log(`  [${r.status.padEnd(9)}] ${num.padEnd(6)} ${r.id.slice(0, 8)}  ${r.workflow_id.padEnd(14)}  ${r.task.slice(0, 50)}${r.task.length > 50 ? "..." : ""}${archivedMark}`);
     }
     return;
   }
@@ -478,6 +494,17 @@ async function main() {
     if (result.status === "not_found") { process.stderr.write(result.message + "\n"); process.exit(1); }
     if (result.status === "already_done") { process.stderr.write(result.message + "\n"); process.exit(1); }
     console.log(`Cancelled run ${result.runId.slice(0, 8)} (${result.workflowId}). ${result.cancelledSteps} step(s) cancelled.`);
+    return;
+  }
+
+  if (action === "archive") {
+    if (!target) { process.stderr.write("Missing run-id.\n"); printUsage(); process.exit(1); }
+    const result = await archiveWorkflow(target);
+    if (result.status === "not_found" || result.status === "already_archived" || result.status === "not_archivable") {
+      process.stderr.write(result.message + "\n");
+      process.exit(1);
+    }
+    console.log(`Archived run ${result.runId.slice(0, 8)} (${result.workflowId}) at ${result.archivedAt}.`);
     return;
   }
 
@@ -518,6 +545,7 @@ async function main() {
       `Workflow: ${run.workflow_id}`,
       `Task: ${run.task.slice(0, 120)}${run.task.length > 120 ? "..." : ""}`,
       `Status: ${run.status}`,
+      ...(run.archived_at ? [`Archived: ${run.archived_at}`] : []),
       `Created: ${run.created_at}`,
       `Updated: ${run.updated_at}`,
       "",

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -23,6 +23,7 @@ import { listBundledWorkflows } from "../installer/workflow-fetch.js";
 import { readRecentLogs } from "../lib/logger.js";
 import { getRecentEvents, getRunEvents, type AntfarmEvent } from "../installer/events.js";
 import { startDaemon, stopDaemon, getDaemonStatus, isRunning } from "../server/daemonctl.js";
+import { getDashboardServeStatus } from "../server/tailscale-serve.js";
 import { claimStep, completeStep, failStep, getStories, peekStep } from "../installer/step-ops.js";
 import { ensureCliSymlink } from "../installer/symlink.js";
 import { runMedicCheck, getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
@@ -249,6 +250,8 @@ async function main() {
       const st = getDaemonStatus();
       if (st && st.running) {
         console.log(`Dashboard running (PID ${st.pid ?? "unknown"})`);
+        const serve = await getDashboardServeStatus();
+        console.log(`Tailscale serve: ${serve.configured ? `ok (${serve.url ?? ":4443 -> 127.0.0.1:3333"})` : "missing"}`);
       } else {
         console.log("Dashboard is not running.");
       }
@@ -267,15 +270,19 @@ async function main() {
     }
 
     if (isRunning().running) {
-      const status = getDaemonStatus();
-      console.log(`Dashboard already running (PID ${status?.pid})`);
+      const result = await startDaemon(port);
+      const serve = await getDashboardServeStatus(port);
+      console.log(`Dashboard already running (PID ${result.pid})`);
       console.log(`  http://localhost:${port}`);
+      if (serve.configured && serve.url) console.log(`  ${serve.url}`);
       return;
     }
 
     const result = await startDaemon(port);
+    const serve = await getDashboardServeStatus(port);
     console.log(`Dashboard started (PID ${result.pid})`);
     console.log(`  http://localhost:${result.port}`);
+    if (serve.configured && serve.url) console.log(`  ${serve.url}`);
     return;
   }
 

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -27,6 +27,7 @@ import { claimStep, completeStep, failStep, getStories, peekStep } from "../inst
 import { ensureCliSymlink } from "../installer/symlink.js";
 import { runMedicCheck, getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
 import { installMedicCron, uninstallMedicCron, isMedicCronInstalled } from "../medic/medic-cron.js";
+import { runConfiguredExecutor } from "../installer/executor.js";
 import { execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
@@ -56,6 +57,9 @@ function formatEventLabel(evt: AntfarmEvent): string {
     "run.completed": "Run completed",
     "run.failed": "Run failed",
     "run.archived": "Run archived",
+    "executor.started": "Executor started",
+    "executor.completed": "Executor completed",
+    "executor.failed": "Executor failed",
     "step.pending": "Step pending",
     "step.running": "Claimed step",
     "step.done": "Step completed",
@@ -112,6 +116,7 @@ function printUsage() {
       "antfarm step complete-file <step-id> <file>  Complete step using output read from a file",
       "antfarm step fail <step-id> <error>  Fail step with retry logic",
       "antfarm step stories <run-id>       List stories for a run",
+      "antfarm executor run <workflow> <agent> <run-id> <step-id> <input-file> <output-file>  Run configured code executor",
       "",
       "antfarm medic install                Install medic watchdog cron",
       "antfarm medic uninstall              Remove medic cron",
@@ -426,6 +431,29 @@ async function main() {
       return;
     }
     process.stderr.write(`Unknown step action: ${action}\n`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (group === "executor") {
+    if (action === "run") {
+      const workflowId = target;
+      const agentId = args[3];
+      const runId = args[4];
+      const stepId = args[5];
+      const inputFile = args[6];
+      const outputFile = args[7];
+      if (!workflowId || !agentId || !runId || !stepId || !inputFile || !outputFile) {
+        process.stderr.write("Usage: antfarm executor run <workflow> <agent> <run-id> <step-id> <input-file> <output-file>\n");
+        process.exit(1);
+      }
+      const input = readFileSync(inputFile, "utf-8");
+      const result = await runConfiguredExecutor({ workflowId, agentId, runId, stepId, input, outputFile });
+      process.stdout.write(JSON.stringify(result) + "\n");
+      if (!result.ok) process.exit(1);
+      return;
+    }
+
     printUsage();
     process.exit(1);
   }

--- a/src/db.ts
+++ b/src/db.ts
@@ -92,6 +92,9 @@ function migrate(db: DatabaseSync): void {
   if (!runColNames.has("notify_url")) {
     db.exec("ALTER TABLE runs ADD COLUMN notify_url TEXT");
   }
+  if (!runColNames.has("archived_at")) {
+    db.exec("ALTER TABLE runs ADD COLUMN archived_at TEXT");
+  }
   if (!runColNames.has("run_number")) {
     db.exec("ALTER TABLE runs ADD COLUMN run_number INTEGER");
     // Backfill existing runs with sequential numbers based on creation order

--- a/src/db.ts
+++ b/src/db.ts
@@ -85,6 +85,30 @@ export function migrate(db: DatabaseSync): void {
   if (!colNames.has("abandoned_count")) {
     db.exec("ALTER TABLE steps ADD COLUMN abandoned_count INTEGER DEFAULT 0");
   }
+  if (!colNames.has("execution_mode")) {
+    db.exec("ALTER TABLE steps ADD COLUMN execution_mode TEXT");
+  }
+  if (!colNames.has("repo_key")) {
+    db.exec("ALTER TABLE steps ADD COLUMN repo_key TEXT");
+  }
+  if (!colNames.has("repo_path")) {
+    db.exec("ALTER TABLE steps ADD COLUMN repo_path TEXT");
+  }
+  if (!colNames.has("queued_at")) {
+    db.exec("ALTER TABLE steps ADD COLUMN queued_at TEXT");
+  }
+  if (!colNames.has("blocked_by_run_id")) {
+    db.exec("ALTER TABLE steps ADD COLUMN blocked_by_run_id TEXT");
+  }
+  if (!colNames.has("blocked_by_step_id")) {
+    db.exec("ALTER TABLE steps ADD COLUMN blocked_by_step_id TEXT");
+  }
+
+  // Index to make same-repo scheduling lookups fast (look up active
+  // shared_checkout_exclusive steps for a given repo_key).
+  db.exec(
+    "CREATE INDEX IF NOT EXISTS idx_steps_repo_key_status ON steps(repo_key, status)"
+  );
 
   // Add columns to runs table for backwards compat
   const runCols = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;

--- a/src/db.ts
+++ b/src/db.ts
@@ -24,7 +24,7 @@ export function getDb(): DatabaseSync {
   return _db;
 }
 
-function migrate(db: DatabaseSync): void {
+export function migrate(db: DatabaseSync): void {
   db.exec(`
     CREATE TABLE IF NOT EXISTS runs (
       id TEXT PRIMARY KEY,
@@ -104,6 +104,27 @@ function migrate(db: DatabaseSync): void {
       ) WHERE run_number IS NULL
     `);
   }
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS linear_issue_links (
+      linear_issue_id TEXT PRIMARY KEY,
+      linear_identifier TEXT NOT NULL,
+      linear_url TEXT NOT NULL,
+      linear_title TEXT NOT NULL,
+      team_id TEXT NOT NULL,
+      workflow_id TEXT NOT NULL,
+      repo_path TEXT NOT NULL,
+      run_id TEXT REFERENCES runs(id),
+      sync_status TEXT NOT NULL,
+      last_linear_updated_at TEXT,
+      last_synced_run_status TEXT,
+      last_synced_step_id TEXT,
+      last_comment_hash TEXT,
+      last_error TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
 }
 
 export function nextRunNumber(): number {

--- a/src/db.ts
+++ b/src/db.ts
@@ -104,6 +104,12 @@ export function migrate(db: DatabaseSync): void {
       ) WHERE run_number IS NULL
     `);
   }
+  if (!runColNames.has("pause_requested_at")) {
+    db.exec("ALTER TABLE runs ADD COLUMN pause_requested_at TEXT");
+  }
+  if (!runColNames.has("paused_at")) {
+    db.exec("ALTER TABLE runs ADD COLUMN paused_at TEXT");
+  }
 
   db.exec(`
     CREATE TABLE IF NOT EXISTS linear_issue_links (

--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
 import { createAgentCronJob, deleteAgentCronJobs, listCronJobs, checkCronToolAvailable } from "./gateway-api.js";
 import type { WorkflowSpec } from "./types.js";
-import { resolveAntfarmCli } from "./paths.js";
+import { resolveAntfarmCli, resolveBundledWorkflowDir, resolveWorkflowDir } from "./paths.js";
 import { getDb } from "../db.js";
 import { readOpenClawConfig } from "./openclaw-config.js";
 
@@ -30,6 +33,7 @@ Step 3 — Do the work described in the input. Format your output with KEY: valu
 
 Step 4 — MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
+Write output to a file first using the write tool.
 Use the write tool to create /tmp/antfarm-step-output.txt with the EXACT KEY: value output requested by this step.
 Do NOT use placeholder keys like CHANGES/TESTS unless the step explicitly asked for them.
 
@@ -44,7 +48,7 @@ node ${cli} step fail "<stepId>" "description of what went wrong"
 
 RULES:
 1. NEVER end your session without calling step complete or step fail
-2. Use the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
+2. Write output to a file first, using the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
 3. If you're unsure whether to complete or fail, call step fail with an explanation
 4. The output file must contain every required KEY from the step instructions before you call step complete
 5. Do NOT use heredocs, pipes, cat, or shell substitution for step completion
@@ -55,6 +59,7 @@ The workflow cannot advance until you report. Your session ending without report
 export function buildWorkPrompt(workflowId: string, agentId: string): string {
   const fullAgentId = `${workflowId}_${agentId}`;
   const cli = resolveAntfarmCli();
+  const executorInstructions = buildExecutorInstructions(workflowId, agentId, cli);
 
   return `You are an Antfarm workflow agent. Execute the pending work below.
 
@@ -66,8 +71,11 @@ The "input" field contains your FULLY RESOLVED task instructions. Read it carefu
 
 Do the work described in the input. Format your output with KEY: value lines as specified.
 
+${executorInstructions}
+
 MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
+Write output to a file first using the write tool.
 Use the write tool to create /tmp/antfarm-step-output.txt with the EXACT KEY: value output requested by this step.
 Do NOT use placeholder keys like CHANGES/TESTS unless the step explicitly asked for them.
 
@@ -82,12 +90,69 @@ node ${cli} step fail "<stepId>" "description of what went wrong"
 
 RULES:
 1. NEVER end your session without calling step complete or step fail
-2. Use the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
+2. Write output to a file first, using the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
 3. If you're unsure whether to complete or fail, call step fail with an explanation
 4. The output file must contain every required KEY from the step instructions before you call step complete
 5. Do NOT use heredocs, pipes, cat, or shell substitution for step completion
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
+}
+
+type AgentExecutorConfig = {
+  kind: "claude-code-wrapper";
+  command: string;
+  model?: string;
+  effort?: string;
+  maxTurns?: number;
+};
+
+const workflowExecutorCache = new Map<string, Map<string, AgentExecutorConfig>>();
+
+function resolveWorkflowYamls(workflowId: string): string[] {
+  const bundled = path.join(resolveBundledWorkflowDir(workflowId), "workflow.yml");
+  const installed = path.join(resolveWorkflowDir(workflowId), "workflow.yml");
+  return [bundled, installed].filter((filePath, index, all) => fs.existsSync(filePath) && all.indexOf(filePath) === index);
+}
+
+function getAgentExecutorConfig(workflowId: string, agentId: string): AgentExecutorConfig | null {
+  let cached = workflowExecutorCache.get(workflowId);
+  if (!cached) {
+    cached = new Map<string, AgentExecutorConfig>();
+    for (const yamlPath of resolveWorkflowYamls(workflowId)) {
+      try {
+        const parsed = YAML.parse(fs.readFileSync(yamlPath, "utf-8")) as { agents?: Array<{ id?: string; executor?: AgentExecutorConfig }> };
+        for (const agent of parsed.agents ?? []) {
+          if (agent.id && agent.executor?.kind === "claude-code-wrapper") {
+            cached.set(agent.id, agent.executor);
+          }
+        }
+      } catch {
+        // best-effort
+      }
+    }
+    workflowExecutorCache.set(workflowId, cached);
+  }
+  return cached.get(agentId) ?? null;
+}
+
+function buildExecutorInstructions(workflowId: string, agentId: string, cli: string): string {
+  const executor = getAgentExecutorConfig(workflowId, agentId);
+  if (!executor || executor.kind !== "claude-code-wrapper") return "";
+
+  return `THIS AGENT IS CONFIGURED TO USE THE CLAUDE CODE WRAPPER FOR IMPLEMENTATION.
+
+When you have a claimed step:
+1. Use the write tool to save the EXACT claimed step input into /tmp/antfarm-claimed-input.txt.
+2. Run this executor command:
+\`\`\`
+node ${cli} executor run "${workflowId}" "${agentId}" "<runId>" "<stepId>" "/tmp/antfarm-claimed-input.txt" "/tmp/antfarm-step-output.txt"
+\`\`\`
+3. The executor automatically loads this Antfarm agent's real local workspace context before it runs Claude Code.
+4. If that command succeeds, /tmp/antfarm-step-output.txt will already contain the exact KEY: value response from Claude Code.
+5. Immediately report completion with step complete-file.
+6. If the executor command fails or the wrapper is unavailable, call step fail instead of doing the coding work manually.
+
+Antfarm will emit executor.started / executor.completed / executor.failed events so the dashboard activity shows the wrapper flow.`;
 }
 
 const DEFAULT_POLLING_TIMEOUT_SECONDS = 120;

--- a/src/installer/agent-cron.ts
+++ b/src/installer/agent-cron.ts
@@ -30,12 +30,11 @@ Step 3 — Do the work described in the input. Format your output with KEY: valu
 
 Step 4 — MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
-cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
-STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
-ANTFARM_EOF
-cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
+Use the write tool to create /tmp/antfarm-step-output.txt with the EXACT KEY: value output requested by this step.
+Do NOT use placeholder keys like CHANGES/TESTS unless the step explicitly asked for them.
+
+Then run:
+node ${cli} step complete-file "<stepId>" "/tmp/antfarm-step-output.txt"
 \`\`\`
 
 If the work FAILED:
@@ -45,8 +44,10 @@ node ${cli} step fail "<stepId>" "description of what went wrong"
 
 RULES:
 1. NEVER end your session without calling step complete or step fail
-2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
+2. Use the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. The output file must contain every required KEY from the step instructions before you call step complete
+5. Do NOT use heredocs, pipes, cat, or shell substitution for step completion
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }
@@ -67,12 +68,11 @@ Do the work described in the input. Format your output with KEY: value lines as 
 
 MANDATORY: Report completion (do this IMMEDIATELY after finishing the work):
 \`\`\`
-cat <<'ANTFARM_EOF' > /tmp/antfarm-step-output.txt
-STATUS: done
-CHANGES: what you did
-TESTS: what tests you ran
-ANTFARM_EOF
-cat /tmp/antfarm-step-output.txt | node ${cli} step complete "<stepId>"
+Use the write tool to create /tmp/antfarm-step-output.txt with the EXACT KEY: value output requested by this step.
+Do NOT use placeholder keys like CHANGES/TESTS unless the step explicitly asked for them.
+
+Then run:
+node ${cli} step complete-file "<stepId>" "/tmp/antfarm-step-output.txt"
 \`\`\`
 
 If the work FAILED:
@@ -82,8 +82,10 @@ node ${cli} step fail "<stepId>" "description of what went wrong"
 
 RULES:
 1. NEVER end your session without calling step complete or step fail
-2. Write output to a file first, then pipe via stdin (shell escaping breaks direct args)
+2. Use the write tool to create /tmp/antfarm-step-output.txt, then run step complete-file
 3. If you're unsure whether to complete or fail, call step fail with an explanation
+4. The output file must contain every required KEY from the step instructions before you call step complete
+5. Do NOT use heredocs, pipes, cat, or shell substitution for step completion
 
 The workflow cannot advance until you report. Your session ending without reporting = broken pipeline.`;
 }

--- a/src/installer/events.ts
+++ b/src/installer/events.ts
@@ -9,6 +9,7 @@ const MAX_EVENTS_SIZE = 10 * 1024 * 1024; // 10MB
 
 export type EventType =
   | "run.started" | "run.completed" | "run.failed" | "run.archived"
+  | "executor.started" | "executor.completed" | "executor.failed"
   | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout"
   | "story.started" | "story.done" | "story.verified" | "story.retry" | "story.failed"
   | "pipeline.advanced";

--- a/src/installer/events.ts
+++ b/src/installer/events.ts
@@ -8,7 +8,7 @@ const EVENTS_FILE = path.join(EVENTS_DIR, "events.jsonl");
 const MAX_EVENTS_SIZE = 10 * 1024 * 1024; // 10MB
 
 export type EventType =
-  | "run.started" | "run.completed" | "run.failed"
+  | "run.started" | "run.completed" | "run.failed" | "run.archived"
   | "step.pending" | "step.running" | "step.done" | "step.failed" | "step.timeout"
   | "story.started" | "story.done" | "story.verified" | "story.retry" | "story.failed"
   | "pipeline.advanced";

--- a/src/installer/executor.ts
+++ b/src/installer/executor.ts
@@ -1,0 +1,196 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { emitEvent } from "./events.js";
+import { resolveBundledWorkflowDir, resolveRunRoot, resolveWorkflowDir, resolveWorkflowWorkspaceDir } from "./paths.js";
+import { loadWorkflowSpec } from "./workflow-spec.js";
+import type { WorkflowAgent, WorkflowAgentExecutor, WorkflowSpec } from "./types.js";
+
+export type ConfiguredExecutorResult = {
+  ok: boolean;
+  summary?: string;
+  recordDir: string;
+  repo?: string;
+  branch?: string | null;
+  sessionId?: string | null;
+  error?: string;
+  stderrExcerpt?: string;
+};
+
+async function pathExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function loadWorkflowForExecution(workflowId: string): Promise<WorkflowSpec> {
+  const installedDir = resolveWorkflowDir(workflowId);
+  if (await pathExists(path.join(installedDir, "workflow.yml"))) {
+    return loadWorkflowSpec(installedDir);
+  }
+  return loadWorkflowSpec(resolveBundledWorkflowDir(workflowId));
+}
+
+function requireExecutor(workflow: WorkflowSpec, agentId: string): WorkflowAgentExecutor {
+  const agent = workflow.agents.find((candidate) => candidate.id === agentId) as WorkflowAgent | undefined;
+  if (!agent) {
+    throw new Error(`Agent not found in workflow ${workflow.id}: ${agentId}`);
+  }
+  if (!agent.executor) {
+    throw new Error(`Agent ${workflow.id}/${agentId} has no configured executor`);
+  }
+  return agent.executor;
+}
+
+function requireAgent(workflow: WorkflowSpec, agentId: string): WorkflowAgent {
+  const agent = workflow.agents.find((candidate) => candidate.id === agentId) as WorkflowAgent | undefined;
+  if (!agent) {
+    throw new Error(`Agent not found in workflow ${workflow.id}: ${agentId}`);
+  }
+  return agent;
+}
+
+function resolveAgentWorkspaceDir(workflow: WorkflowSpec, agentId: string): string {
+  const agent = requireAgent(workflow, agentId);
+  const baseDir = agent.workspace.baseDir?.trim() || agent.id;
+  return path.join(resolveWorkflowWorkspaceDir(workflow.id), baseDir);
+}
+
+function getKeyValue(input: string, key: string): string | null {
+  const match = input.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+  return match?.[1]?.trim() || null;
+}
+
+function runCommand(command: string, args: string[], input: string): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["pipe", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+
+    child.stdout.on("data", (chunk) => { stdout += String(chunk); });
+    child.stderr.on("data", (chunk) => { stderr += String(chunk); });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+
+    child.stdin.write(input);
+    child.stdin.end();
+  });
+}
+
+export async function runConfiguredExecutor(params: {
+  workflowId: string;
+  agentId: string;
+  runId: string;
+  stepId: string;
+  input: string;
+  outputFile?: string;
+}): Promise<ConfiguredExecutorResult> {
+  const workflow = await loadWorkflowForExecution(params.workflowId);
+  const executor = requireExecutor(workflow, params.agentId);
+  const agentWorkspaceDir = resolveAgentWorkspaceDir(workflow, params.agentId);
+  if (executor.kind !== "claude-code-wrapper") {
+    throw new Error(`Unsupported executor kind: ${executor.kind}`);
+  }
+
+  const repo = getKeyValue(params.input, "REPO");
+  const recordDir = path.join(resolveRunRoot(), params.runId, params.stepId, "executor");
+  if (!repo) {
+    return {
+      ok: false,
+      recordDir,
+      error: "Claimed step input is missing required REPO: line for Claude Code execution.",
+    };
+  }
+
+  const branch = getKeyValue(params.input, "BRANCH");
+  await fs.mkdir(recordDir, { recursive: true });
+  await fs.writeFile(path.join(recordDir, "claimed-input.txt"), params.input, "utf-8");
+
+  if (!(await pathExists(agentWorkspaceDir))) {
+    return {
+      ok: false,
+      recordDir,
+      repo,
+      branch,
+      error: `Agent workspace not found: ${agentWorkspaceDir}`,
+    };
+  }
+
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "executor.started",
+    runId: params.runId,
+    workflowId: params.workflowId,
+    stepId: params.stepId,
+    agentId: `${params.workflowId}_${params.agentId}`,
+    detail: `Claude Code wrapper in ${repo}${branch ? ` on ${branch}` : ""}`,
+  });
+
+  const args = [
+    "--agent-workspace", agentWorkspaceDir,
+    "--cwd", repo,
+    "--record-to", recordDir,
+    "--model", executor.model ?? "claude-opus-4-7",
+    "--effort", executor.effort ?? "high",
+    "--max-turns", String(executor.maxTurns ?? 60),
+  ];
+
+  const { exitCode, stdout, stderr } = await runCommand(executor.command, args, params.input);
+  let payload: any = null;
+  try {
+    payload = JSON.parse(stdout.trim());
+  } catch {
+    payload = null;
+  }
+
+  if (exitCode !== 0 || !payload?.ok || typeof payload?.summary !== "string" || !payload.summary.trim()) {
+    const error = payload?.stderrExcerpt || payload?.summary || stderr.trim() || `Executor exited with code ${exitCode}`;
+    emitEvent({
+      ts: new Date().toISOString(),
+      event: "executor.failed",
+      runId: params.runId,
+      workflowId: params.workflowId,
+      stepId: params.stepId,
+      agentId: `${params.workflowId}_${params.agentId}`,
+      detail: error.slice(0, 300),
+    });
+    return {
+      ok: false,
+      recordDir,
+      repo,
+      branch,
+      sessionId: payload?.sessionId ?? null,
+      error,
+      stderrExcerpt: payload?.stderrExcerpt || stderr.trim() || undefined,
+    };
+  }
+
+  const summary = payload.summary.trim();
+  if (params.outputFile) {
+    await fs.writeFile(params.outputFile, summary + "\n", "utf-8");
+  }
+
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "executor.completed",
+    runId: params.runId,
+    workflowId: params.workflowId,
+    stepId: params.stepId,
+    agentId: `${params.workflowId}_${params.agentId}`,
+    detail: `Claude Code session ${payload.sessionId ?? "unknown"}`,
+  });
+
+  return {
+    ok: true,
+    summary,
+    recordDir,
+    repo,
+    branch,
+    sessionId: payload.sessionId ?? null,
+  };
+}

--- a/src/installer/repo-isolation.ts
+++ b/src/installer/repo-isolation.ts
@@ -1,0 +1,127 @@
+import path from "node:path";
+import os from "node:os";
+import type { AgentRole, StepExecutionMode } from "./types.js";
+
+/**
+ * Repo isolation policy for Antfarm step scheduling.
+ *
+ * v1 goal: prevent two repo-mutating coding steps from running against the
+ * same shared repo checkout concurrently. We mark such steps as
+ * `shared_checkout_exclusive` and leave a clean seam so that future
+ * worktree-isolated modes can be added without touching call sites.
+ *
+ * This module is intentionally pure — no DB access — so the policy can be
+ * unit-tested in isolation and reused by both the runner (when persisting
+ * step rows) and the scheduler (when deciding whether a step can claim the
+ * repo lock).
+ */
+
+export const SHARED_CHECKOUT_EXCLUSIVE: StepExecutionMode = "shared_checkout_exclusive";
+export const NO_LOCK: StepExecutionMode = "no_lock";
+
+/**
+ * Agent roles whose steps mutate the shared repo checkout and therefore
+ * require exclusive access under v1 shared-checkout semantics.
+ *
+ * `coding` covers developer / fixer / setup agents — anything that runs
+ * write-enabled executors against the repo. Other roles (analysis,
+ * verification, testing, pr, scanning) are treated as non-mutating from the
+ * scheduler's perspective; they either don't touch the checkout or only
+ * read from it.
+ */
+const REPO_MUTATING_ROLES: ReadonlySet<AgentRole> = new Set<AgentRole>([
+  "coding",
+]);
+
+export function isRepoMutatingRole(role: AgentRole | undefined | null): boolean {
+  if (!role) return false;
+  return REPO_MUTATING_ROLES.has(role);
+}
+
+/**
+ * Resolve the execution mode for a step given the role of the agent that will
+ * run it.
+ *
+ * Repo-mutating roles (`coding`) → `shared_checkout_exclusive` under v1.
+ * Everything else → `no_lock`.
+ *
+ * `undefined` / unknown roles are treated conservatively as non-mutating —
+ * the caller is responsible for tagging roles explicitly when exclusivity
+ * matters. (The runner always resolves a role via `inferRole()` before this
+ * helper is invoked, so the undefined branch only matters for tests and
+ * defensive callers.)
+ */
+export function resolveStepExecutionMode(opts: {
+  role?: AgentRole | null;
+}): StepExecutionMode {
+  return isRepoMutatingRole(opts.role) ? SHARED_CHECKOUT_EXCLUSIVE : NO_LOCK;
+}
+
+/**
+ * Normalize a raw REPO path into a stable scheduling key.
+ *
+ * Goals:
+ *   - Two different workflow ids pointing at the same on-disk checkout
+ *     produce the same `repo_key`.
+ *   - Relative paths, `~`, and trailing slashes collapse to a canonical form.
+ *   - Returns `null` when the input is empty/whitespace so callers can treat
+ *     "no repo" as "no lock needed" rather than crashing.
+ *
+ * Note: we deliberately do NOT call `fs.realpathSync` here. The key must be
+ * derivable without the checkout existing on disk (e.g. when a step row is
+ * persisted before setup has cloned). Symlinked checkouts pointing at the
+ * same underlying repo will resolve to different keys — that's acceptable
+ * for v1 and can be tightened later.
+ */
+export function normalizeRepoKey(repoPath: string | null | undefined): string | null {
+  if (repoPath == null) return null;
+  const raw = String(repoPath).trim();
+  if (!raw) return null;
+
+  const expanded = expandHome(raw);
+  const absolute = path.resolve(expanded);
+
+  // `path.resolve` strips trailing slashes on POSIX but leaves `/` alone; we
+  // never want a bare `/` as a repo key.
+  if (absolute === "/" || absolute === "") return null;
+
+  return absolute;
+}
+
+function expandHome(input: string): string {
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+/**
+ * Persisted repo metadata derived for a step at insert time.
+ * Callers pass this straight into the `steps` row.
+ */
+export type StepRepoMetadata = {
+  execution_mode: StepExecutionMode;
+  repo_key: string | null;
+  repo_path: string | null;
+};
+
+/**
+ * One-shot helper that produces the persisted metadata for a step from its
+ * role and the run's repo path. Handy at `runWorkflow` time where both are
+ * already in scope.
+ */
+export function deriveStepRepoMetadata(opts: {
+  role?: AgentRole | null;
+  repoPath?: string | null;
+}): StepRepoMetadata {
+  const mode = resolveStepExecutionMode({ role: opts.role });
+  const repoKey = normalizeRepoKey(opts.repoPath ?? null);
+  const repoPath = opts.repoPath == null ? null : String(opts.repoPath).trim() || null;
+
+  // If the step does not need a lock, we still record the repo identity for
+  // operator visibility, but the scheduler will ignore it.
+  return {
+    execution_mode: mode,
+    repo_key: mode === SHARED_CHECKOUT_EXCLUSIVE ? repoKey : repoKey,
+    repo_path: repoPath,
+  };
+}

--- a/src/installer/repo-scheduler.ts
+++ b/src/installer/repo-scheduler.ts
@@ -1,0 +1,147 @@
+import { getDb } from "../db.js";
+import { SHARED_CHECKOUT_EXCLUSIVE } from "./repo-isolation.js";
+import type { StepExecutionMode } from "./types.js";
+
+/**
+ * Repo scheduler boundary.
+ *
+ * Every terminal transition for a repo-mutating step (completed, failed,
+ * cancelled, abandoned-and-reset) must run through this release helper. In
+ * v1 the only responsibility is cleaning up stale `blocked_by_*` annotations
+ * that were pointing at the step we just released so the dashboard doesn't
+ * lie about why later same-repo work is queued. The claim guard itself
+ * naturally promotes the next queued same-repo step on the next poll because
+ * it filters on `status = 'running'`.
+ *
+ * Keeping this behind a helper gives us a single seam to extend when we add
+ * per-step worktree isolation later: a future `worktree_isolated` mode will
+ * plug its cleanup (rm -rf worktree, git worktree prune, release held file
+ * lock) into this function without the runner needing to know about it.
+ */
+
+export type ReleaseReason =
+  | "completed"
+  | "failed"
+  | "cancelled"
+  | "abandoned";
+
+export interface ReleaseStepResourcesArgs {
+  stepId: string;
+  runId?: string | null;
+  executionMode: StepExecutionMode | string | null | undefined;
+  repoKey: string | null | undefined;
+  reason: ReleaseReason;
+}
+
+/**
+ * Clear metadata attached to peer pending same-repo coding steps that were
+ * annotated as "blocked by this step" so operators see the new state on the
+ * next dashboard read instead of waiting for annotateBlockedCodingSteps to
+ * refresh on the next poll.
+ *
+ * Returns the id of the oldest queued same-repo pending step (FIFO by
+ * created_at, then id) for visibility / future promotion hooks. Today the
+ * actual promotion happens in the claim path — this function does not flip
+ * the successor to running.
+ */
+export function releaseStepResources(args: ReleaseStepResourcesArgs): {
+  nextStepId: string | null;
+} {
+  if (args.executionMode !== SHARED_CHECKOUT_EXCLUSIVE) {
+    return { nextStepId: null };
+  }
+  if (!args.repoKey) return { nextStepId: null };
+
+  const db = getDb();
+
+  // Wipe stale block annotations that referenced the step we just released.
+  // These will be re-stamped against a new owner by annotateBlockedCodingSteps
+  // on the next poll if the repo is re-claimed; for now we want the UI to
+  // stop showing the released step as the blocker.
+  db.prepare(
+    `UPDATE steps
+        SET blocked_by_run_id = NULL,
+            blocked_by_step_id = NULL,
+            updated_at = datetime('now')
+      WHERE status = 'pending'
+        AND execution_mode = 'shared_checkout_exclusive'
+        AND repo_key = ?
+        AND blocked_by_step_id = ?`,
+  ).run(args.repoKey, args.stepId);
+
+  // Identify the next queued same-repo step under deterministic FIFO ordering
+  // (created_at ASC, then id ASC as tiebreaker). Callers may log / emit this
+  // for observability; today we just return it so tests can assert ordering.
+  const next = db.prepare(
+    `SELECT s.id AS id
+       FROM steps s
+       JOIN runs r ON r.id = s.run_id
+      WHERE s.status = 'pending'
+        AND s.execution_mode = 'shared_checkout_exclusive'
+        AND s.repo_key = ?
+        AND s.id != ?
+        AND r.status NOT IN ('failed','cancelled')
+      ORDER BY s.created_at ASC, s.id ASC
+      LIMIT 1`,
+  ).get(args.repoKey, args.stepId) as { id: string } | undefined;
+
+  return { nextStepId: next?.id ?? null };
+}
+
+/**
+ * Convenience wrapper: look up a step by id and release its lease.
+ * Used by callers that don't already have execution_mode / repo_key in scope.
+ * Silently no-ops for missing steps.
+ */
+export function releaseStepLeaseById(
+  stepId: string,
+  reason: ReleaseReason,
+): { nextStepId: string | null } {
+  const db = getDb();
+  const row = db.prepare(
+    `SELECT id, run_id, execution_mode, repo_key
+       FROM steps
+      WHERE id = ?`,
+  ).get(stepId) as
+    | { id: string; run_id: string; execution_mode: string | null; repo_key: string | null }
+    | undefined;
+  if (!row) return { nextStepId: null };
+  return releaseStepResources({
+    stepId: row.id,
+    runId: row.run_id,
+    executionMode: row.execution_mode,
+    repoKey: row.repo_key,
+    reason,
+  });
+}
+
+/**
+ * Release every currently-running repo-mutating step for a run. Used during
+ * cancellation when the caller has already flipped statuses in bulk.
+ *
+ * Important: call this BEFORE marking the steps non-running is fine, or
+ * AFTER — the helper just clears block metadata on peers that referenced
+ * these steps. It does not inspect or change the released step's status.
+ */
+export function releaseRunSteps(
+  runId: string,
+  reason: ReleaseReason,
+): void {
+  const db = getDb();
+  const rows = db.prepare(
+    `SELECT id, execution_mode, repo_key
+       FROM steps
+      WHERE run_id = ?
+        AND execution_mode = 'shared_checkout_exclusive'
+        AND repo_key IS NOT NULL`,
+  ).all(runId) as Array<{ id: string; execution_mode: string; repo_key: string }>;
+  for (const row of rows) {
+    releaseStepResources({
+      stepId: row.id,
+      runId,
+      executionMode: row.execution_mode,
+      repoKey: row.repo_key,
+      reason,
+    });
+  }
+}

--- a/src/installer/repo-visibility.ts
+++ b/src/installer/repo-visibility.ts
@@ -1,0 +1,144 @@
+import { getDb } from "../db.js";
+import { SHARED_CHECKOUT_EXCLUSIVE } from "./repo-isolation.js";
+import type { StepInfo } from "./status.js";
+
+/**
+ * Operator-facing description of why a pending coding step is queued on a
+ * shared repo checkout. Resolved from the raw `blocked_by_*` pointers the
+ * scheduler writes so the CLI/dashboard can render "waiting on run #42"
+ * without the UI having to do its own joins.
+ *
+ * All fields are optional/nullable because the blocking row may have been
+ * released between the moment the step was annotated and the moment the
+ * status reader resolved context.
+ */
+export interface RepoQueueContext {
+  /** Normalized repo key the queued step is contending for. */
+  repoKey: string;
+  /** Raw repo path as supplied by the run context, for human display. */
+  repoPath: string | null;
+  /** ISO timestamp when the step first entered the blocked/queued state. */
+  queuedAt: string | null;
+  /** Run that is currently holding the shared checkout, if known. */
+  blockingRunId: string | null;
+  blockingRunNumber: number | null;
+  blockingWorkflowId: string | null;
+  blockingTask: string | null;
+  /** Human-readable step id (e.g. "implement") of the blocking step. */
+  blockingStepId: string | null;
+  blockingAgentId: string | null;
+}
+
+/**
+ * StepInfo + an optional `queue` block populated when the step is a pending
+ * shared_checkout_exclusive coder waiting on a same-repo owner.
+ */
+export type EnrichedStepInfo = StepInfo & {
+  queue: RepoQueueContext | null;
+};
+
+/**
+ * A step is "queued on repo" when it is pending, scheduled as
+ * shared_checkout_exclusive, and the scheduler annotated it with a same-repo
+ * contender. We deliberately require both the repo key and a blocker pointer
+ * so we do not flag steps that are simply pending because nothing has polled
+ * them yet.
+ */
+export function isStepQueuedOnRepo(step: StepInfo): boolean {
+  if (step.status !== "pending") return false;
+  if (step.execution_mode !== SHARED_CHECKOUT_EXCLUSIVE) return false;
+  if (!step.repo_key) return false;
+  return step.blocked_by_step_id != null || step.blocked_by_run_id != null;
+}
+
+/**
+ * Resolve the blocking run/step for a queued step via two small lookups.
+ * Returns null for steps that are not queued-on-repo.
+ */
+export function resolveRepoQueueContext(step: StepInfo): RepoQueueContext | null {
+  if (!isStepQueuedOnRepo(step)) return null;
+  const db = getDb();
+
+  let blockingRunNumber: number | null = null;
+  let blockingWorkflowId: string | null = null;
+  let blockingTask: string | null = null;
+  if (step.blocked_by_run_id) {
+    const runRow = db.prepare(
+      "SELECT run_number, workflow_id, task FROM runs WHERE id = ?",
+    ).get(step.blocked_by_run_id) as
+      | { run_number: number | null; workflow_id: string; task: string }
+      | undefined;
+    if (runRow) {
+      blockingRunNumber = runRow.run_number;
+      blockingWorkflowId = runRow.workflow_id;
+      blockingTask = runRow.task;
+    }
+  }
+
+  let blockingStepId: string | null = null;
+  let blockingAgentId: string | null = null;
+  if (step.blocked_by_step_id) {
+    const stepRow = db.prepare(
+      "SELECT step_id, agent_id FROM steps WHERE id = ?",
+    ).get(step.blocked_by_step_id) as { step_id: string; agent_id: string } | undefined;
+    if (stepRow) {
+      blockingStepId = stepRow.step_id;
+      blockingAgentId = stepRow.agent_id;
+    }
+  }
+
+  return {
+    repoKey: step.repo_key!,
+    repoPath: step.repo_path,
+    queuedAt: step.queued_at,
+    blockingRunId: step.blocked_by_run_id,
+    blockingRunNumber,
+    blockingWorkflowId,
+    blockingTask,
+    blockingStepId,
+    blockingAgentId,
+  };
+}
+
+export function enrichStepWithQueueContext(step: StepInfo): EnrichedStepInfo {
+  return { ...step, queue: resolveRepoQueueContext(step) };
+}
+
+export function enrichStepsWithQueueContext(steps: StepInfo[]): EnrichedStepInfo[] {
+  return steps.map(enrichStepWithQueueContext);
+}
+
+/**
+ * Pure formatter for a one-line CLI annotation describing the queue state.
+ * Returns null when the context has no useful information to render.
+ *
+ * Example:
+ *   "queued on /Users/friday/repos/app — blocked by run #42 (implement)"
+ */
+export function formatQueuedAnnotation(ctx: RepoQueueContext | null): string | null {
+  if (!ctx) return null;
+  const repoLabel = ctx.repoPath ?? ctx.repoKey;
+  const blockerPieces: string[] = [];
+  if (ctx.blockingRunNumber != null) {
+    blockerPieces.push(`run #${ctx.blockingRunNumber}`);
+  } else if (ctx.blockingRunId) {
+    blockerPieces.push(`run ${ctx.blockingRunId.slice(0, 8)}`);
+  }
+  if (ctx.blockingStepId) {
+    blockerPieces.push(`step "${ctx.blockingStepId}"`);
+  }
+  const blocker = blockerPieces.length > 0 ? ` — blocked by ${blockerPieces.join(" ")}` : "";
+  return `queued on ${repoLabel}${blocker}`;
+}
+
+/**
+ * Pure formatter for one CLI status step line. Callers that already computed
+ * enrichment can pass the `queue` context explicitly; otherwise they get the
+ * standard `[status] step (agent)` line with no annotation.
+ */
+export function formatStepStatusLine(step: StepInfo, queue: RepoQueueContext | null): string {
+  const base = `  [${step.status}] ${step.step_id} (${step.agent_id})`;
+  const annotation = formatQueuedAnnotation(queue);
+  if (!annotation) return base;
+  return `${base}\n      ↳ ${annotation}`;
+}

--- a/src/installer/run.ts
+++ b/src/installer/run.ts
@@ -6,10 +6,23 @@ import { logger } from "../lib/logger.js";
 import { ensureWorkflowCrons } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
 
+export function buildRunContext(
+  taskTitle: string,
+  workflowContext: Record<string, string> | undefined,
+  initialContext: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  return {
+    task: taskTitle,
+    ...(workflowContext ?? {}),
+    ...(initialContext ?? {}),
+  };
+}
+
 export async function runWorkflow(params: {
   workflowId: string;
   taskTitle: string;
   notifyUrl?: string;
+  initialContext?: Record<string, unknown>;
 }): Promise<{ id: string; runNumber: number; workflowId: string; task: string; status: string }> {
   const workflowDir = resolveWorkflowDir(params.workflowId);
   const workflow = await loadWorkflowSpec(workflowDir);
@@ -18,10 +31,7 @@ export async function runWorkflow(params: {
   const runId = crypto.randomUUID();
   const runNumber = nextRunNumber();
 
-  const initialContext: Record<string, string> = {
-    task: params.taskTitle,
-    ...workflow.context,
-  };
+  const runContext = buildRunContext(params.taskTitle, workflow.context, params.initialContext);
 
   db.exec("BEGIN");
   try {
@@ -29,7 +39,7 @@ export async function runWorkflow(params: {
     const insertRun = db.prepare(
       "INSERT INTO runs (id, run_number, workflow_id, task, status, context, notify_url, created_at, updated_at) VALUES (?, ?, ?, ?, 'running', ?, ?, ?, ?)"
     );
-    insertRun.run(runId, runNumber, workflow.id, params.taskTitle, JSON.stringify(initialContext), notifyUrl, now, now);
+    insertRun.run(runId, runNumber, workflow.id, params.taskTitle, JSON.stringify(runContext), notifyUrl, now, now);
 
     const insertStep = db.prepare(
       "INSERT INTO steps (id, run_id, step_id, agent_id, step_index, input_template, expects, status, max_retries, type, loop_config, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"

--- a/src/installer/status.test.ts
+++ b/src/installer/status.test.ts
@@ -2,8 +2,7 @@ import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import crypto from "node:crypto";
 import { getDb } from "../db.js";
-import { stopWorkflow } from "./status.js";
-import type { StopWorkflowResult } from "./status.js";
+import { archiveWorkflow, listRuns, stopWorkflow } from "./status.js";
 
 // Helper to create a test run with steps
 function createTestRun(opts: {
@@ -45,16 +44,16 @@ function cleanupTestRun(runId: string) {
   db.prepare("DELETE FROM runs WHERE id = ?").run(runId);
 }
 
+const testRunIds: string[] = [];
+
+afterEach(() => {
+  for (const id of testRunIds) {
+    cleanupTestRun(id);
+  }
+  testRunIds.length = 0;
+});
+
 describe("stopWorkflow", () => {
-  const testRunIds: string[] = [];
-
-  afterEach(() => {
-    for (const id of testRunIds) {
-      cleanupTestRun(id);
-    }
-    testRunIds.length = 0;
-  });
-
   it("stops a running workflow with mixed step statuses and returns correct cancelled count", async () => {
     const runId = crypto.randomUUID();
     testRunIds.push(runId);
@@ -72,19 +71,18 @@ describe("stopWorkflow", () => {
 
     const result = await stopWorkflow(runId);
     assert.equal(result.status, "ok");
-    if (result.status !== "ok") return; // narrow type
+    if (result.status !== "ok") return;
     assert.equal(result.runId, runId);
     assert.equal(result.workflowId, "test-wf-1");
-    assert.equal(result.cancelledSteps, 3); // running + waiting + pending
+    assert.equal(result.cancelledSteps, 3);
 
-    // Verify DB state
     const db = getDb();
     const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
     assert.equal(run.status, "cancelled");
 
     const steps = db.prepare("SELECT step_id, status, output FROM steps WHERE run_id = ? ORDER BY step_index").all(runId) as Array<{ step_id: string; status: string; output: string | null }>;
-    assert.equal(steps[0].status, "done"); // done step unchanged
-    assert.equal(steps[0].output, "plan output"); // done step output unchanged
+    assert.equal(steps[0].status, "done");
+    assert.equal(steps[0].output, "plan output");
     assert.equal(steps[1].status, "failed");
     assert.equal(steps[1].output, "Cancelled by user");
     assert.equal(steps[2].status, "failed");
@@ -167,9 +165,8 @@ describe("stopWorkflow", () => {
     const result = await stopWorkflow(runId);
     assert.equal(result.status, "ok");
     if (result.status !== "ok") return;
-    assert.equal(result.cancelledSteps, 1); // only the running step
+    assert.equal(result.cancelledSteps, 1);
 
-    // Verify done steps are untouched
     const db = getDb();
     const steps = db.prepare("SELECT step_id, status, output FROM steps WHERE run_id = ? ORDER BY step_index").all(runId) as Array<{ step_id: string; status: string; output: string | null }>;
     assert.equal(steps[0].status, "done");
@@ -178,5 +175,61 @@ describe("stopWorkflow", () => {
     assert.equal(steps[1].output, "also done");
     assert.equal(steps[2].status, "failed");
     assert.equal(steps[2].output, "Cancelled by user");
+  });
+});
+
+describe("archiveWorkflow", () => {
+  it("archives a cancelled run and hides it from the default run list", async () => {
+    const runId = crypto.randomUUID();
+    testRunIds.push(runId);
+    createTestRun({
+      runId,
+      workflowId: "test-wf-archive",
+      status: "cancelled",
+      steps: [{ stepId: "investigate", status: "failed", output: "Cancelled by user" }],
+    });
+
+    const result = await archiveWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+
+    const db = getDb();
+    const row = db.prepare("SELECT archived_at FROM runs WHERE id = ?").get(runId) as { archived_at: string | null };
+    assert.ok(row.archived_at, "archived_at should be set");
+
+    assert.equal(listRuns().some((r) => r.id === runId), false);
+    assert.equal(listRuns({ onlyArchived: true }).some((r) => r.id === runId), true);
+  });
+
+  it("rejects archiving an active run", async () => {
+    const runId = crypto.randomUUID();
+    testRunIds.push(runId);
+    createTestRun({
+      runId,
+      workflowId: "test-wf-active",
+      status: "running",
+      steps: [{ stepId: "investigate", status: "running" }],
+    });
+
+    const result = await archiveWorkflow(runId);
+    assert.equal(result.status, "not_archivable");
+    if (result.status !== "not_archivable") return;
+    assert.ok(result.message.includes("Only completed, failed, or cancelled runs can be archived"));
+  });
+
+  it("returns already_archived for a run archived twice", async () => {
+    const runId = crypto.randomUUID();
+    testRunIds.push(runId);
+    createTestRun({
+      runId,
+      workflowId: "test-wf-archived",
+      status: "failed",
+      steps: [{ stepId: "fix", status: "failed", output: "boom" }],
+    });
+
+    const first = await archiveWorkflow(runId);
+    assert.equal(first.status, "ok");
+    const second = await archiveWorkflow(runId);
+    assert.equal(second.status, "already_archived");
   });
 });

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -115,24 +115,86 @@ export type ArchiveWorkflowResult =
   | { status: "already_archived"; message: string }
   | { status: "not_archivable"; message: string };
 
+export type PauseMode = "immediate" | "requested";
+
+export type PauseWorkflowResult =
+  | { status: "ok"; mode: PauseMode; runId: string; workflowId: string; pausedAt: string | null; pauseRequestedAt: string }
+  | { status: "not_found"; message: string }
+  | { status: "not_pausable"; message: string }
+  | { status: "already_paused"; message: string };
+
+export type ResumeMode = "paused" | "failed";
+
+export type ResumeWorkflowResult =
+  | {
+      status: "ok";
+      mode: ResumeMode;
+      runId: string;
+      workflowId: string;
+      /** Step id (human-readable) that was returned to pending, when one exists. */
+      nextStepId?: string | null;
+      detail?: string;
+    }
+  | { status: "not_found"; message: string }
+  | { status: "not_resumable"; message: string };
+
+/**
+ * Shared run lookup that mirrors the resolution order used across the
+ * CLI and status helpers:
+ *
+ *   1. numeric `run_number` (if the query is pure digits)
+ *   2. exact `id` match
+ *   3. `id` prefix match
+ *
+ * Returns `undefined` when no run matches. Callers decide how to render
+ * the "not found" message so they can include a recent-runs list.
+ */
+export function findRun(query: string): RunInfo | undefined {
+  const db = getDb();
+  let run: RunInfo | undefined;
+  if (/^\d+$/.test(query)) {
+    run = db
+      .prepare("SELECT * FROM runs WHERE run_number = ? LIMIT 1")
+      .get(parseInt(query, 10)) as RunInfo | undefined;
+  }
+  if (!run) {
+    run = db.prepare("SELECT * FROM runs WHERE id = ?").get(query) as RunInfo | undefined;
+  }
+  if (!run) {
+    run = db
+      .prepare("SELECT * FROM runs WHERE id LIKE ? || '%' ORDER BY created_at DESC LIMIT 1")
+      .get(query) as RunInfo | undefined;
+  }
+  return run;
+}
+
+/**
+ * Build a "no run matching X" message that lists up to 20 recent
+ * non-archived runs so operators can correct typos quickly. Shared by
+ * stop/archive/pause/resume so the UX is consistent.
+ */
+function notFoundMessage(query: string): string {
+  const db = getDb();
+  const allRuns = db
+    .prepare(
+      "SELECT id, run_number, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20",
+    )
+    .all() as Array<{ id: string; run_number: number | null; task: string; status: string; created_at: string }>;
+  const available = allRuns.map((r) => {
+    const num = r.run_number != null ? `#${r.run_number}` : r.id.slice(0, 8);
+    return `  [${r.status}] ${num.padEnd(6)} ${r.task.slice(0, 60)}`;
+  });
+  return available.length
+    ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
+    : "No workflow runs found.";
+}
+
 export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
   const db = getDb();
 
-  // Try exact match first, then prefix match (same pattern as resume command)
-  let run = db.prepare("SELECT * FROM runs WHERE id = ?").get(query) as RunInfo | undefined;
+  const run = findRun(query);
   if (!run) {
-    run = db.prepare("SELECT * FROM runs WHERE id LIKE ? || '%' ORDER BY created_at DESC LIMIT 1").get(query) as RunInfo | undefined;
-  }
-
-  if (!run) {
-    const allRuns = db.prepare("SELECT id, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; task: string; status: string; created_at: string }>;
-    const available = allRuns.map((r) => `  [${r.status}] ${r.id.slice(0, 8)} ${r.task.slice(0, 60)}`);
-    return {
-      status: "not_found",
-      message: available.length
-        ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
-        : "No workflow runs found.",
-    };
+    return { status: "not_found", message: notFoundMessage(query) };
   }
 
   if (run.status === "completed" || run.status === "cancelled") {
@@ -174,26 +236,9 @@ export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
 export async function archiveWorkflow(query: string): Promise<ArchiveWorkflowResult> {
   const db = getDb();
 
-  let run: RunInfo | undefined;
-  if (/^\d+$/.test(query)) {
-    run = db.prepare("SELECT * FROM runs WHERE run_number = ? LIMIT 1").get(parseInt(query, 10)) as RunInfo | undefined;
-  }
+  const run = findRun(query);
   if (!run) {
-    run = db.prepare("SELECT * FROM runs WHERE id = ?").get(query) as RunInfo | undefined;
-  }
-  if (!run) {
-    run = db.prepare("SELECT * FROM runs WHERE id LIKE ? || '%' ORDER BY created_at DESC LIMIT 1").get(query) as RunInfo | undefined;
-  }
-
-  if (!run) {
-    const allRuns = db.prepare("SELECT id, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; task: string; status: string; created_at: string }>;
-    const available = allRuns.map((r) => `  [${r.status}] ${r.id.slice(0, 8)} ${r.task.slice(0, 60)}`);
-    return {
-      status: "not_found",
-      message: available.length
-        ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
-        : "No workflow runs found.",
-    };
+    return { status: "not_found", message: notFoundMessage(query) };
   }
 
   if (run.archived_at) {
@@ -228,4 +273,289 @@ export async function archiveWorkflow(query: string): Promise<ArchiveWorkflowRes
     workflowId: run.workflow_id,
     archivedAt: archived.archived_at,
   };
+}
+
+/**
+ * Cooperatively pause a run.
+ *
+ * If no step is currently running, the run is moved straight into the
+ * `paused` state. If a step is mid-flight, we only record
+ * `pause_requested_at` — the run keeps its active status and pipeline
+ * advancement is expected to honor the flag between steps rather than
+ * killing in-flight work.
+ */
+export async function pauseWorkflow(query: string): Promise<PauseWorkflowResult> {
+  const db = getDb();
+
+  const run = findRun(query);
+  if (!run) {
+    return { status: "not_found", message: notFoundMessage(query) };
+  }
+
+  if (run.status === "paused") {
+    return {
+      status: "already_paused",
+      message: `Run ${run.id.slice(0, 8)} is already paused.`,
+    };
+  }
+
+  if (["completed", "failed", "cancelled"].includes(run.status)) {
+    return {
+      status: "not_pausable",
+      message: `Run ${run.id.slice(0, 8)} is "${run.status}" and cannot be paused.`,
+    };
+  }
+
+  const runningStep = db
+    .prepare("SELECT id FROM steps WHERE run_id = ? AND status = 'running' LIMIT 1")
+    .get(run.id) as { id: string } | undefined;
+
+  const now = new Date().toISOString();
+
+  if (runningStep) {
+    // Cooperative pause: mark the request but leave the running step alone.
+    db.prepare(
+      "UPDATE runs SET pause_requested_at = COALESCE(pause_requested_at, ?), updated_at = datetime('now') WHERE id = ?",
+    ).run(now, run.id);
+    const after = db
+      .prepare("SELECT pause_requested_at FROM runs WHERE id = ?")
+      .get(run.id) as { pause_requested_at: string };
+    emitEvent({
+      ts: now,
+      event: "run.failed",
+      runId: run.id,
+      workflowId: run.workflow_id,
+      detail: "Pause requested (cooperative); will settle between steps",
+    });
+    return {
+      status: "ok",
+      mode: "requested",
+      runId: run.id,
+      workflowId: run.workflow_id,
+      pausedAt: null,
+      pauseRequestedAt: after.pause_requested_at,
+    };
+  }
+
+  // Immediate pause — no step is running, so settle into paused now.
+  db.prepare(
+    `UPDATE runs
+       SET status = 'paused',
+           pause_requested_at = COALESCE(pause_requested_at, ?),
+           paused_at = ?,
+           updated_at = datetime('now')
+     WHERE id = ?`,
+  ).run(now, now, run.id);
+
+  // Best-effort teardown of workflow crons if no other active runs are left.
+  await teardownWorkflowCronsIfIdle(run.workflow_id);
+
+  emitEvent({
+    ts: now,
+    event: "run.failed",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    detail: "Paused by user",
+  });
+
+  return {
+    status: "ok",
+    mode: "immediate",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    pausedAt: now,
+    pauseRequestedAt: now,
+  };
+}
+
+/**
+ * Resume a run.
+ *
+ * - Paused runs: clear pause metadata, set status back to running, and
+ *   promote the next eligible step from `waiting` to `pending` so the
+ *   agent cron picks it up again.
+ * - Failed runs: preserve the historical behavior — reset the failed
+ *   step (or failed story for loop steps) and set the run back to
+ *   running. The verify-each loop case is handled explicitly so resume
+ *   works for both simple steps and verify-each loops.
+ */
+export async function resumeWorkflow(query: string): Promise<ResumeWorkflowResult> {
+  const db = getDb();
+
+  const run = findRun(query);
+  if (!run) {
+    return { status: "not_found", message: notFoundMessage(query) };
+  }
+
+  if (run.status === "paused") {
+    return resumePausedRun(run);
+  }
+  if (run.status === "failed") {
+    return resumeFailedRun(run);
+  }
+
+  return {
+    status: "not_resumable",
+    message: `Run ${run.id.slice(0, 8)} is "${run.status}". Only paused or failed runs can be resumed.`,
+  };
+}
+
+async function resumePausedRun(run: RunInfo): Promise<ResumeWorkflowResult> {
+  const db = getDb();
+
+  db.prepare(
+    `UPDATE runs
+       SET status = 'running',
+           pause_requested_at = NULL,
+           paused_at = NULL,
+           updated_at = datetime('now')
+     WHERE id = ?`,
+  ).run(run.id);
+
+  // Find the next step that is not already terminal. If it's still
+  // `waiting` promote to `pending`; if it's already `pending` or
+  // `running` leave it alone.
+  const nextStep = db
+    .prepare(
+      `SELECT id, step_id, status FROM steps
+        WHERE run_id = ? AND status IN ('waiting', 'pending', 'running')
+        ORDER BY step_index ASC LIMIT 1`,
+    )
+    .get(run.id) as { id: string; step_id: string; status: string } | undefined;
+
+  if (nextStep && nextStep.status === "waiting") {
+    db.prepare(
+      "UPDATE steps SET status = 'pending', updated_at = datetime('now') WHERE id = ?",
+    ).run(nextStep.id);
+  }
+
+  await ensureCronsForWorkflow(run.workflow_id);
+
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "run.started",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    stepId: nextStep?.step_id,
+    detail: "Resumed from paused",
+  });
+
+  return {
+    status: "ok",
+    mode: "paused",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    nextStepId: nextStep?.step_id ?? null,
+    detail: nextStep
+      ? `Resumed from paused — next step "${nextStep.step_id}" is pending`
+      : "Resumed from paused — no pending steps remain",
+  };
+}
+
+async function resumeFailedRun(run: RunInfo): Promise<ResumeWorkflowResult> {
+  const db = getDb();
+
+  const failedStep = db
+    .prepare(
+      "SELECT id, step_id, type, current_story_id FROM steps WHERE run_id = ? AND status = 'failed' ORDER BY step_index ASC LIMIT 1",
+    )
+    .get(run.id) as { id: string; step_id: string; type: string; current_story_id: string | null } | undefined;
+
+  if (!failedStep) {
+    return {
+      status: "not_resumable",
+      message: `No failed step found in run ${run.id.slice(0, 8)}.`,
+    };
+  }
+
+  // If it's a loop step with a failed story, reset that story to pending.
+  if (failedStep.type === "loop") {
+    const failedStory = db
+      .prepare(
+        "SELECT id FROM stories WHERE run_id = ? AND status = 'failed' ORDER BY story_index ASC LIMIT 1",
+      )
+      .get(run.id) as { id: string } | undefined;
+    if (failedStory) {
+      db.prepare(
+        "UPDATE stories SET status = 'pending', updated_at = datetime('now') WHERE id = ?",
+      ).run(failedStory.id);
+    }
+    db.prepare(
+      "UPDATE steps SET retry_count = 0 WHERE run_id = ? AND type = 'loop'",
+    ).run(run.id);
+  }
+
+  // Verify-each loop: a failing verify step means we have to rewind the
+  // paired loop (developer) step so it re-claims the story and repopulates
+  // context, and put the verify step back into `waiting`.
+  const loopStep = db
+    .prepare(
+      "SELECT id, loop_config FROM steps WHERE run_id = ? AND type = 'loop' AND status IN ('running', 'failed') LIMIT 1",
+    )
+    .get(run.id) as { id: string; loop_config: string | null } | undefined;
+
+  if (loopStep?.loop_config) {
+    const lc = JSON.parse(loopStep.loop_config) as { verifyEach?: boolean; verifyStep?: string };
+    if (lc.verifyEach && lc.verifyStep === failedStep.step_id) {
+      db.prepare(
+        "UPDATE steps SET status = 'pending', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?",
+      ).run(loopStep.id);
+      db.prepare(
+        "UPDATE steps SET status = 'waiting', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?",
+      ).run(failedStep.id);
+      db.prepare(
+        "UPDATE stories SET status = 'pending', updated_at = datetime('now') WHERE run_id = ? AND status = 'failed'",
+      ).run(run.id);
+
+      db.prepare(
+        "UPDATE runs SET status = 'running', updated_at = datetime('now') WHERE id = ?",
+      ).run(run.id);
+
+      await ensureCronsForWorkflow(run.workflow_id);
+
+      return {
+        status: "ok",
+        mode: "failed",
+        runId: run.id,
+        workflowId: run.workflow_id,
+        nextStepId: failedStep.step_id,
+        detail: `Reset loop step "${loopStep.id.slice(0, 8)}" to pending, verify step "${failedStep.step_id}" to waiting`,
+      };
+    }
+  }
+
+  // Simple failed step: reset to pending and run.
+  db.prepare(
+    "UPDATE steps SET status = 'pending', current_story_id = NULL, retry_count = 0, updated_at = datetime('now') WHERE id = ?",
+  ).run(failedStep.id);
+
+  db.prepare(
+    "UPDATE runs SET status = 'running', updated_at = datetime('now') WHERE id = ?",
+  ).run(run.id);
+
+  await ensureCronsForWorkflow(run.workflow_id);
+
+  return {
+    status: "ok",
+    mode: "failed",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    nextStepId: failedStep.step_id,
+    detail: `Resumed from failed step "${failedStep.step_id}"`,
+  };
+}
+
+async function ensureCronsForWorkflow(workflowId: string): Promise<void> {
+  try {
+    const { loadWorkflowSpec } = await import("./workflow-spec.js");
+    const { resolveWorkflowDir } = await import("./paths.js");
+    const { ensureWorkflowCrons } = await import("./agent-cron.js");
+    const workflowDir = resolveWorkflowDir(workflowId);
+    const workflow = await loadWorkflowSpec(workflowDir);
+    await ensureWorkflowCrons(workflow);
+  } catch {
+    // Best-effort — callers should not fail their lifecycle operation
+    // just because cron bootstrap failed. Operators can re-run
+    // `workflow ensure-crons` to recover.
+  }
 }

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -3,6 +3,7 @@ import { teardownWorkflowCronsIfIdle } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
 import { archiveRunProgress } from "./step-ops.js";
 import { releaseRunSteps } from "./repo-scheduler.js";
+import { enrichStepsWithQueueContext, type EnrichedStepInfo } from "./repo-visibility.js";
 
 /**
  * Lifecycle states a run row in the `runs` table can have.
@@ -66,7 +67,7 @@ export type StepInfo = {
 };
 
 export type WorkflowStatusResult =
-  | { status: "ok"; run: RunInfo; steps: StepInfo[] }
+  | { status: "ok"; run: RunInfo; steps: EnrichedStepInfo[] }
   | { status: "not_found"; message: string };
 
 export function getWorkflowStatus(query: string): WorkflowStatusResult {
@@ -107,7 +108,7 @@ export function getWorkflowStatus(query: string): WorkflowStatusResult {
   }
 
   const steps = db.prepare("SELECT * FROM steps WHERE run_id = ? ORDER BY step_index ASC").all(run.id) as StepInfo[];
-  return { status: "ok", run, steps };
+  return { status: "ok", run, steps: enrichStepsWithQueueContext(steps) };
 }
 
 export function listRuns(opts: { includeArchived?: boolean; onlyArchived?: boolean } = {}): RunInfo[] {

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -2,6 +2,7 @@ import { getDb } from "../db.js";
 import { teardownWorkflowCronsIfIdle } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
 import { archiveRunProgress } from "./step-ops.js";
+import { releaseRunSteps } from "./repo-scheduler.js";
 
 /**
  * Lifecycle states a run row in the `runs` table can have.
@@ -228,6 +229,11 @@ export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
     "UPDATE steps SET status = 'failed', output = 'Cancelled by user', updated_at = datetime('now') WHERE run_id = ? AND status IN ('waiting', 'pending', 'running')"
   ).run(run.id);
   const cancelledSteps = Number(result.changes);
+
+  // Release any shared_checkout_exclusive repo leases held by this run so
+  // queued same-repo work resumes immediately instead of waiting for the
+  // next annotateBlockedCodingSteps pass to self-heal.
+  releaseRunSteps(run.id, "cancelled");
 
   // Clean up cron jobs if no other active runs
   await teardownWorkflowCronsIfIdle(run.workflow_id);

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -44,6 +44,22 @@ export type StepInfo = {
   output: string | null;
   retry_count: number;
   max_retries: number;
+  /**
+   * Scheduling policy for this step against the shared repo checkout.
+   * See `StepExecutionMode` for values. `null` on legacy rows that predate the
+   * same-repo serialization migration.
+   */
+  execution_mode: string | null;
+  /** Normalized repo identity used to key same-checkout scheduling decisions. */
+  repo_key: string | null;
+  /** Raw repo path as supplied by the run context; preserved for operator visibility. */
+  repo_path: string | null;
+  /** When the step first entered the queued/blocked-by-repo-lock state. */
+  queued_at: string | null;
+  /** If queued/blocked, the run id currently holding the shared checkout. */
+  blocked_by_run_id: string | null;
+  /** If queued/blocked, the step id currently holding the shared checkout. */
+  blocked_by_step_id: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -1,6 +1,7 @@
 import { getDb } from "../db.js";
 import { teardownWorkflowCronsIfIdle } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
+import { archiveRunProgress } from "./step-ops.js";
 
 export type RunInfo = {
   id: string;
@@ -9,6 +10,7 @@ export type RunInfo = {
   task: string;
   status: string;
   context: string;
+  archived_at: string | null;
   created_at: string;
   updated_at: string;
 };
@@ -57,7 +59,7 @@ export function getWorkflowStatus(query: string): WorkflowStatusResult {
   }
 
   if (!run) {
-    const allRuns = db.prepare("SELECT id, run_number, task, status, created_at FROM runs ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; run_number: number | null; task: string; status: string; created_at: string }>;
+    const allRuns = db.prepare("SELECT id, run_number, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; run_number: number | null; task: string; status: string; created_at: string }>;
     const available = allRuns.map((r) => {
       const num = r.run_number != null ? `#${r.run_number}` : r.id.slice(0, 8);
       return `  [${r.status}] ${num.padEnd(6)} ${r.task.slice(0, 60)}`;
@@ -74,15 +76,27 @@ export function getWorkflowStatus(query: string): WorkflowStatusResult {
   return { status: "ok", run, steps };
 }
 
-export function listRuns(): RunInfo[] {
+export function listRuns(opts: { includeArchived?: boolean; onlyArchived?: boolean } = {}): RunInfo[] {
   const db = getDb();
-  return db.prepare("SELECT * FROM runs ORDER BY created_at DESC").all() as RunInfo[];
+  if (opts.onlyArchived) {
+    return db.prepare("SELECT * FROM runs WHERE archived_at IS NOT NULL ORDER BY archived_at DESC, created_at DESC").all() as RunInfo[];
+  }
+  if (opts.includeArchived) {
+    return db.prepare("SELECT * FROM runs ORDER BY created_at DESC").all() as RunInfo[];
+  }
+  return db.prepare("SELECT * FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC").all() as RunInfo[];
 }
 
 export type StopWorkflowResult =
   | { status: "ok"; runId: string; workflowId: string; cancelledSteps: number }
   | { status: "not_found"; message: string }
   | { status: "already_done"; message: string };
+
+export type ArchiveWorkflowResult =
+  | { status: "ok"; runId: string; workflowId: string; archivedAt: string }
+  | { status: "not_found"; message: string }
+  | { status: "already_archived"; message: string }
+  | { status: "not_archivable"; message: string };
 
 export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
   const db = getDb();
@@ -94,7 +108,7 @@ export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
   }
 
   if (!run) {
-    const allRuns = db.prepare("SELECT id, task, status, created_at FROM runs ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; task: string; status: string; created_at: string }>;
+    const allRuns = db.prepare("SELECT id, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; task: string; status: string; created_at: string }>;
     const available = allRuns.map((r) => `  [${r.status}] ${r.id.slice(0, 8)} ${r.task.slice(0, 60)}`);
     return {
       status: "not_found",
@@ -137,5 +151,64 @@ export async function stopWorkflow(query: string): Promise<StopWorkflowResult> {
     runId: run.id,
     workflowId: run.workflow_id,
     cancelledSteps,
+  };
+}
+
+export async function archiveWorkflow(query: string): Promise<ArchiveWorkflowResult> {
+  const db = getDb();
+
+  let run: RunInfo | undefined;
+  if (/^\d+$/.test(query)) {
+    run = db.prepare("SELECT * FROM runs WHERE run_number = ? LIMIT 1").get(parseInt(query, 10)) as RunInfo | undefined;
+  }
+  if (!run) {
+    run = db.prepare("SELECT * FROM runs WHERE id = ?").get(query) as RunInfo | undefined;
+  }
+  if (!run) {
+    run = db.prepare("SELECT * FROM runs WHERE id LIKE ? || '%' ORDER BY created_at DESC LIMIT 1").get(query) as RunInfo | undefined;
+  }
+
+  if (!run) {
+    const allRuns = db.prepare("SELECT id, task, status, created_at FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC LIMIT 20").all() as Array<{ id: string; task: string; status: string; created_at: string }>;
+    const available = allRuns.map((r) => `  [${r.status}] ${r.id.slice(0, 8)} ${r.task.slice(0, 60)}`);
+    return {
+      status: "not_found",
+      message: available.length
+        ? `No run matching "${query}". Recent runs:\n${available.join("\n")}`
+        : "No workflow runs found.",
+    };
+  }
+
+  if (run.archived_at) {
+    return {
+      status: "already_archived",
+      message: `Run ${run.id.slice(0, 8)} is already archived.`,
+    };
+  }
+
+  if (!["completed", "failed", "cancelled"].includes(run.status)) {
+    return {
+      status: "not_archivable",
+      message: `Run ${run.id.slice(0, 8)} is "${run.status}". Only completed, failed, or cancelled runs can be archived.`,
+    };
+  }
+
+  db.prepare("UPDATE runs SET archived_at = datetime('now'), updated_at = datetime('now') WHERE id = ?").run(run.id);
+  archiveRunProgress(run.id);
+  const archived = db.prepare("SELECT archived_at FROM runs WHERE id = ?").get(run.id) as { archived_at: string };
+
+  emitEvent({
+    ts: new Date().toISOString(),
+    event: "run.archived",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    detail: `Archived from ${run.status}`,
+  });
+
+  return {
+    status: "ok",
+    runId: run.id,
+    workflowId: run.workflow_id,
+    archivedAt: archived.archived_at,
   };
 }

--- a/src/installer/status.ts
+++ b/src/installer/status.ts
@@ -3,14 +3,31 @@ import { teardownWorkflowCronsIfIdle } from "./agent-cron.js";
 import { emitEvent } from "./events.js";
 import { archiveRunProgress } from "./step-ops.js";
 
+/**
+ * Lifecycle states a run row in the `runs` table can have.
+ *
+ * `paused` is a resumable parked state distinct from `cancelled` /
+ * `completed` / `failed` — the run keeps its progress and can later be
+ * resumed without being archived.
+ */
+export type RunStatus =
+  | "running"
+  | "paused"
+  | "blocked"
+  | "completed"
+  | "cancelled"
+  | "failed";
+
 export type RunInfo = {
   id: string;
   run_number: number | null;
   workflow_id: string;
   task: string;
-  status: string;
+  status: RunStatus | string;
   context: string;
   archived_at: string | null;
+  pause_requested_at: string | null;
+  paused_at: string | null;
   created_at: string;
   updated_at: string;
 };

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -503,6 +503,75 @@ let lastCleanupTime = 0;
 const CLEANUP_THROTTLE_MS = 5 * 60 * 1000; // 5 minutes
 
 /**
+ * Refresh `blocked_by_*` / `queued_at` metadata on pending
+ * shared_checkout_exclusive steps so operators can see *why* a same-repo
+ * coding step is still queued.
+ *
+ * Scoped by agentId to keep the update set small: we only annotate the
+ * candidates this agent would actually consider on its next poll. The guard
+ * itself (in the claim SELECT) already spans workflows, so this helper is
+ * strictly for visibility.
+ *
+ * Rules:
+ *   - If a pending shared_checkout_exclusive step's repo_key matches any
+ *     currently-running shared_checkout_exclusive step, record the busy
+ *     owner on the pending step. Re-runs safely refresh the annotation.
+ *   - If no running same-repo step exists, clear any stale block metadata.
+ */
+function annotateBlockedCodingSteps(agentId: string): void {
+  const db = getDb();
+
+  const pending = db.prepare(
+    `SELECT s.id, s.repo_key
+       FROM steps s
+       JOIN runs r ON r.id = s.run_id
+      WHERE s.agent_id = ?
+        AND s.status = 'pending'
+        AND s.execution_mode = 'shared_checkout_exclusive'
+        AND s.repo_key IS NOT NULL
+        AND r.status NOT IN ('failed', 'cancelled')`
+  ).all(agentId) as Array<{ id: string; repo_key: string }>;
+
+  if (pending.length === 0) return;
+
+  const findOwner = db.prepare(
+    `SELECT id, run_id
+       FROM steps
+      WHERE status = 'running'
+        AND execution_mode = 'shared_checkout_exclusive'
+        AND repo_key = ?
+      ORDER BY updated_at ASC
+      LIMIT 1`
+  );
+  const markBlocked = db.prepare(
+    `UPDATE steps
+        SET blocked_by_run_id = ?,
+            blocked_by_step_id = ?,
+            queued_at = COALESCE(queued_at, datetime('now')),
+            updated_at = datetime('now')
+      WHERE id = ? AND status = 'pending'`
+  );
+  const clearBlocked = db.prepare(
+    `UPDATE steps
+        SET blocked_by_run_id = NULL,
+            blocked_by_step_id = NULL,
+            queued_at = NULL,
+            updated_at = datetime('now')
+      WHERE id = ? AND status = 'pending'
+        AND (blocked_by_run_id IS NOT NULL OR blocked_by_step_id IS NOT NULL OR queued_at IS NOT NULL)`
+  );
+
+  for (const row of pending) {
+    const owner = findOwner.get(row.repo_key) as { id: string; run_id: string } | undefined;
+    if (owner && owner.id !== row.id) {
+      markBlocked.run(owner.run_id, owner.id, row.id);
+    } else {
+      clearBlocked.run(row.id);
+    }
+  }
+}
+
+/**
  * Find and claim a pending step for an agent, returning the resolved input.
  */
 export function claimStep(agentId: string): ClaimResult {
@@ -515,7 +584,8 @@ export function claimStep(agentId: string): ClaimResult {
   const db = getDb();
 
   const step = db.prepare(
-    `SELECT s.id, s.step_id, s.run_id, s.input_template, s.type, s.loop_config, s.step_index
+    `SELECT s.id, s.step_id, s.run_id, s.input_template, s.type, s.loop_config, s.step_index,
+            s.execution_mode, s.repo_key
      FROM steps s
      JOIN runs r ON r.id = s.run_id
      WHERE s.agent_id = ? AND s.status = 'pending'
@@ -526,15 +596,33 @@ export function claimStep(agentId: string): ClaimResult {
            AND prev.step_index < s.step_index
            AND prev.status NOT IN ('done', 'skipped')
        )
+       AND NOT EXISTS (
+         SELECT 1 FROM steps busy
+         WHERE busy.status = 'running'
+           AND busy.execution_mode = 'shared_checkout_exclusive'
+           AND s.execution_mode = 'shared_checkout_exclusive'
+           AND busy.repo_key IS NOT NULL
+           AND s.repo_key IS NOT NULL
+           AND busy.repo_key = s.repo_key
+           AND busy.id != s.id
+       )
     ORDER BY s.step_index ASC, s.step_id ASC
      LIMIT 1`
   ).get(agentId) as {
     id: string; step_id: string; run_id: string; input_template: string; type: string;
     loop_config: string | null;
     step_index: number;
+    execution_mode: string | null;
+    repo_key: string | null;
   } | undefined;
 
-  if (!step) return { found: false };
+  if (!step) {
+    // Nothing claimable right now — refresh block metadata for any pending
+    // shared_checkout_exclusive steps this agent owns so the dashboard /
+    // status output can explain why later same-repo work is still queued.
+    annotateBlockedCodingSteps(agentId);
+    return { found: false };
+  }
 
   // Guard: don't claim work for a failed run
   const runStatus = db.prepare("SELECT status FROM runs WHERE id = ?").get(step.run_id) as { status: string } | undefined;
@@ -612,7 +700,14 @@ export function claimStep(agentId: string): ClaimResult {
         "UPDATE stories SET status = 'running', updated_at = datetime('now') WHERE id = ?"
       ).run(nextStory.id);
       db.prepare(
-        "UPDATE steps SET status = 'running', current_story_id = ?, updated_at = datetime('now') WHERE id = ?"
+        `UPDATE steps
+            SET status = 'running',
+                current_story_id = ?,
+                blocked_by_run_id = NULL,
+                blocked_by_step_id = NULL,
+                queued_at = NULL,
+                updated_at = datetime('now')
+          WHERE id = ?`
       ).run(nextStory.id, step.id);
 
       const wfId = getWorkflowId(step.run_id);
@@ -663,9 +758,17 @@ export function claimStep(agentId: string): ClaimResult {
     }
   }
 
-  // Single step: existing logic
+  // Single step: existing logic. Clear any stale block metadata recorded while
+  // this step was queued behind a same-repo coding step so the dashboard no
+  // longer shows it as blocked once it's actually running.
   db.prepare(
-    "UPDATE steps SET status = 'running', updated_at = datetime('now') WHERE id = ? AND status = 'pending'"
+    `UPDATE steps
+        SET status = 'running',
+            blocked_by_run_id = NULL,
+            blocked_by_step_id = NULL,
+            queued_at = NULL,
+            updated_at = datetime('now')
+      WHERE id = ? AND status = 'pending'`
   ).run(step.id);
   emitEvent({ ts: new Date().toISOString(), event: "step.running", runId: step.run_id, workflowId: getWorkflowId(step.run_id), stepId: step.step_id, agentId: agentId });
   logger.info(`Step claimed by ${agentId}`, { runId: step.run_id, stepId: step.step_id });

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -54,6 +54,29 @@ export function parseOutputKeyValues(output: string): Record<string, string> {
 }
 
 /**
+ * Structured expects blocks are newline-delimited required snippets.
+ * A single KEY: value line is also treated as structured so guards like
+ * expects: "STATUS: done" cannot silently pass on STATUS: retry output.
+ * Plain one-word expects remain advisory for backwards compatibility.
+ */
+export function getStructuredExpectSnippets(expects: string): string[] {
+  const lines = expects
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length > 1) return lines;
+  if (lines.length === 1 && /^[A-Z_]+:\s*.*$/.test(lines[0])) return lines;
+  return [];
+}
+
+export function findMissingStructuredExpectSnippets(output: string, expects: string): string[] {
+  const required = getStructuredExpectSnippets(expects);
+  if (required.length === 0) return [];
+  return required.filter((snippet) => !output.includes(snippet));
+}
+
+/**
  * Fire-and-forget cron teardown when a run ends.
  * Looks up the workflow_id for the run and tears down crons if no other active runs.
  */
@@ -680,14 +703,43 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
   const db = getDb();
 
   const step = db.prepare(
-    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id FROM steps WHERE id = ?"
-  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null } | undefined;
+    "SELECT id, run_id, step_id, step_index, type, loop_config, current_story_id, expects FROM steps WHERE id = ?"
+  ).get(stepId) as { id: string; run_id: string; step_id: string; step_index: number; type: string; loop_config: string | null; current_story_id: string | null; expects: string } | undefined;
 
   if (!step) throw new Error(`Step not found: ${stepId}`);
 
   // Guard: don't process completions for failed runs
   const runCheck = db.prepare("SELECT status FROM runs WHERE id = ?").get(step.run_id) as { status: string } | undefined;
   if (runCheck?.status === "failed") {
+    return { advanced: false, runCompleted: false };
+  }
+
+  const missingExpected = findMissingStructuredExpectSnippets(output, step.expects);
+  if (missingExpected.length > 0) {
+    const wfId = getWorkflowId(step.run_id);
+    const message = `Step output is missing required content: ${missingExpected.join(", ")}`;
+
+    db.prepare(
+      "UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?"
+    ).run(message, step.id);
+    db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
+
+    emitEvent({
+      ts: new Date().toISOString(),
+      event: "step.failed",
+      runId: step.run_id,
+      workflowId: wfId,
+      stepId: step.step_id,
+      detail: message,
+    });
+    emitEvent({
+      ts: new Date().toISOString(),
+      event: "run.failed",
+      runId: step.run_id,
+      workflowId: wfId,
+      detail: message,
+    });
+    scheduleRunCronTeardown(step.run_id);
     return { advanced: false, runCompleted: false };
   }
 

--- a/src/installer/step-ops.ts
+++ b/src/installer/step-ops.ts
@@ -14,6 +14,7 @@ import { loadWorkflowSpec } from "./workflow-spec.js";
 import { resolveWorkflowDir } from "./paths.js";
 import { isFrontendChange } from "../lib/frontend-detect.js";
 import type { WorkflowStepFailure } from "./types.js";
+import { releaseStepLeaseById, releaseStepResources } from "./repo-scheduler.js";
 
 /**
  * Parse KEY: value lines from step output with support for multi-line values.
@@ -333,6 +334,7 @@ export function cleanupAbandonedSteps(): void {
         if (newRetry > story.max_retries) {
           db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
           db.prepare("UPDATE steps SET status = 'failed', output = 'Story abandoned and retries exhausted', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(step.id);
+          releaseStepLeaseById(step.id, "abandoned");
           db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
           emitEvent({ ts: new Date().toISOString(), event: "story.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, storyId: story.story_id, storyTitle: story.title, detail: "Abandoned — retries exhausted" });
           emitEvent({ ts: new Date().toISOString(), event: "step.failed", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: "Story abandoned and retries exhausted" });
@@ -341,6 +343,7 @@ export function cleanupAbandonedSteps(): void {
         } else {
           db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
           db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(step.id);
+          releaseStepLeaseById(step.id, "abandoned");
           emitEvent({ ts: new Date().toISOString(), event: "step.timeout", runId: step.run_id, workflowId: wfId, stepId: step.step_id, detail: `Story ${story.story_id} abandoned — reset to pending (story retry ${newRetry})` });
           logger.info(`Abandoned step reset to pending (story retry ${newRetry})`, { runId: step.run_id, stepId: step.step_id });
         }
@@ -355,6 +358,7 @@ export function cleanupAbandonedSteps(): void {
       db.prepare(
         "UPDATE steps SET status = 'failed', output = 'Agent abandoned step without completing (' || ? || ' times)', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
       ).run(newAbandonCount, newAbandonCount, step.id);
+      releaseStepLeaseById(step.id, "abandoned");
       db.prepare(
         "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
       ).run(step.run_id);
@@ -368,6 +372,7 @@ export function cleanupAbandonedSteps(): void {
       db.prepare(
         "UPDATE steps SET status = 'pending', abandoned_count = ?, updated_at = datetime('now') WHERE id = ?"
       ).run(newAbandonCount, step.id);
+      releaseStepLeaseById(step.id, "abandoned");
       emitEvent({ ts: new Date().toISOString(), event: "step.timeout", runId: step.run_id, workflowId: getWorkflowId(step.run_id), stepId: step.step_id, detail: `Reset to pending (abandon ${newAbandonCount}/${MAX_ABANDON_RESETS})` });
     }
   }
@@ -605,6 +610,22 @@ export function claimStep(agentId: string): ClaimResult {
            AND s.repo_key IS NOT NULL
            AND busy.repo_key = s.repo_key
            AND busy.id != s.id
+       )
+       AND NOT EXISTS (
+         SELECT 1 FROM steps earlier
+         JOIN runs earlier_run ON earlier_run.id = earlier.run_id
+         WHERE earlier.status = 'pending'
+           AND earlier.execution_mode = 'shared_checkout_exclusive'
+           AND s.execution_mode = 'shared_checkout_exclusive'
+           AND earlier.repo_key IS NOT NULL
+           AND s.repo_key IS NOT NULL
+           AND earlier.repo_key = s.repo_key
+           AND earlier.id != s.id
+           AND earlier_run.status NOT IN ('failed','cancelled')
+           AND (
+             earlier.created_at < s.created_at
+             OR (earlier.created_at = s.created_at AND earlier.id < s.id)
+           )
        )
     ORDER BY s.step_index ASC, s.step_id ASC
      LIMIT 1`
@@ -922,6 +943,7 @@ export function completeStep(stepId: string, output: string): { advanced: boolea
   db.prepare(
     "UPDATE steps SET status = 'done', output = ?, updated_at = datetime('now') WHERE id = ?"
   ).run(output, stepId);
+  releaseStepLeaseById(stepId, "completed");
   emitEvent({ ts: new Date().toISOString(), event: "step.done", runId: step.run_id, workflowId: getWorkflowId(step.run_id), stepId: step.step_id });
   logger.info(`Step completed: ${step.step_id}`, { runId: step.run_id, stepId: step.step_id });
 
@@ -962,6 +984,7 @@ function handleVerifyEachCompletion(
         // Story retries exhausted — fail everything
         db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, lastDoneStory.id);
         db.prepare("UPDATE steps SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(loopStepId);
+        releaseStepLeaseById(loopStepId, "failed");
         db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(verifyStep.run_id);
         const wfId = getWorkflowId(verifyStep.run_id);
         emitEvent({ ts: new Date().toISOString(), event: "story.failed", runId: verifyStep.run_id, workflowId: wfId, stepId: verifyStep.step_id });
@@ -982,6 +1005,7 @@ function handleVerifyEachCompletion(
 
     // Set loop step back to pending for retry
     db.prepare("UPDATE steps SET status = 'pending', updated_at = datetime('now') WHERE id = ?").run(loopStepId);
+    releaseStepLeaseById(loopStepId, "failed");
     return { advanced: false, runCompleted: false };
   }
 
@@ -1032,6 +1056,7 @@ function checkLoopContinuation(runId: string, loopStepId: string): { advanced: b
     db.prepare(
       "UPDATE steps SET status = 'failed', output = ?, updated_at = datetime('now') WHERE id = ?"
     ).run("Loop cannot continue because one or more stories failed", loopStepId);
+    releaseStepLeaseById(loopStepId, "failed");
     db.prepare(
       "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
     ).run(runId);
@@ -1046,6 +1071,7 @@ function checkLoopContinuation(runId: string, loopStepId: string): { advanced: b
   db.prepare(
     "UPDATE steps SET status = 'done', updated_at = datetime('now') WHERE id = ?"
   ).run(loopStepId);
+  releaseStepLeaseById(loopStepId, "completed");
 
   // Also mark verify step done if it exists
   const loopStep = db.prepare("SELECT loop_config, run_id FROM steps WHERE id = ?").get(loopStepId) as { loop_config: string | null; run_id: string } | undefined;
@@ -1216,6 +1242,7 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
         // Story retries exhausted
         db.prepare("UPDATE stories SET status = 'failed', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
         db.prepare("UPDATE steps SET status = 'failed', output = ?, current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(error, stepId);
+        releaseStepLeaseById(stepId, "failed");
         db.prepare("UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?").run(step.run_id);
         const wfId = getWorkflowId(step.run_id);
         emitEvent({ ts: new Date().toISOString(), event: "story.failed", runId: step.run_id, workflowId: wfId, stepId: stepId, storyId: storyRow?.story_id, storyTitle: storyRow?.title, detail: error });
@@ -1226,9 +1253,11 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
         return { retrying: false, runFailed: true };
       }
 
-      // Retry the story
+      // Retry the story — loop step resets to pending so the lock is released
+      // and the next queued same-repo step can claim before we retry.
       db.prepare("UPDATE stories SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?").run(newRetry, story.id);
       db.prepare("UPDATE steps SET status = 'pending', current_story_id = NULL, updated_at = datetime('now') WHERE id = ?").run(stepId);
+      releaseStepLeaseById(stepId, "failed");
       return { retrying: true, runFailed: false };
     }
   }
@@ -1240,6 +1269,7 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
     db.prepare(
       "UPDATE steps SET status = 'failed', output = ?, retry_count = ?, updated_at = datetime('now') WHERE id = ?"
     ).run(error, newRetryCount, stepId);
+    releaseStepLeaseById(stepId, "failed");
     db.prepare(
       "UPDATE runs SET status = 'failed', updated_at = datetime('now') WHERE id = ?"
     ).run(step.run_id);
@@ -1253,6 +1283,7 @@ export async function failStep(stepId: string, error: string): Promise<{ retryin
     db.prepare(
       "UPDATE steps SET status = 'pending', retry_count = ?, updated_at = datetime('now') WHERE id = ?"
     ).run(newRetryCount, stepId);
+    releaseStepLeaseById(stepId, "failed");
     return { retrying: true, runFailed: false };
   }
 }

--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -23,8 +23,17 @@ export type WorkflowAgent = {
   role?: AgentRole;
   model?: string;
   pollingModel?: string;
+  executor?: WorkflowAgentExecutor;
   timeoutSeconds?: number;
   workspace: WorkflowAgentFiles;
+};
+
+export type WorkflowAgentExecutor = {
+  kind: "claude-code-wrapper";
+  command: string;
+  model?: string;
+  effort?: "low" | "medium" | "high";
+  maxTurns?: number;
 };
 
 export type PollingConfig = {

--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -67,6 +67,22 @@ export type WorkflowStep = {
   on_fail?: WorkflowStepFailure;
 };
 
+/**
+ * How a step must be scheduled against its target repo checkout.
+ *
+ * - `shared_checkout_exclusive`: v1 serialization. The step mutates the shared
+ *   repo checkout, so at most one such step may be active per `repo_key` at a
+ *   time. Other same-repo steps queue until the lock is released.
+ * - `no_lock`: The step does not need exclusive access to the repo checkout
+ *   (read-only analysis, verification of already-committed code, etc.) and
+ *   may run alongside other steps.
+ *
+ * Future modes (e.g. `worktree_isolated`) can be added here once explicit
+ * per-run worktrees exist — the scheduler seam is designed so `no_lock`
+ * behavior is the fallback and exclusivity is opt-in by mode value.
+ */
+export type StepExecutionMode = "shared_checkout_exclusive" | "no_lock";
+
 export type Story = {
   id: string;
   runId: string;

--- a/src/installer/types.ts
+++ b/src/installer/types.ts
@@ -120,6 +120,10 @@ export type WorkflowRunRecord = {
   stepResults: StepResult[];
   retryCount: number;
   context: Record<string, string>;
+  /** Set when a cooperative pause has been requested but the current step is still running. */
+  pauseRequestedAt?: string | null;
+  /** Set once the run has actually settled into a paused state between steps. */
+  pausedAt?: string | null;
   createdAt: string;
   updatedAt: string;
 };

--- a/src/installer/workflow-spec.ts
+++ b/src/installer/workflow-spec.ts
@@ -68,6 +68,20 @@ function validateAgents(agents: WorkflowAgent[], workflowDir: string) {
     if (agent.timeoutSeconds !== undefined && agent.timeoutSeconds <= 0) {
       throw new Error(`workflow.yml agent "${agent.id}" timeoutSeconds must be positive`);
     }
+    if (agent.executor) {
+      if (agent.executor.kind !== "claude-code-wrapper") {
+        throw new Error(`workflow.yml agent "${agent.id}" has unsupported executor kind "${(agent.executor as any).kind}"`);
+      }
+      if (!agent.executor.command?.trim()) {
+        throw new Error(`workflow.yml agent "${agent.id}" executor.command is required`);
+      }
+      if (agent.executor.maxTurns !== undefined && agent.executor.maxTurns <= 0) {
+        throw new Error(`workflow.yml agent "${agent.id}" executor.maxTurns must be positive`);
+      }
+      if (agent.executor.effort !== undefined && !["low", "medium", "high"].includes(agent.executor.effort)) {
+        throw new Error(`workflow.yml agent "${agent.id}" executor.effort must be low, medium, or high`);
+      }
+    }
   }
 }
 

--- a/src/integrations/linear/config.ts
+++ b/src/integrations/linear/config.ts
@@ -1,0 +1,238 @@
+/**
+ * Linear integration config loader.
+ *
+ * Reads ~/.openclaw/antfarm/linear.json and LINEAR_API_TOKEN, validates
+ * them against the MVP scope (one team, feature-dev workflow, exactly
+ * one readiness selector, full state-map writeback), and returns a
+ * typed result.
+ *
+ * Invalid config throws LinearConfigError with an actionable message.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type { LinearConfig, LinearStateMap } from "./types.js";
+
+export const MVP_WORKFLOW_ID = "feature-dev";
+
+export const DEFAULT_LINEAR_CONFIG_PATH = path.join(
+  os.homedir(),
+  ".openclaw",
+  "antfarm",
+  "linear.json",
+);
+
+export class LinearConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LinearConfigError";
+  }
+}
+
+export interface LoadLinearConfigOptions {
+  /** Override the config file path. Defaults to ~/.openclaw/antfarm/linear.json. */
+  configPath?: string;
+  /** Override the API token. Defaults to process.env.LINEAR_API_TOKEN. */
+  apiToken?: string;
+  /** Override env lookup (used by tests). */
+  env?: NodeJS.ProcessEnv;
+}
+
+export interface LoadedLinearConfig {
+  config: LinearConfig;
+  apiToken: string;
+  path: string;
+}
+
+/**
+ * Load, parse, and validate the Linear integration config.
+ *
+ * Precedence: explicit options override env and filesystem.
+ * Throws {@link LinearConfigError} with a clear message on any problem.
+ */
+export function loadLinearConfig(
+  options: LoadLinearConfigOptions = {},
+): LoadedLinearConfig {
+  const env = options.env ?? process.env;
+  const configPath = options.configPath ?? DEFAULT_LINEAR_CONFIG_PATH;
+
+  const apiToken = (options.apiToken ?? env.LINEAR_API_TOKEN ?? "").trim();
+  if (!apiToken) {
+    throw new LinearConfigError(
+      "Missing LINEAR_API_TOKEN environment variable. " +
+        "Set it to a Linear personal API key to enable the integration.",
+    );
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(configPath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      throw new LinearConfigError(
+        `Linear config not found at ${configPath}. ` +
+          `Create it with: antfarm linear install`,
+      );
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new LinearConfigError(
+      `Failed to read Linear config at ${configPath}: ${message}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new LinearConfigError(
+      `Linear config at ${configPath} is not valid JSON: ${message}`,
+    );
+  }
+
+  const config = validateLinearConfig(parsed, configPath);
+  return { config, apiToken, path: configPath };
+}
+
+/**
+ * Validate a parsed config blob against MVP rules and return a typed
+ * {@link LinearConfig}. Exported so tests and the installer can run
+ * validation without touching the filesystem.
+ */
+export function validateLinearConfig(
+  input: unknown,
+  sourceLabel = "linear.json",
+): LinearConfig {
+  if (!isRecord(input)) {
+    throw new LinearConfigError(
+      `${sourceLabel} must be a JSON object (got ${describe(input)}).`,
+    );
+  }
+
+  const teamId = requireString(input.teamId, "teamId", sourceLabel);
+  const workflowId = requireString(input.workflowId, "workflowId", sourceLabel);
+  if (workflowId !== MVP_WORKFLOW_ID) {
+    throw new LinearConfigError(
+      `${sourceLabel}: workflowId must be "${MVP_WORKFLOW_ID}" for the ` +
+        `Linear MVP (got "${workflowId}").`,
+    );
+  }
+
+  const defaultRepoPath = requireString(
+    input.defaultRepoPath,
+    "defaultRepoPath",
+    sourceLabel,
+  );
+
+  if (!isRecord(input.states)) {
+    throw new LinearConfigError(
+      `${sourceLabel}: "states" must be an object mapping Linear workflow ` +
+        `state ids for readiness, running, done, and failed transitions.`,
+    );
+  }
+  const states = validateStateMap(input.states, sourceLabel);
+
+  return {
+    teamId,
+    workflowId,
+    defaultRepoPath,
+    states,
+  };
+}
+
+function validateStateMap(
+  input: Record<string, unknown>,
+  sourceLabel: string,
+): LinearStateMap {
+  const runningStateId = requireString(
+    input.runningStateId,
+    "states.runningStateId",
+    sourceLabel,
+  );
+  const doneStateId = requireString(
+    input.doneStateId,
+    "states.doneStateId",
+    sourceLabel,
+  );
+  const failedStateId = requireString(
+    input.failedStateId,
+    "states.failedStateId",
+    sourceLabel,
+  );
+
+  const readyStateId = optionalString(
+    input.readyStateId,
+    "states.readyStateId",
+    sourceLabel,
+  );
+  const readyLabelId = optionalString(
+    input.readyLabelId,
+    "states.readyLabelId",
+    sourceLabel,
+  );
+
+  if (!readyStateId && !readyLabelId) {
+    throw new LinearConfigError(
+      `${sourceLabel}: configure exactly one readiness selector — either ` +
+        `"states.readyStateId" (a Linear workflow state id) or ` +
+        `"states.readyLabelId" (a Linear label id).`,
+    );
+  }
+  if (readyStateId && readyLabelId) {
+    throw new LinearConfigError(
+      `${sourceLabel}: set exactly one of "states.readyStateId" or ` +
+        `"states.readyLabelId" — not both.`,
+    );
+  }
+
+  return {
+    readyStateId,
+    readyLabelId,
+    runningStateId,
+    doneStateId,
+    failedStateId,
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && !Array.isArray(value)
+  );
+}
+
+function requireString(
+  value: unknown,
+  field: string,
+  sourceLabel: string,
+): string {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new LinearConfigError(
+      `${sourceLabel}: "${field}" is required and must be a non-empty string ` +
+        `(got ${describe(value)}).`,
+    );
+  }
+  return value;
+}
+
+function optionalString(
+  value: unknown,
+  field: string,
+  sourceLabel: string,
+): string | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new LinearConfigError(
+      `${sourceLabel}: "${field}" must be a non-empty string when set ` +
+        `(got ${describe(value)}).`,
+    );
+  }
+  return value;
+}
+
+function describe(value: unknown): string {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  return typeof value;
+}

--- a/src/integrations/linear/types.ts
+++ b/src/integrations/linear/types.ts
@@ -1,0 +1,161 @@
+/**
+ * Shared types for the Linear → Antfarm integration.
+ *
+ * These describe the shape of:
+ *   - on-disk config (~/.openclaw/antfarm/linear.json)
+ *   - Linear GraphQL issue payloads
+ *   - linear_issue_links DB rows
+ *   - sync loop results
+ *
+ * Keep this file type-only. No runtime imports.
+ */
+
+// ── Config ──────────────────────────────────────────────────────────
+
+/**
+ * State transitions applied to a Linear issue as an Antfarm run moves
+ * through its lifecycle. Each value is a Linear workflow state id.
+ *
+ * Keep the set small for MVP: running, done, failed. The "ready" state
+ * is what the sync loop polls to find eligible issues.
+ */
+export interface LinearStateMap {
+  /** Linear workflow state id that marks issues eligible for launch. */
+  readyStateId: string;
+  /** Applied once the Antfarm run has started. */
+  runningStateId: string;
+  /** Applied when the run completes successfully (done or review). */
+  doneStateId: string;
+  /** Applied when the run fails or is cancelled. */
+  failedStateId: string;
+}
+
+/**
+ * MVP config shape. Loaded from ~/.openclaw/antfarm/linear.json.
+ * API token is read separately from LINEAR_API_TOKEN.
+ */
+export interface LinearConfig {
+  /** Team to poll. MVP supports one team. */
+  teamId: string;
+  /** Workflow to launch for each eligible issue. MVP: "feature-dev". */
+  workflowId: string;
+  /** Default repo path used when the issue does not specify one. */
+  defaultRepoPath: string;
+  /** State id map. */
+  states: LinearStateMap;
+  /**
+   * Optional label that must be present on an issue for it to be picked
+   * up. When unset, every issue in the ready state is eligible.
+   */
+  requiredLabel?: string;
+}
+
+// ── Linear API payloads ─────────────────────────────────────────────
+
+/** Minimal shape of a Linear workflow state returned via GraphQL. */
+export interface LinearState {
+  id: string;
+  name: string;
+  type?: string;
+}
+
+/** Minimal shape of a Linear label returned via GraphQL. */
+export interface LinearLabel {
+  id: string;
+  name: string;
+}
+
+/** Minimal shape of a Linear user returned via GraphQL. */
+export interface LinearUser {
+  id: string;
+  name: string;
+  email?: string;
+}
+
+/**
+ * Linear issue payload. Only the fields Antfarm actually uses for sync
+ * and task rendering. The client maps GraphQL responses onto this.
+ */
+export interface LinearIssue {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  updatedAt: string;
+  state: LinearState;
+  team: { id: string; key: string };
+  labels: LinearLabel[];
+  assignee?: LinearUser | null;
+  priority?: number;
+  estimate?: number | null;
+}
+
+// ── DB row ──────────────────────────────────────────────────────────
+
+/**
+ * Sync status lifecycle for a single Linear issue link.
+ *
+ *   pending   issue is eligible but no run has been created yet
+ *   launched  Antfarm run created, start-comment not yet posted
+ *   running   start-comment posted, Linear moved to runningStateId
+ *   done      run completed, completion-comment posted
+ *   failed    run failed/cancelled, failure-comment posted
+ */
+export type LinearSyncStatus =
+  | "pending"
+  | "launched"
+  | "running"
+  | "done"
+  | "failed";
+
+/**
+ * Row shape of the linear_issue_links table. Mirrors the schema in
+ * src/db.ts exactly. All timestamps are ISO-8601 strings.
+ */
+export interface LinearIssueLinkRow {
+  linear_issue_id: string;
+  linear_identifier: string;
+  linear_url: string;
+  linear_title: string;
+  team_id: string;
+  workflow_id: string;
+  repo_path: string;
+  run_id: string | null;
+  sync_status: LinearSyncStatus;
+  last_linear_updated_at: string | null;
+  last_synced_run_status: string | null;
+  last_synced_step_id: string | null;
+  last_comment_hash: string | null;
+  last_error: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+// ── Sync loop results ───────────────────────────────────────────────
+
+/** Per-issue outcome returned by a single sync pass. */
+export interface LinearSyncIssueResult {
+  linearIssueId: string;
+  linearIdentifier: string;
+  action:
+    | "launched"
+    | "started"
+    | "completed"
+    | "failed"
+    | "skipped"
+    | "noop"
+    | "error";
+  runId?: string;
+  message?: string;
+  error?: string;
+}
+
+/** Aggregate result of one sync pass across all eligible issues. */
+export interface LinearSyncResult {
+  scanned: number;
+  launched: number;
+  reconciled: number;
+  errors: number;
+  issues: LinearSyncIssueResult[];
+}

--- a/src/integrations/linear/types.ts
+++ b/src/integrations/linear/types.ts
@@ -20,8 +20,18 @@
  * is what the sync loop polls to find eligible issues.
  */
 export interface LinearStateMap {
-  /** Linear workflow state id that marks issues eligible for launch. */
-  readyStateId: string;
+  /**
+   * Readiness selector: a Linear workflow state id. Issues in this
+   * state are eligible for launch. Exactly one of `readyStateId` or
+   * `readyLabelId` must be set.
+   */
+  readyStateId?: string;
+  /**
+   * Readiness selector: a Linear label id. Issues carrying this label
+   * are eligible for launch. Exactly one of `readyStateId` or
+   * `readyLabelId` must be set.
+   */
+  readyLabelId?: string;
   /** Applied once the Antfarm run has started. */
   runningStateId: string;
   /** Applied when the run completes successfully (done or review). */
@@ -43,11 +53,6 @@ export interface LinearConfig {
   defaultRepoPath: string;
   /** State id map. */
   states: LinearStateMap;
-  /**
-   * Optional label that must be present on an issue for it to be picked
-   * up. When unset, every issue in the ready state is eligible.
-   */
-  requiredLabel?: string;
 }
 
 // ── Linear API payloads ─────────────────────────────────────────────

--- a/src/medic/checks.ts
+++ b/src/medic/checks.ts
@@ -3,12 +3,16 @@
  */
 import { getDb } from "../db.js";
 import { getMaxRoleTimeoutSeconds } from "../installer/install.js";
+import { isRunning, isDashboardHealthy } from "../server/daemonctl.js";
+import { getDashboardServeStatus } from "../server/tailscale-serve.js";
 
 export type MedicSeverity = "info" | "warning" | "critical";
 export type MedicActionType =
   | "reset_step"
   | "fail_run"
   | "teardown_crons"
+  | "restart_dashboard"
+  | "restore_dashboard_proxy"
   | "none";
 
 export interface MedicFinding {
@@ -207,4 +211,37 @@ export function runSyncChecks(): MedicFinding[] {
     ...checkStalledRuns(),
     ...checkDeadRuns(),
   ];
+}
+
+export async function checkDashboardInfrastructure(): Promise<MedicFinding[]> {
+  const findings: MedicFinding[] = [];
+  const running = isRunning();
+  const healthy = running.running ? await isDashboardHealthy() : false;
+
+  if (!running.running || !healthy) {
+    findings.push({
+      check: "dashboard_health",
+      severity: "critical",
+      message: running.running
+        ? "Dashboard daemon is running but /healthz is failing"
+        : "Dashboard daemon is not running",
+      action: "restart_dashboard",
+      remediated: false,
+    });
+  }
+
+  const serve = await getDashboardServeStatus();
+  if (!serve.configured) {
+    findings.push({
+      check: "dashboard_proxy",
+      severity: healthy ? "warning" : "critical",
+      message: serve.error
+        ? `Tailscale serve mapping for the dashboard is missing or unhealthy (${serve.error})`
+        : "Tailscale serve mapping for the dashboard is missing or unhealthy",
+      action: "restore_dashboard_proxy",
+      remediated: false,
+    });
+  }
+
+  return findings;
 }

--- a/src/medic/medic.ts
+++ b/src/medic/medic.ts
@@ -10,9 +10,12 @@ import { teardownWorkflowCronsIfIdle } from "../installer/agent-cron.js";
 import { listCronJobs } from "../installer/gateway-api.js";
 import {
   runSyncChecks,
+  checkDashboardInfrastructure,
   checkOrphanedCrons,
   type MedicFinding,
 } from "./checks.js";
+import { ensureDashboardServe } from "../server/tailscale-serve.js";
+import { restartDaemon } from "../server/daemonctl.js";
 import crypto from "node:crypto";
 
 // ── DB Migration ────────────────────────────────────────────────────
@@ -119,6 +122,24 @@ async function remediate(finding: MedicFinding): Promise<boolean> {
       }
     }
 
+    case "restart_dashboard": {
+      try {
+        await restartDaemon(3333);
+        return true;
+      } catch {
+        return false;
+      }
+    }
+
+    case "restore_dashboard_proxy": {
+      try {
+        const result = await ensureDashboardServe(3333);
+        return result.ok;
+      } catch {
+        return false;
+      }
+    }
+
     case "none":
     default:
       return false;
@@ -144,6 +165,12 @@ export async function runMedicCheck(): Promise<MedicCheckResult> {
 
   // Gather all findings
   const findings: MedicFinding[] = runSyncChecks();
+
+  try {
+    findings.push(...await checkDashboardInfrastructure());
+  } catch {
+    // skip dashboard checks on failure
+  }
 
   // Async check: orphaned crons
   try {

--- a/src/server/daemon.ts
+++ b/src/server/daemon.ts
@@ -3,8 +3,10 @@ import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
 import { startDashboard } from "./dashboard.js";
+import { ensureDashboardServe } from "./tailscale-serve.js";
 
 const port = parseInt(process.argv[2], 10) || 3333;
+const SERVE_RECONCILE_INTERVAL_MS = 5 * 60 * 1000;
 
 const pidDir = path.join(os.homedir(), ".openclaw", "antfarm");
 const pidFile = path.join(pidDir, "dashboard.pid");
@@ -18,3 +20,17 @@ process.on("SIGTERM", () => {
 });
 
 startDashboard(port);
+
+void ensureDashboardServe(port).catch((error) => {
+  console.error(`[antfarm] Failed to attach Tailscale serve for dashboard: ${error instanceof Error ? error.message : String(error)}`);
+});
+
+const serveInterval = setInterval(() => {
+  void ensureDashboardServe(port).catch((error) => {
+    console.error(`[antfarm] Failed to reconcile Tailscale serve for dashboard: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}, SERVE_RECONCILE_INTERVAL_MS);
+
+process.on("SIGTERM", () => {
+  clearInterval(serveInterval);
+});

--- a/src/server/daemonctl.ts
+++ b/src/server/daemonctl.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import os from "node:os";
 import { spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import { ensureDashboardServe } from "./tailscale-serve.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -29,9 +30,21 @@ export function isRunning(): { running: true; pid: number } | { running: false }
   }
 }
 
+export async function isDashboardHealthy(port = 3333): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}/healthz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    return response.ok;
+  } catch {
+    return false;
+  }
+}
+
 export async function startDaemon(port = 3333): Promise<{ pid: number; port: number }> {
   const status = isRunning();
   if (status.running) {
+    await ensureDashboardServe(port);
     return { pid: status.pid, port };
   }
 
@@ -56,7 +69,17 @@ export async function startDaemon(port = 3333): Promise<{ pid: number; port: num
   if (!check.running) {
     throw new Error("Daemon failed to start. Check " + logFile);
   }
+
+  await ensureDashboardServe(port);
   return { pid: check.pid, port };
+}
+
+export async function restartDaemon(port = 3333): Promise<{ pid: number; port: number }> {
+  if (isRunning().running) {
+    stopDaemon();
+    await new Promise((resolve) => setTimeout(resolve, 750));
+  }
+  return startDaemon(port);
 }
 
 export function stopDaemon(): boolean {

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -7,6 +7,7 @@ import { resolveBundledWorkflowsDir } from "../installer/paths.js";
 import YAML from "yaml";
 
 import type { RunInfo, StepInfo } from "../installer/status.js";
+import { archiveWorkflow } from "../installer/status.js";
 import { getRunEvents } from "../installer/events.js";
 import { getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
 
@@ -40,8 +41,8 @@ function loadWorkflows(): WorkflowDef[] {
 function getRuns(workflowId?: string): Array<RunInfo & { steps: StepInfo[] }> {
   const db = getDb();
   const runs = workflowId
-    ? db.prepare("SELECT * FROM runs WHERE workflow_id = ? ORDER BY created_at DESC").all(workflowId) as RunInfo[]
-    : db.prepare("SELECT * FROM runs ORDER BY created_at DESC").all() as RunInfo[];
+    ? db.prepare("SELECT * FROM runs WHERE workflow_id = ? AND archived_at IS NULL ORDER BY created_at DESC").all(workflowId) as RunInfo[]
+    : db.prepare("SELECT * FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC").all() as RunInfo[];
   return runs.map((r) => {
     const steps = db.prepare("SELECT * FROM steps WHERE run_id = ? ORDER BY step_index ASC").all(r.id) as StepInfo[];
     return { ...r, steps };
@@ -71,9 +72,17 @@ function serveHTML(res: http.ServerResponse) {
 }
 
 export function startDashboard(port = 3333): http.Server {
-  const server = http.createServer((req, res) => {
+  const server = http.createServer(async (req, res) => {
     const url = new URL(req.url ?? "/", `http://localhost:${port}`);
     const p = url.pathname;
+
+    const archiveMatch = p.match(/^\/api\/runs\/([^/]+)\/archive$/);
+    if (archiveMatch && req.method === "POST") {
+      const result = await archiveWorkflow(archiveMatch[1]);
+      if (result.status === "ok") return json(res, result);
+      const status = result.status === "not_found" ? 404 : 409;
+      return json(res, { error: result.message }, status);
+    }
 
     if (p === "/api/workflows") {
       return json(res, loadWorkflows());

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -76,6 +76,12 @@ export function startDashboard(port = 3333): http.Server {
     const url = new URL(req.url ?? "/", `http://localhost:${port}`);
     const p = url.pathname;
 
+    if (p === "/healthz") {
+      res.writeHead(200, { "Content-Type": "application/json", "Cache-Control": "no-store" });
+      res.end(JSON.stringify({ ok: true, service: "antfarm-dashboard" }));
+      return;
+    }
+
     const archiveMatch = p.match(/^\/api\/runs\/([^/]+)\/archive$/);
     if (archiveMatch && req.method === "POST") {
       const result = await archiveWorkflow(archiveMatch[1]);

--- a/src/server/dashboard.ts
+++ b/src/server/dashboard.ts
@@ -10,6 +10,10 @@ import type { RunInfo, StepInfo } from "../installer/status.js";
 import { archiveWorkflow } from "../installer/status.js";
 import { getRunEvents } from "../installer/events.js";
 import { getMedicStatus, getRecentMedicChecks } from "../medic/medic.js";
+import {
+  enrichStepsWithQueueContext,
+  type EnrichedStepInfo,
+} from "../installer/repo-visibility.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -38,23 +42,23 @@ function loadWorkflows(): WorkflowDef[] {
   return results;
 }
 
-function getRuns(workflowId?: string): Array<RunInfo & { steps: StepInfo[] }> {
+export function getRuns(workflowId?: string): Array<RunInfo & { steps: EnrichedStepInfo[] }> {
   const db = getDb();
   const runs = workflowId
     ? db.prepare("SELECT * FROM runs WHERE workflow_id = ? AND archived_at IS NULL ORDER BY created_at DESC").all(workflowId) as RunInfo[]
     : db.prepare("SELECT * FROM runs WHERE archived_at IS NULL ORDER BY created_at DESC").all() as RunInfo[];
   return runs.map((r) => {
     const steps = db.prepare("SELECT * FROM steps WHERE run_id = ? ORDER BY step_index ASC").all(r.id) as StepInfo[];
-    return { ...r, steps };
+    return { ...r, steps: enrichStepsWithQueueContext(steps) };
   });
 }
 
-function getRunById(id: string): (RunInfo & { steps: StepInfo[] }) | null {
+export function getRunById(id: string): (RunInfo & { steps: EnrichedStepInfo[] }) | null {
   const db = getDb();
   const run = db.prepare("SELECT * FROM runs WHERE id = ?").get(id) as RunInfo | undefined;
   if (!run) return null;
   const steps = db.prepare("SELECT * FROM steps WHERE run_id = ? ORDER BY step_index ASC").all(run.id) as StepInfo[];
-  return { ...run, steps };
+  return { ...run, steps: enrichStepsWithQueueContext(steps) };
 }
 
 function json(res: http.ServerResponse, data: unknown, status = 200) {

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -151,6 +151,10 @@ select:focus{outline:none;border-color:#8ECFC0}
 .panel-task{font-size:13px;color:var(--text-secondary);margin-bottom:16px;white-space:pre-wrap;word-break:break-word;max-height:120px;overflow-y:auto;line-height:1.5}
 .panel-meta{display:flex;gap:12px;margin-bottom:20px;font-size:12px;color:var(--text-secondary);flex-wrap:wrap}
 .panel-meta span{display:flex;align-items:center;gap:4px}
+.panel-actions{display:flex;gap:8px;flex-wrap:wrap;margin:-8px 0 20px}
+.panel-button{appearance:none;border:1px solid var(--border);background:var(--bg-surface-alt);color:var(--text-primary);border-radius:6px;padding:8px 12px;font-size:12px;font-weight:600;cursor:pointer;transition:border-color .15s,background .15s}
+.panel-button:hover{border-color:var(--accent-orange);background:var(--bg-column-header)}
+.panel-button.archive{color:var(--accent-orange)}
 
 /* ── Steps ─────────────────────────────────────────────────────── */
 .steps-list{display:flex;flex-direction:column;gap:8px}
@@ -169,7 +173,7 @@ select:focus{outline:none;border-color:#8ECFC0}
 .badge{font-size:10px;font-weight:600;padding:2px 6px;border-radius:4px;text-transform:uppercase}
 .badge-running{background:var(--accent-teal-subtle);color:var(--accent-teal)}
 .badge-done,.badge-completed{background:var(--accent-green-subtle);color:var(--accent-green)}
-.badge-failed,.badge-error{background:var(--accent-orange-subtle);color:var(--accent-orange)}
+.badge-failed,.badge-error,.badge-cancelled,.badge-archived{background:var(--accent-orange-subtle);color:var(--accent-orange)}
 .badge-waiting{background:var(--accent-muted);color:var(--text-secondary)}
 .badge-pending{background:var(--accent-muted);color:var(--text-secondary)}
 .badge-blocked{background:var(--accent-orange-faint);color:var(--accent-orange)}
@@ -251,6 +255,18 @@ function startOpenRunRefresh() {
 async function fetchJSON(url) {
   const r = await fetch(API + url);
   return r.json();
+}
+
+async function archiveRun(id) {
+  if (!confirm('Archive this run? It will disappear from the main board.')) return;
+  const r = await fetch(API + `/api/runs/${id}/archive`, { method: 'POST' });
+  const data = await r.json();
+  if (!r.ok) {
+    alert(data.error || 'Could not archive run.');
+    return;
+  }
+  closePanel();
+  await loadRuns();
 }
 
 async function loadWorkflows() {
@@ -357,6 +373,7 @@ function renderRunPanel(run) {
   const panel = document.getElementById('panel');
   const created = run.created_at ? parseTS(run.created_at)?.toLocaleString() || "" : '';
   const updated = run.updated_at ? parseTS(run.updated_at)?.toLocaleString() || "" : '';
+  const canArchive = ['completed', 'failed', 'cancelled'].includes(run.status) && !run.archived_at;
   const stepsHTML = (run.steps || []).map(s => {
     const st = s.status || 'waiting';
     const icon = stepIcons[st] || '○';
@@ -381,9 +398,11 @@ function renderRunPanel(run) {
     <div class="panel-task">${esc(run.task)}</div>
     <div class="panel-meta">
       <span><span class="badge badge-${run.status}">${run.status}</span></span>
+      ${run.archived_at ? `<span>Archived: ${parseTS(run.archived_at)?.toLocaleString() || ''}</span>` : ''}
       <span>Created: ${created}</span>
       <span>Updated: ${updated}</span>
     </div>
+    ${canArchive ? `<div class="panel-actions"><button class="panel-button archive" onclick="archiveRun('${run.id}')">Archive run</button></div>` : ''}
     <div class="steps-list">${stepsHTML}</div>
       <div id="stories-panel"></div>
     <div id="activity-panel"></div>
@@ -397,6 +416,7 @@ function formatEventDesc(evt) {
     case 'run.started': return 'Run started';
     case 'run.completed': return 'Run completed ✅';
     case 'run.failed': return 'Run failed ❌';
+    case 'run.archived': return 'Run archived 📦';
     case 'step.pending': return `Step pending`;
     case 'step.running': return `Claimed step`;
     case 'step.done': return `Step completed`;

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -417,6 +417,9 @@ function formatEventDesc(evt) {
     case 'run.completed': return 'Run completed ✅';
     case 'run.failed': return 'Run failed ❌';
     case 'run.archived': return 'Run archived 📦';
+    case 'executor.started': return 'Claude Code executor started';
+    case 'executor.completed': return 'Claude Code executor completed';
+    case 'executor.failed': return 'Claude Code executor failed';
     case 'step.pending': return `Step pending`;
     case 'step.running': return `Claimed step`;
     case 'step.done': return `Step completed`;

--- a/src/server/index.html
+++ b/src/server/index.html
@@ -177,6 +177,11 @@ select:focus{outline:none;border-color:#8ECFC0}
 .badge-waiting{background:var(--accent-muted);color:var(--text-secondary)}
 .badge-pending{background:var(--accent-muted);color:var(--text-secondary)}
 .badge-blocked{background:var(--accent-orange-faint);color:var(--accent-orange)}
+.badge-queued{background:var(--accent-orange-faint);color:var(--accent-orange);border:1px dashed var(--accent-orange)}
+.step-queue-note{padding:0 12px 10px 44px;font-size:11px;color:var(--accent-orange);line-height:1.5}
+.step-queue-note code{font-family:'Geist Mono',monospace;background:var(--bg-code);padding:1px 4px;border-radius:3px}
+.card.queued{border-left:3px dashed var(--accent-orange)}
+.card-queue-note{font-size:10px;color:var(--accent-orange);margin-top:4px;line-height:1.4}
 
 /* ── Misc ──────────────────────────────────────────────────────── */
 .empty{color:var(--text-secondary);font-size:12px;text-align:center;padding:24px 8px}
@@ -325,16 +330,23 @@ function renderBoard(wf, runs) {
       : cards.map(run => {
           const isDone = run.status === 'done';
           const isFailed = run.status === 'failed' || run.status === 'error';
-          const cls = isDone ? 'done' : isFailed ? 'failed' : '';
-          const badge = `badge-${run.status}`;
+          const queuedStep = findQueuedStep(run);
+          const isQueued = !!queuedStep;
+          const cls = isDone ? 'done' : isFailed ? 'failed' : isQueued ? 'queued' : '';
+          const badgeClass = isQueued ? 'badge-queued' : `badge-${run.status}`;
+          const badgeLabel = isQueued ? 'queued' : run.status;
           const time = run.updated_at ? parseTS(run.updated_at)?.toLocaleString() || "" : '';
           const title = run.task.length > 60 ? run.task.slice(0, 57) + '…' : run.task;
+          const queueNote = isQueued
+            ? `<div class="card-queue-note">Waiting on ${esc(queuedStep.queue.repoPath || queuedStep.queue.repoKey)}${formatBlockerHTML(queuedStep.queue)}</div>`
+            : '';
           return `<div class="card ${cls}" onclick="openRun('${run.id}')">
             <div class="card-title" title="${run.task.replace(/"/g, '&quot;')}">${title}</div>
             <div class="card-meta">
-              <span class="badge ${badge}">${run.status}</span>
+              <span class="badge ${badgeClass}">${badgeLabel}</span>
               <span>${time}</span>
             </div>
+            ${queueNote}
           </div>`;
         }).join('');
     return `<div class="column">
@@ -344,8 +356,20 @@ function renderBoard(wf, runs) {
   }).join('');
 }
 
-const stepIcons = {done:'✓',running:'●',pending:'○',waiting:'◌',failed:'✗',error:'✗'};
+const stepIcons = {done:'✓',running:'●',pending:'○',waiting:'◌',failed:'✗',error:'✗',queued:'⏸'};
 function esc(s) { if (!s) return ''; return s.replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;'); }
+function formatBlockerHTML(q) {
+  if (!q) return '';
+  const parts = [];
+  if (q.blockingRunNumber != null) parts.push(`run #${q.blockingRunNumber}`);
+  else if (q.blockingRunId) parts.push(`run ${q.blockingRunId.slice(0,8)}`);
+  if (q.blockingStepId) parts.push(`step "${esc(q.blockingStepId)}"`);
+  return parts.length ? ` — blocked by ${parts.join(' ')}` : '';
+}
+function findQueuedStep(run) {
+  if (!run || !run.steps) return null;
+  return run.steps.find(s => s.queue) || null;
+}
 // Normalize SQLite datetime('now') format (no T/Z) to proper ISO 8601 UTC
 function parseTS(ts) { if (!ts) return null; if (!ts.endsWith('Z') && !ts.includes('+')) ts = ts.replace(' ', 'T') + 'Z'; return new Date(ts); }
 
@@ -378,15 +402,20 @@ function renderRunPanel(run) {
     const st = s.status || 'waiting';
     const icon = stepIcons[st] || '○';
     const hasOutput = !!s.output;
+    const queued = !!s.queue;
+    const badgeLabel = queued ? 'queued' : st;
+    const badgeClass = queued ? 'badge-queued' : `badge-${st}`;
+    const queueNote = queued ? `<div class="step-queue-note">Queued on <code>${esc(s.queue.repoPath || s.queue.repoKey)}</code>${formatBlockerHTML(s.queue)}</div>` : '';
     const toggleAttr = hasOutput ? `onclick="this.querySelector('.step-details').classList.toggle('step-open');this.querySelector('.step-chevron').classList.toggle('step-chevron-open')" style="cursor:pointer"` : '';
     return `<div class="step-row" style="flex-direction:column;align-items:stretch;gap:0;padding:0;overflow:hidden" ${toggleAttr}>
       <div style="display:flex;align-items:center;gap:8px;padding:10px 12px">
         <div class="step-icon ${st}">${icon}</div>
         <div class="step-name" style="flex:1">${s.step_id}</div>
         <div class="step-agent">${s.agent_id || ''}</div>
-        <div class="step-status"><span class="badge badge-${st}">${st}</span></div>
+        <div class="step-status"><span class="badge ${badgeClass}">${badgeLabel}</span></div>
         ${hasOutput ? '<span class="step-chevron" style="color:var(--text-secondary);font-size:10px;transition:transform .15s;display:inline-block">▶</span>' : ''}
       </div>
+      ${queueNote}
       ${hasOutput ? `<div class="step-details" style="display:none;padding:0 12px 12px 44px;font-size:12px;color:var(--text-tertiary);line-height:1.6">
         <details style="margin-top:4px" onclick="event.stopPropagation()"><summary style="font-size:11px;color:var(--text-secondary);cursor:pointer;font-weight:500">Output</summary><pre style="margin-top:6px;padding:8px;background:var(--bg-code);border:1px solid var(--border);border-radius:4px;font-family:'Geist Mono',monospace;font-size:11px;white-space:pre-wrap;word-break:break-word;max-height:300px;overflow-y:auto">${esc(s.output)}</pre></details>
       </div>` : ''}

--- a/src/server/tailscale-serve.ts
+++ b/src/server/tailscale-serve.ts
@@ -1,0 +1,74 @@
+import { execFile } from "node:child_process";
+
+export const DEFAULT_DASHBOARD_PORT = 3333;
+export const DEFAULT_TAILSCALE_HTTPS_PORT = 4443;
+
+function execFileAsync(command: string, args: string[], timeout = 15_000): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  return new Promise((resolve, reject) => {
+    execFile(command, args, { timeout }, (error, stdout, stderr) => {
+      if (error) {
+        const anyErr = error as NodeJS.ErrnoException & { code?: number | string };
+        const exitCode = typeof anyErr.code === "number" ? anyErr.code : 1;
+        reject(new Error(stderr?.trim() || stdout?.trim() || error.message || `Command failed: ${command}`));
+        return;
+      }
+      resolve({ stdout, stderr, exitCode: 0 });
+    });
+  });
+}
+
+function hasExpectedProxy(status: any, localPort: number, httpsPort: number): boolean {
+  const expected = `http://127.0.0.1:${localPort}`;
+  const web = status?.Web;
+  if (!web || typeof web !== "object") return false;
+
+  for (const [hostPort, config] of Object.entries(web as Record<string, any>)) {
+    if (!hostPort.endsWith(`:${httpsPort}`)) continue;
+    const proxy = config?.Handlers?.["/"]?.Proxy;
+    if (proxy === expected) return true;
+  }
+
+  return false;
+}
+
+export async function getDashboardServeStatus(localPort = DEFAULT_DASHBOARD_PORT, httpsPort = DEFAULT_TAILSCALE_HTTPS_PORT): Promise<{
+  configured: boolean;
+  url?: string;
+  error?: string;
+}> {
+  try {
+    const { stdout } = await execFileAsync("tailscale", ["serve", "status", "--json"]);
+    const parsed = JSON.parse(stdout);
+    const configured = hasExpectedProxy(parsed, localPort, httpsPort);
+    const url = configured
+      ? Object.keys(parsed?.Web ?? {}).find((hostPort) => hostPort.endsWith(`:${httpsPort}`))
+      : undefined;
+    return { configured, url: url ? `https://${url}` : undefined };
+  } catch (error) {
+    return { configured: false, error: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+export async function ensureDashboardServe(localPort = DEFAULT_DASHBOARD_PORT, httpsPort = DEFAULT_TAILSCALE_HTTPS_PORT): Promise<{
+  ok: boolean;
+  changed: boolean;
+  error?: string;
+}> {
+  const existing = await getDashboardServeStatus(localPort, httpsPort);
+  if (existing.configured) {
+    return { ok: true, changed: false };
+  }
+
+  try {
+    await execFileAsync("tailscale", ["serve", "--bg", `--https=${httpsPort}`, `127.0.0.1:${localPort}`], 20_000);
+  } catch (error) {
+    return { ok: false, changed: false, error: error instanceof Error ? error.message : String(error) };
+  }
+
+  const after = await getDashboardServeStatus(localPort, httpsPort);
+  if (after.configured) {
+    return { ok: true, changed: true };
+  }
+
+  return { ok: false, changed: true, error: after.error ?? `tailscale serve did not attach :${httpsPort} -> 127.0.0.1:${localPort}` };
+}

--- a/tests/linear-config.test.ts
+++ b/tests/linear-config.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests: Linear integration config loader
+ *
+ * Covers US-003:
+ *   - Reads ~/.openclaw/antfarm/linear.json and LINEAR_API_TOKEN
+ *   - Enforces MVP scope (one team, feature-dev, one readiness selector)
+ *   - Requires running/done/failed state ids
+ *   - Produces clear, actionable errors for each failure mode
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  DEFAULT_LINEAR_CONFIG_PATH,
+  LinearConfigError,
+  MVP_WORKFLOW_ID,
+  loadLinearConfig,
+  validateLinearConfig,
+} from "../dist/integrations/linear/config.js";
+
+function tmpConfig(blob: unknown): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-linear-cfg-"));
+  const p = path.join(dir, "linear.json");
+  fs.writeFileSync(p, JSON.stringify(blob), "utf-8");
+  return p;
+}
+
+function writeRaw(raw: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-linear-cfg-"));
+  const p = path.join(dir, "linear.json");
+  fs.writeFileSync(p, raw, "utf-8");
+  return p;
+}
+
+const validBlob = {
+  teamId: "team_abc",
+  workflowId: "feature-dev",
+  defaultRepoPath: "/Users/me/repo",
+  states: {
+    readyStateId: "state_ready",
+    runningStateId: "state_running",
+    doneStateId: "state_done",
+    failedStateId: "state_failed",
+  },
+};
+
+describe("linear config: defaults and exports", () => {
+  it("DEFAULT_LINEAR_CONFIG_PATH points at ~/.openclaw/antfarm/linear.json", () => {
+    assert.equal(
+      DEFAULT_LINEAR_CONFIG_PATH,
+      path.join(os.homedir(), ".openclaw", "antfarm", "linear.json"),
+    );
+  });
+
+  it("MVP_WORKFLOW_ID is feature-dev", () => {
+    assert.equal(MVP_WORKFLOW_ID, "feature-dev");
+  });
+});
+
+describe("loadLinearConfig: happy path", () => {
+  it("loads and validates a minimal valid config using state-based readiness", () => {
+    const configPath = tmpConfig(validBlob);
+    const loaded = loadLinearConfig({
+      configPath,
+      env: { LINEAR_API_TOKEN: "lin_test_token" },
+    });
+    assert.equal(loaded.apiToken, "lin_test_token");
+    assert.equal(loaded.path, configPath);
+    assert.equal(loaded.config.teamId, "team_abc");
+    assert.equal(loaded.config.workflowId, "feature-dev");
+    assert.equal(loaded.config.defaultRepoPath, "/Users/me/repo");
+    assert.equal(loaded.config.states.readyStateId, "state_ready");
+    assert.equal(loaded.config.states.readyLabelId, undefined);
+    assert.equal(loaded.config.states.runningStateId, "state_running");
+    assert.equal(loaded.config.states.doneStateId, "state_done");
+    assert.equal(loaded.config.states.failedStateId, "state_failed");
+  });
+
+  it("accepts label-based readiness selector", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyLabelId: "label_ready",
+        runningStateId: "state_running",
+        doneStateId: "state_done",
+        failedStateId: "state_failed",
+      },
+    };
+    const configPath = tmpConfig(blob);
+    const loaded = loadLinearConfig({
+      configPath,
+      env: { LINEAR_API_TOKEN: "tok" },
+    });
+    assert.equal(loaded.config.states.readyStateId, undefined);
+    assert.equal(loaded.config.states.readyLabelId, "label_ready");
+  });
+
+  it("apiToken option overrides env", () => {
+    const configPath = tmpConfig(validBlob);
+    const loaded = loadLinearConfig({
+      configPath,
+      apiToken: "explicit",
+      env: { LINEAR_API_TOKEN: "from_env" },
+    });
+    assert.equal(loaded.apiToken, "explicit");
+  });
+
+  it("trims whitespace around the API token", () => {
+    const configPath = tmpConfig(validBlob);
+    const loaded = loadLinearConfig({
+      configPath,
+      env: { LINEAR_API_TOKEN: "  padded  " },
+    });
+    assert.equal(loaded.apiToken, "padded");
+  });
+});
+
+describe("loadLinearConfig: error surfaces", () => {
+  it("throws when LINEAR_API_TOKEN is missing", () => {
+    const configPath = tmpConfig(validBlob);
+    assert.throws(
+      () => loadLinearConfig({ configPath, env: {} }),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /LINEAR_API_TOKEN/.test(err.message),
+    );
+  });
+
+  it("throws when LINEAR_API_TOKEN is blank", () => {
+    const configPath = tmpConfig(validBlob);
+    assert.throws(
+      () => loadLinearConfig({ configPath, env: { LINEAR_API_TOKEN: "  " } }),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /LINEAR_API_TOKEN/.test(err.message),
+    );
+  });
+
+  it("throws with install hint when config file is missing", () => {
+    const missing = path.join(
+      os.tmpdir(),
+      `antfarm-linear-missing-${Date.now()}.json`,
+    );
+    assert.throws(
+      () =>
+        loadLinearConfig({
+          configPath: missing,
+          env: { LINEAR_API_TOKEN: "tok" },
+        }),
+      (err) =>
+        err instanceof LinearConfigError &&
+        err.message.includes(missing) &&
+        /antfarm linear install/.test(err.message),
+    );
+  });
+
+  it("throws on invalid JSON", () => {
+    const configPath = writeRaw("{ not json");
+    assert.throws(
+      () =>
+        loadLinearConfig({
+          configPath,
+          env: { LINEAR_API_TOKEN: "tok" },
+        }),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /not valid JSON/.test(err.message),
+    );
+  });
+});
+
+describe("validateLinearConfig: field-level validation", () => {
+  it("rejects non-object input", () => {
+    assert.throws(
+      () => validateLinearConfig(null),
+      (err) =>
+        err instanceof LinearConfigError && /must be a JSON object/.test(err.message),
+    );
+    assert.throws(
+      () => validateLinearConfig([]),
+      (err) =>
+        err instanceof LinearConfigError && /must be a JSON object/.test(err.message),
+    );
+  });
+
+  it("rejects missing teamId", () => {
+    const { teamId: _omit, ...rest } = validBlob;
+    assert.throws(
+      () => validateLinearConfig(rest),
+      (err) =>
+        err instanceof LinearConfigError && /teamId/.test(err.message),
+    );
+  });
+
+  it("rejects empty-string teamId", () => {
+    assert.throws(
+      () => validateLinearConfig({ ...validBlob, teamId: "   " }),
+      (err) =>
+        err instanceof LinearConfigError && /teamId/.test(err.message),
+    );
+  });
+
+  it("rejects workflowId other than feature-dev", () => {
+    assert.throws(
+      () =>
+        validateLinearConfig({ ...validBlob, workflowId: "custom-wf" }),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /feature-dev/.test(err.message) &&
+        /custom-wf/.test(err.message),
+    );
+  });
+
+  it("rejects missing defaultRepoPath", () => {
+    const { defaultRepoPath: _omit, ...rest } = validBlob;
+    assert.throws(
+      () => validateLinearConfig(rest),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /defaultRepoPath/.test(err.message),
+    );
+  });
+
+  it("rejects missing states object", () => {
+    const { states: _omit, ...rest } = validBlob;
+    assert.throws(
+      () => validateLinearConfig(rest),
+      (err) =>
+        err instanceof LinearConfigError && /"states"/.test(err.message),
+    );
+  });
+
+  it("rejects when no readiness selector is set", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        runningStateId: "r",
+        doneStateId: "d",
+        failedStateId: "f",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /readyStateId/.test(err.message) &&
+        /readyLabelId/.test(err.message),
+    );
+  });
+
+  it("rejects when both readiness selectors are set", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyStateId: "a",
+        readyLabelId: "b",
+        runningStateId: "r",
+        doneStateId: "d",
+        failedStateId: "f",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /exactly one/.test(err.message) &&
+        /not both/.test(err.message),
+    );
+  });
+
+  it("rejects missing runningStateId", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyStateId: "x",
+        doneStateId: "d",
+        failedStateId: "f",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /runningStateId/.test(err.message),
+    );
+  });
+
+  it("rejects missing doneStateId", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyStateId: "x",
+        runningStateId: "r",
+        failedStateId: "f",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError && /doneStateId/.test(err.message),
+    );
+  });
+
+  it("rejects missing failedStateId", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyStateId: "x",
+        runningStateId: "r",
+        doneStateId: "d",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /failedStateId/.test(err.message),
+    );
+  });
+
+  it("rejects non-string state id values", () => {
+    const blob = {
+      ...validBlob,
+      states: {
+        readyStateId: "x",
+        runningStateId: 42,
+        doneStateId: "d",
+        failedStateId: "f",
+      },
+    };
+    assert.throws(
+      () => validateLinearConfig(blob),
+      (err) =>
+        err instanceof LinearConfigError &&
+        /runningStateId/.test(err.message),
+    );
+  });
+});

--- a/tests/linear-schema.test.ts
+++ b/tests/linear-schema.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests: linear_issue_links schema migration
+ *
+ * Covers US-001:
+ *   - migrate() creates linear_issue_links with the MVP columns
+ *   - run_id has a foreign key to runs(id)
+ *   - Migration is idempotent (safe to run on an existing DB)
+ *   - types.ts exports the expected shared types
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../dist/db.js";
+
+const EXPECTED_COLUMNS = [
+  "linear_issue_id",
+  "linear_identifier",
+  "linear_url",
+  "linear_title",
+  "team_id",
+  "workflow_id",
+  "repo_path",
+  "run_id",
+  "sync_status",
+  "last_linear_updated_at",
+  "last_synced_run_status",
+  "last_synced_step_id",
+  "last_comment_hash",
+  "last_error",
+  "created_at",
+  "updated_at",
+];
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys=ON");
+  migrate(db);
+  return db;
+}
+
+describe("linear_issue_links schema", () => {
+  it("creates the table with all MVP columns", () => {
+    const db = freshDb();
+    const cols = db
+      .prepare("PRAGMA table_info(linear_issue_links)")
+      .all() as Array<{ name: string; notnull: number; pk: number }>;
+    const names = cols.map((c) => c.name);
+    for (const col of EXPECTED_COLUMNS) {
+      assert.ok(names.includes(col), `missing column: ${col}`);
+    }
+  });
+
+  it("uses linear_issue_id as the primary key", () => {
+    const db = freshDb();
+    const cols = db
+      .prepare("PRAGMA table_info(linear_issue_links)")
+      .all() as Array<{ name: string; pk: number }>;
+    const pk = cols.find((c) => c.pk === 1);
+    assert.ok(pk, "primary key should exist");
+    assert.equal(pk!.name, "linear_issue_id");
+  });
+
+  it("enforces NOT NULL on the required columns", () => {
+    const db = freshDb();
+    const cols = db
+      .prepare("PRAGMA table_info(linear_issue_links)")
+      .all() as Array<{ name: string; notnull: number }>;
+    const byName = new Map(cols.map((c) => [c.name, c.notnull]));
+    // linear_issue_id is the PK — PRAGMA reports notnull=0 for TEXT PKs
+    // in SQLite, but the PK constraint still rejects NULL at insert time.
+    const requiredNotNull = [
+      "linear_identifier",
+      "linear_url",
+      "linear_title",
+      "team_id",
+      "workflow_id",
+      "repo_path",
+      "sync_status",
+      "created_at",
+      "updated_at",
+    ];
+    for (const col of requiredNotNull) {
+      assert.equal(byName.get(col), 1, `${col} should be NOT NULL`);
+    }
+    assert.equal(byName.get("run_id"), 0, "run_id should be nullable");
+    assert.equal(byName.get("last_error"), 0, "last_error should be nullable");
+  });
+
+  it("declares a foreign key from run_id to runs(id)", () => {
+    const db = freshDb();
+    const fks = db
+      .prepare("PRAGMA foreign_key_list(linear_issue_links)")
+      .all() as Array<{ from: string; to: string; table: string }>;
+    const runFk = fks.find((f) => f.from === "run_id");
+    assert.ok(runFk, "run_id FK should be declared");
+    assert.equal(runFk!.table, "runs");
+    assert.equal(runFk!.to, "id");
+  });
+
+  it("is idempotent — running migrate twice does not error or duplicate", () => {
+    const db = freshDb();
+    // Seed a row so we can verify it survives re-migration.
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO linear_issue_links
+       (linear_issue_id, linear_identifier, linear_url, linear_title,
+        team_id, workflow_id, repo_path, sync_status, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "iss_1",
+      "ENG-1",
+      "https://linear.app/x/issue/ENG-1",
+      "Test",
+      "team_1",
+      "feature-dev",
+      "/repo",
+      "pending",
+      now,
+      now,
+    );
+
+    assert.doesNotThrow(() => migrate(db));
+    assert.doesNotThrow(() => migrate(db));
+
+    const count = (
+      db.prepare("SELECT COUNT(*) AS n FROM linear_issue_links").get() as {
+        n: number;
+      }
+    ).n;
+    assert.equal(count, 1, "existing row should survive re-migration");
+  });
+
+  it("accepts a full MVP row insert and round-trips values", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+    const runId = "run_abc";
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, 'feature-dev', 'task', 'running', '{}', ?, ?)`,
+    ).run(runId, now, now);
+
+    db.prepare(
+      `INSERT INTO linear_issue_links
+       (linear_issue_id, linear_identifier, linear_url, linear_title,
+        team_id, workflow_id, repo_path, run_id, sync_status,
+        last_linear_updated_at, last_synced_run_status, last_synced_step_id,
+        last_comment_hash, last_error, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "iss_full",
+      "ENG-42",
+      "https://linear.app/x/issue/ENG-42",
+      "Full row",
+      "team_1",
+      "feature-dev",
+      "/Users/me/repo",
+      runId,
+      "running",
+      now,
+      "running",
+      "step_1",
+      "hash-1",
+      null,
+      now,
+      now,
+    );
+
+    const row = db
+      .prepare("SELECT * FROM linear_issue_links WHERE linear_issue_id = ?")
+      .get("iss_full") as Record<string, unknown>;
+    assert.equal(row.linear_identifier, "ENG-42");
+    assert.equal(row.run_id, runId);
+    assert.equal(row.sync_status, "running");
+    assert.equal(row.last_synced_step_id, "step_1");
+    assert.equal(row.last_error, null);
+  });
+
+  it("rejects FK violations on run_id when foreign_keys=ON", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+    assert.throws(() => {
+      db.prepare(
+        `INSERT INTO linear_issue_links
+         (linear_issue_id, linear_identifier, linear_url, linear_title,
+          team_id, workflow_id, repo_path, run_id, sync_status,
+          created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(
+        "iss_bad",
+        "ENG-99",
+        "https://linear.app/x/issue/ENG-99",
+        "Bad FK",
+        "team_1",
+        "feature-dev",
+        "/repo",
+        "missing_run",
+        "launched",
+        now,
+        now,
+      );
+    }, /FOREIGN KEY/i);
+  });
+});
+
+describe("linear types module", () => {
+  it("can be imported without runtime errors", async () => {
+    const mod = await import("../dist/integrations/linear/types.js");
+    assert.equal(
+      typeof mod,
+      "object",
+      "types module should load (type-only, no runtime exports)",
+    );
+  });
+});

--- a/tests/repo-execution-schema.test.ts
+++ b/tests/repo-execution-schema.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Tests: steps table repo execution metadata migration
+ *
+ * Covers US-001 (Persist repo execution metadata and step isolation policy):
+ *   - migrate() adds execution_mode, repo_key, repo_path, queued_at,
+ *     blocked_by_run_id, blocked_by_step_id columns to the steps table
+ *   - All new columns are nullable so legacy rows migrate cleanly
+ *   - Migration is idempotent — repeat calls don't error or duplicate columns
+ *   - Applied to a legacy steps table, existing rows survive and the new
+ *     columns default to NULL
+ *   - A step row round-trips the new fields (mode, key, blocked metadata)
+ *   - An index on (repo_key, status) exists so same-repo lookups can be
+ *     served without a full table scan
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../dist/db.js";
+import type { StepInfo } from "../dist/installer/status.js";
+
+const NEW_STEP_COLUMNS = [
+  "execution_mode",
+  "repo_key",
+  "repo_path",
+  "queued_at",
+  "blocked_by_run_id",
+  "blocked_by_step_id",
+] as const;
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys=ON");
+  migrate(db);
+  return db;
+}
+
+/**
+ * Build a "legacy" steps table that mirrors the pre-isolation schema,
+ * then call migrate() and assert it adds the new columns without
+ * recreating the table.
+ */
+function legacyDbWithoutRepoColumns(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys=ON");
+  db.exec(`
+    CREATE TABLE runs (
+      id TEXT PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      task TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      context TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+    CREATE TABLE steps (
+      id TEXT PRIMARY KEY,
+      run_id TEXT NOT NULL REFERENCES runs(id),
+      step_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      step_index INTEGER NOT NULL,
+      input_template TEXT NOT NULL,
+      expects TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'waiting',
+      output TEXT,
+      retry_count INTEGER DEFAULT 0,
+      max_retries INTEGER DEFAULT 2,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+describe("steps table repo execution metadata", () => {
+  it("adds all repo execution metadata columns on a fresh migration", () => {
+    const db = freshDb();
+    const cols = db.prepare("PRAGMA table_info(steps)").all() as Array<{ name: string }>;
+    const names = new Set(cols.map((c) => c.name));
+    for (const col of NEW_STEP_COLUMNS) {
+      assert.ok(names.has(col), `missing column ${col}`);
+    }
+  });
+
+  it("declares all new repo execution columns as nullable", () => {
+    const db = freshDb();
+    const cols = db.prepare("PRAGMA table_info(steps)").all() as Array<{
+      name: string;
+      notnull: number;
+    }>;
+    const byName = new Map(cols.map((c) => [c.name, c.notnull]));
+    for (const col of NEW_STEP_COLUMNS) {
+      assert.equal(byName.get(col), 0, `${col} must be nullable`);
+    }
+  });
+
+  it("is idempotent — repeat migrate() calls don't error or duplicate columns", () => {
+    const db = freshDb();
+    assert.doesNotThrow(() => migrate(db));
+    assert.doesNotThrow(() => migrate(db));
+    assert.doesNotThrow(() => migrate(db));
+    const cols = db.prepare("PRAGMA table_info(steps)").all() as Array<{ name: string }>;
+    for (const col of NEW_STEP_COLUMNS) {
+      const matches = cols.filter((c) => c.name === col);
+      assert.equal(matches.length, 1, `${col} should appear exactly once`);
+    }
+  });
+
+  it("upgrades a legacy DB without recreating the steps table, preserving rows", () => {
+    const db = legacyDbWithoutRepoColumns();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES ('run_legacy', 'feature-dev', 't', 'running', '{}', ?, ?)`,
+    ).run(now, now);
+    db.prepare(
+      `INSERT INTO steps
+        (id, run_id, step_id, agent_id, step_index, input_template, expects,
+         status, created_at, updated_at)
+       VALUES ('step_legacy', 'run_legacy', 'implement', 'feature-dev_developer',
+               0, '', '', 'waiting', ?, ?)`,
+    ).run(now, now);
+
+    const before = db.prepare("PRAGMA table_info(steps)").all() as Array<{ name: string }>;
+    for (const col of NEW_STEP_COLUMNS) {
+      assert.ok(!before.some((c) => c.name === col), `legacy table should lack ${col}`);
+    }
+
+    assert.doesNotThrow(() => migrate(db));
+
+    const after = db.prepare("PRAGMA table_info(steps)").all() as Array<{ name: string }>;
+    for (const col of NEW_STEP_COLUMNS) {
+      assert.ok(after.some((c) => c.name === col), `${col} added after migration`);
+    }
+
+    const row = db
+      .prepare(
+        `SELECT id, status, execution_mode, repo_key, repo_path,
+                queued_at, blocked_by_run_id, blocked_by_step_id
+         FROM steps WHERE id = ?`,
+      )
+      .get("step_legacy") as {
+        id: string;
+        status: string;
+        execution_mode: string | null;
+        repo_key: string | null;
+        repo_path: string | null;
+        queued_at: string | null;
+        blocked_by_run_id: string | null;
+        blocked_by_step_id: string | null;
+      };
+    assert.equal(row.id, "step_legacy");
+    assert.equal(row.status, "waiting");
+    assert.equal(row.execution_mode, null);
+    assert.equal(row.repo_key, null);
+    assert.equal(row.repo_path, null);
+    assert.equal(row.queued_at, null);
+    assert.equal(row.blocked_by_run_id, null);
+    assert.equal(row.blocked_by_step_id, null);
+  });
+
+  it("round-trips repo execution metadata through a step row", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES ('run_A', 'feature-dev', 't', 'running', '{}', ?, ?)`,
+    ).run(now, now);
+    db.prepare(
+      `INSERT INTO steps
+        (id, run_id, step_id, agent_id, step_index, input_template, expects,
+         status, execution_mode, repo_key, repo_path, queued_at,
+         blocked_by_run_id, blocked_by_step_id, created_at, updated_at)
+       VALUES ('step_A', 'run_A', 'implement', 'feature-dev_developer', 0,
+               '', '', 'pending',
+               'shared_checkout_exclusive', '/repos/app', '/repos/app',
+               ?, 'run_B', 'step_B', ?, ?)`,
+    ).run(now, now, now);
+
+    const row = db.prepare("SELECT * FROM steps WHERE id = 'step_A'").get() as StepInfo;
+    assert.equal(row.execution_mode, "shared_checkout_exclusive");
+    assert.equal(row.repo_key, "/repos/app");
+    assert.equal(row.repo_path, "/repos/app");
+    assert.equal(row.queued_at, now);
+    assert.equal(row.blocked_by_run_id, "run_B");
+    assert.equal(row.blocked_by_step_id, "step_B");
+  });
+
+  it("permits clearing queue metadata when a step claims the repo lock", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES ('run_C', 'feature-dev', 't', 'running', '{}', ?, ?)`,
+    ).run(now, now);
+    db.prepare(
+      `INSERT INTO steps
+        (id, run_id, step_id, agent_id, step_index, input_template, expects,
+         status, execution_mode, repo_key, repo_path, queued_at,
+         blocked_by_run_id, blocked_by_step_id, created_at, updated_at)
+       VALUES ('step_C', 'run_C', 'implement', 'feature-dev_developer', 0,
+               '', '', 'pending',
+               'shared_checkout_exclusive', '/repos/app', '/repos/app',
+               ?, 'run_D', 'step_D', ?, ?)`,
+    ).run(now, now, now);
+
+    db.prepare(
+      `UPDATE steps
+         SET status = 'running',
+             queued_at = NULL,
+             blocked_by_run_id = NULL,
+             blocked_by_step_id = NULL,
+             updated_at = ?
+       WHERE id = 'step_C'`,
+    ).run(new Date().toISOString());
+
+    const row = db
+      .prepare(
+        `SELECT status, queued_at, blocked_by_run_id, blocked_by_step_id
+         FROM steps WHERE id = 'step_C'`,
+      )
+      .get() as {
+        status: string;
+        queued_at: string | null;
+        blocked_by_run_id: string | null;
+        blocked_by_step_id: string | null;
+      };
+    assert.equal(row.status, "running");
+    assert.equal(row.queued_at, null);
+    assert.equal(row.blocked_by_run_id, null);
+    assert.equal(row.blocked_by_step_id, null);
+  });
+
+  it("creates an index on (repo_key, status) for same-repo scheduling lookups", () => {
+    const db = freshDb();
+    const indexes = db
+      .prepare("PRAGMA index_list(steps)")
+      .all() as Array<{ name: string }>;
+    const idx = indexes.find((i) => i.name === "idx_steps_repo_key_status");
+    assert.ok(idx, "expected idx_steps_repo_key_status index to exist");
+
+    const cols = db
+      .prepare("PRAGMA index_info(idx_steps_repo_key_status)")
+      .all() as Array<{ seqno: number; name: string }>;
+    const orderedNames = cols
+      .sort((a, b) => a.seqno - b.seqno)
+      .map((c) => c.name);
+    assert.deepEqual(orderedNames, ["repo_key", "status"]);
+  });
+});
+
+describe("StepInfo type exposes repo execution metadata fields", () => {
+  it("compiles a StepInfo literal that includes the new fields", () => {
+    // Compile-time guarantee via dist d.ts: if any field is missing from
+    // StepInfo, this cast fails at runtime when dist is rebuilt.
+    const info = {
+      id: "step_1",
+      run_id: "run_1",
+      step_id: "implement",
+      agent_id: "feature-dev_developer",
+      step_index: 0,
+      input_template: "",
+      expects: "",
+      status: "pending",
+      output: null,
+      retry_count: 0,
+      max_retries: 2,
+      execution_mode: "shared_checkout_exclusive",
+      repo_key: "/repos/app",
+      repo_path: "/repos/app",
+      queued_at: "2026-04-20T00:00:00.000Z",
+      blocked_by_run_id: "run_other",
+      blocked_by_step_id: "step_other",
+      created_at: "2026-04-20T00:00:00.000Z",
+      updated_at: "2026-04-20T00:00:00.000Z",
+    } as const;
+
+    const asInfo: StepInfo = info as unknown as StepInfo;
+    assert.equal(asInfo.execution_mode, "shared_checkout_exclusive");
+    assert.equal(asInfo.repo_key, "/repos/app");
+    assert.equal(asInfo.blocked_by_run_id, "run_other");
+  });
+});

--- a/tests/repo-isolation-claim.test.ts
+++ b/tests/repo-isolation-claim.test.ts
@@ -1,0 +1,420 @@
+/**
+ * Tests: claimStep() repo-isolation guard
+ *
+ * Covers US-002 (Block same-repo coding-step claims while a shared checkout
+ * is busy):
+ *   - When a shared_checkout_exclusive step is already running for a repo
+ *     key, claimStep() refuses to claim another same-repo coding step —
+ *     regardless of which run / workflow the pending step belongs to.
+ *   - The blocked same-repo step stays pending and gets `blocked_by_run_id`
+ *     / `blocked_by_step_id` / `queued_at` metadata pointing at the busy
+ *     owner so operators can see why it's queued.
+ *   - A pending shared_checkout_exclusive step for a *different* repo key
+ *     is still claimable while the first repo is busy.
+ *   - Once the busy step finishes, the queued step becomes claimable and
+ *     its block metadata is cleared on the winning transition.
+ *
+ * Mirrors the tmp-HOME pattern used in run-pause-resume.test.ts so the
+ * compiled dist/db.js module points at an isolated sqlite file.
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+type StepOpsModule = typeof import("../dist/installer/step-ops.js");
+type DbModule = typeof import("../dist/db.js");
+
+let stepOps: StepOpsModule;
+let dbMod: DbModule;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+const REPO_A = "/tmp/antfarm-test-repo-a";
+const REPO_B = "/tmp/antfarm-test-repo-b";
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function insertRun(
+  db: DatabaseSync,
+  opts: {
+    id?: string;
+    workflowId?: string;
+    status?: string;
+    context?: Record<string, string>;
+  } = {},
+): string {
+  const id = opts.id ?? crypto.randomUUID();
+  const t = nowIso();
+  db.prepare(
+    `INSERT INTO runs
+     (id, workflow_id, task, status, context, created_at, updated_at)
+     VALUES (?, ?, 'test task', ?, ?, ?, ?)`,
+  ).run(
+    id,
+    opts.workflowId ?? "feature-dev",
+    opts.status ?? "running",
+    JSON.stringify(opts.context ?? { repo: REPO_A, branch: "main" }),
+    t,
+    t,
+  );
+  return id;
+}
+
+function insertStep(
+  db: DatabaseSync,
+  runId: string,
+  opts: {
+    stepId?: string;
+    agentId?: string;
+    stepIndex?: number;
+    status?: string;
+    executionMode?: string | null;
+    repoKey?: string | null;
+    repoPath?: string | null;
+    inputTemplate?: string;
+  } = {},
+): string {
+  const id = crypto.randomUUID();
+  const t = nowIso();
+  db.prepare(
+    `INSERT INTO steps
+      (id, run_id, step_id, agent_id, step_index, input_template, expects,
+       status, type, execution_mode, repo_key, repo_path, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, '', ?, 'single', ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    runId,
+    opts.stepId ?? "implement",
+    opts.agentId ?? "feature-dev_developer",
+    opts.stepIndex ?? 0,
+    opts.inputTemplate ?? "",
+    opts.status ?? "pending",
+    opts.executionMode ?? null,
+    opts.repoKey ?? null,
+    opts.repoPath ?? null,
+    t,
+    t,
+  );
+  return id;
+}
+
+function resetTables(db: DatabaseSync): void {
+  db.exec("DELETE FROM steps");
+  db.exec("DELETE FROM stories");
+  db.exec("DELETE FROM runs");
+}
+
+before(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-repo-isolation-claim-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  dbMod = await import("../dist/db.js");
+  stepOps = await import("../dist/installer/step-ops.js");
+});
+
+after(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+beforeEach(() => {
+  resetTables(dbMod.getDb());
+});
+
+describe("claimStep() same-repo coding guard", () => {
+  it("refuses to claim a same-repo coding step while another is running — across workflows", () => {
+    const db = dbMod.getDb();
+
+    // Run A is actively running a coding step against REPO_A. Its agent_id
+    // differs from Run B's to prove the guard keys on repo, not workflow id.
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    // Run B (different workflow id) has a pending coding step for the same repo.
+    const runB = insertRun(db, { workflowId: "bug-fix" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const result = stepOps.claimStep("bug-fix_fixer");
+
+    assert.equal(result.found, false, "claimStep must not hand out a same-repo step");
+
+    const row = db.prepare(
+      "SELECT status FROM steps WHERE id = ?"
+    ).get(pendingStepB) as { status: string };
+    assert.equal(row.status, "pending", "pending step must remain pending, not running");
+  });
+
+  it("records blocked_by metadata referencing the busy repo owner", () => {
+    const db = dbMod.getDb();
+
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    const runningStepA = insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "bug-fix" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const result = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(result.found, false);
+
+    const row = db.prepare(
+      `SELECT status, blocked_by_run_id, blocked_by_step_id, queued_at
+         FROM steps WHERE id = ?`
+    ).get(pendingStepB) as {
+      status: string;
+      blocked_by_run_id: string | null;
+      blocked_by_step_id: string | null;
+      queued_at: string | null;
+    };
+
+    assert.equal(row.status, "pending");
+    assert.equal(row.blocked_by_run_id, runA, "blocked_by_run_id must point at the busy run");
+    assert.equal(row.blocked_by_step_id, runningStepA, "blocked_by_step_id must point at the running step");
+    assert.ok(row.queued_at, "queued_at must be stamped so operators see when it was first blocked");
+  });
+
+  it("same-repo coding step stays blocked even within the same workflow across runs", () => {
+    const db = dbMod.getDb();
+
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "feature-dev" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const result = stepOps.claimStep("feature-dev_developer");
+    assert.equal(result.found, false, "Same agent, same workflow, same repo — must stay queued");
+
+    const row = db.prepare(
+      "SELECT status FROM steps WHERE id = ?"
+    ).get(pendingStepB) as { status: string };
+    assert.equal(row.status, "pending");
+  });
+
+  it("claims a pending shared_checkout_exclusive step for a DIFFERENT repo while first repo is busy", () => {
+    const db = dbMod.getDb();
+
+    // Busy repo A
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    // Unrelated repo B, different workflow
+    const runB = insertRun(db, {
+      workflowId: "other-feature",
+      context: { repo: REPO_B, branch: "main" },
+    });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "implement",
+      agentId: "other-feature_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_B,
+      repoPath: REPO_B,
+      inputTemplate: "Implement in {{repo}} on {{branch}}",
+    });
+
+    const result = stepOps.claimStep("other-feature_developer");
+
+    assert.equal(result.found, true, "Different repo must still be claimable");
+    assert.equal(result.stepId, pendingStepB);
+
+    const row = db.prepare(
+      "SELECT status FROM steps WHERE id = ?"
+    ).get(pendingStepB) as { status: string };
+    assert.equal(row.status, "running", "Unrelated repo's step should transition to running");
+  });
+
+  it("does not block a non-coding step (no_lock) even when it shares the repo_key", () => {
+    const db = dbMod.getDb();
+
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    // A pending verify step on the same repo — verify is no_lock and should
+    // be allowed to proceed even while coding is active. (In practice the
+    // pipeline ordering inside the same run stops this, but across runs /
+    // agents it must not be blocked by the repo lock.)
+    const runB = insertRun(db, { workflowId: "feature-dev" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "verify",
+      agentId: "feature-dev_verifier",
+      status: "pending",
+      executionMode: "no_lock",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const result = stepOps.claimStep("feature-dev_verifier");
+    assert.equal(result.found, true, "no_lock steps must not be affected by repo lock");
+    assert.equal(result.stepId, pendingStepB);
+  });
+
+  it("claims the queued step once the busy owner is no longer running and clears block metadata", () => {
+    const db = dbMod.getDb();
+
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    const runningStepA = insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "bug-fix" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    // First poll: blocked and annotated.
+    let result = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(result.found, false);
+
+    const blocked = db.prepare(
+      "SELECT blocked_by_run_id, queued_at FROM steps WHERE id = ?"
+    ).get(pendingStepB) as { blocked_by_run_id: string | null; queued_at: string | null };
+    assert.equal(blocked.blocked_by_run_id, runA);
+    assert.ok(blocked.queued_at);
+
+    // Finish the owner step.
+    db.prepare(
+      "UPDATE steps SET status = 'done', updated_at = datetime('now') WHERE id = ?"
+    ).run(runningStepA);
+
+    // Second poll: should now claim.
+    result = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(result.found, true, "Queued step must claim once owner is no longer running");
+    assert.equal(result.stepId, pendingStepB);
+
+    const cleared = db.prepare(
+      `SELECT status, blocked_by_run_id, blocked_by_step_id, queued_at
+         FROM steps WHERE id = ?`
+    ).get(pendingStepB) as {
+      status: string;
+      blocked_by_run_id: string | null;
+      blocked_by_step_id: string | null;
+      queued_at: string | null;
+    };
+    assert.equal(cleared.status, "running");
+    assert.equal(cleared.blocked_by_run_id, null, "block metadata must be cleared on claim");
+    assert.equal(cleared.blocked_by_step_id, null);
+    assert.equal(cleared.queued_at, null);
+  });
+
+  it("clears stale block metadata on next poll when owner is gone even if claim would be denied for other reasons", () => {
+    const db = dbMod.getDb();
+
+    // Pre-populate a pending step with stale block metadata pointing at a
+    // run/step that's already completed.
+    const runOld = insertRun(db, { workflowId: "feature-dev", status: "completed" });
+    const oldStep = insertStep(db, runOld, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "done",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "feature-dev" });
+    const pendingStepB = insertStep(db, runB, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    // Seed stale metadata that should be cleared because no step is running now.
+    db.prepare(
+      `UPDATE steps
+          SET blocked_by_run_id = ?, blocked_by_step_id = ?, queued_at = datetime('now')
+        WHERE id = ?`
+    ).run(runOld, oldStep, pendingStepB);
+
+    // Claim should succeed; the SELECT guard only excludes pending same-repo
+    // steps when a *running* owner exists. So this polls, claims the step,
+    // and clears block metadata in the same transition.
+    const result = stepOps.claimStep("feature-dev_developer");
+    assert.equal(result.found, true);
+
+    const row = db.prepare(
+      "SELECT blocked_by_run_id, blocked_by_step_id, queued_at FROM steps WHERE id = ?"
+    ).get(pendingStepB) as {
+      blocked_by_run_id: string | null;
+      blocked_by_step_id: string | null;
+      queued_at: string | null;
+    };
+    assert.equal(row.blocked_by_run_id, null);
+    assert.equal(row.blocked_by_step_id, null);
+    assert.equal(row.queued_at, null);
+  });
+});

--- a/tests/repo-isolation-policy.test.ts
+++ b/tests/repo-isolation-policy.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests: repo-isolation policy helpers
+ *
+ * Covers US-001:
+ *   - resolveStepExecutionMode() returns `shared_checkout_exclusive` for
+ *     repo-mutating (coding) roles and `no_lock` for everything else
+ *   - normalizeRepoKey() canonicalizes repo paths so different representations
+ *     of the same checkout collapse to one scheduling key
+ *   - deriveStepRepoMetadata() glues role + path into a persist-ready record
+ *
+ * These helpers are pure (no DB, no fs), so we import them directly from dist/
+ * to mirror the existing test-import convention.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import {
+  resolveStepExecutionMode,
+  normalizeRepoKey,
+  deriveStepRepoMetadata,
+  isRepoMutatingRole,
+  SHARED_CHECKOUT_EXCLUSIVE,
+  NO_LOCK,
+} from "../dist/installer/repo-isolation.js";
+import type { AgentRole } from "../dist/installer/types.js";
+
+describe("resolveStepExecutionMode()", () => {
+  it("returns shared_checkout_exclusive for coding roles", () => {
+    assert.equal(
+      resolveStepExecutionMode({ role: "coding" }),
+      SHARED_CHECKOUT_EXCLUSIVE,
+    );
+  });
+
+  it("returns no_lock for non-mutating roles", () => {
+    const nonMutating: AgentRole[] = [
+      "analysis",
+      "verification",
+      "testing",
+      "pr",
+      "scanning",
+    ];
+    for (const role of nonMutating) {
+      assert.equal(
+        resolveStepExecutionMode({ role }),
+        NO_LOCK,
+        `role ${role} should resolve to no_lock`,
+      );
+    }
+  });
+
+  it("treats missing role as non-mutating (conservative default)", () => {
+    assert.equal(resolveStepExecutionMode({}), NO_LOCK);
+    assert.equal(resolveStepExecutionMode({ role: null }), NO_LOCK);
+    assert.equal(resolveStepExecutionMode({ role: undefined }), NO_LOCK);
+  });
+
+  it("isRepoMutatingRole() matches the resolved mode", () => {
+    assert.equal(isRepoMutatingRole("coding"), true);
+    assert.equal(isRepoMutatingRole("analysis"), false);
+    assert.equal(isRepoMutatingRole(undefined), false);
+    assert.equal(isRepoMutatingRole(null), false);
+  });
+});
+
+describe("normalizeRepoKey()", () => {
+  it("returns null for empty / whitespace / nullish input", () => {
+    assert.equal(normalizeRepoKey(null), null);
+    assert.equal(normalizeRepoKey(undefined), null);
+    assert.equal(normalizeRepoKey(""), null);
+    assert.equal(normalizeRepoKey("   "), null);
+  });
+
+  it("returns null for a bare root path (no meaningful repo)", () => {
+    assert.equal(normalizeRepoKey("/"), null);
+  });
+
+  it("collapses trailing slashes to a single canonical form", () => {
+    const a = normalizeRepoKey("/tmp/antfarm-repo");
+    const b = normalizeRepoKey("/tmp/antfarm-repo/");
+    const c = normalizeRepoKey("/tmp/antfarm-repo///");
+    assert.equal(a, "/tmp/antfarm-repo");
+    assert.equal(b, a);
+    assert.equal(c, a);
+  });
+
+  it("resolves relative paths against the process cwd", () => {
+    const rel = "./some-repo";
+    const normalized = normalizeRepoKey(rel);
+    assert.equal(normalized, path.resolve(rel));
+    assert.ok(path.isAbsolute(normalized!), "normalized key must be absolute");
+  });
+
+  it("collapses `..` segments so equivalent paths share a key", () => {
+    const a = normalizeRepoKey("/tmp/antfarm/../antfarm/repo");
+    const b = normalizeRepoKey("/tmp/antfarm/repo");
+    assert.equal(a, b);
+  });
+
+  it("expands `~` and `~/…` using the user's home directory", () => {
+    const home = os.homedir();
+    assert.equal(normalizeRepoKey("~"), home);
+    assert.equal(normalizeRepoKey("~/repos/app"), path.join(home, "repos/app"));
+  });
+
+  it("different workflow ids pointing at the same checkout resolve to the same key", () => {
+    const keyA = normalizeRepoKey("/Users/dev/workspace/feature-dev-app");
+    const keyB = normalizeRepoKey("/Users/dev/workspace/feature-dev-app/");
+    const keyC = normalizeRepoKey("/Users/dev/workspace/../workspace/feature-dev-app");
+    assert.equal(keyA, keyB);
+    assert.equal(keyA, keyC);
+  });
+
+  it("distinct checkouts resolve to distinct keys", () => {
+    const a = normalizeRepoKey("/repos/app-one");
+    const b = normalizeRepoKey("/repos/app-two");
+    assert.notEqual(a, b);
+  });
+});
+
+describe("deriveStepRepoMetadata()", () => {
+  it("produces exclusive mode + normalized key for coding steps", () => {
+    const meta = deriveStepRepoMetadata({
+      role: "coding",
+      repoPath: "/repos/app/",
+    });
+    assert.equal(meta.execution_mode, SHARED_CHECKOUT_EXCLUSIVE);
+    assert.equal(meta.repo_key, "/repos/app");
+    assert.equal(meta.repo_path, "/repos/app/");
+  });
+
+  it("produces no-lock mode for analysis steps (but still records identity)", () => {
+    const meta = deriveStepRepoMetadata({
+      role: "analysis",
+      repoPath: "/repos/app",
+    });
+    assert.equal(meta.execution_mode, NO_LOCK);
+    // We still persist repo identity for operator visibility even when no
+    // lock is taken.
+    assert.equal(meta.repo_key, "/repos/app");
+    assert.equal(meta.repo_path, "/repos/app");
+  });
+
+  it("handles missing repo path by nulling out key + path", () => {
+    const meta = deriveStepRepoMetadata({ role: "coding", repoPath: null });
+    assert.equal(meta.execution_mode, SHARED_CHECKOUT_EXCLUSIVE);
+    assert.equal(meta.repo_key, null);
+    assert.equal(meta.repo_path, null);
+  });
+
+  it("handles missing role by defaulting to no_lock", () => {
+    const meta = deriveStepRepoMetadata({ repoPath: "/repos/app" });
+    assert.equal(meta.execution_mode, NO_LOCK);
+    assert.equal(meta.repo_key, "/repos/app");
+  });
+
+  it("trims whitespace in repo path but preserves the raw-ish value", () => {
+    const meta = deriveStepRepoMetadata({
+      role: "coding",
+      repoPath: "   ",
+    });
+    assert.equal(meta.repo_key, null);
+    assert.equal(meta.repo_path, null);
+  });
+});

--- a/tests/repo-isolation-release.test.ts
+++ b/tests/repo-isolation-release.test.ts
@@ -1,0 +1,557 @@
+/**
+ * Tests: repo-lease release + FIFO promotion (US-003)
+ *
+ * Covers:
+ *   - releaseStepResources() is a no-op for no_lock steps
+ *   - releaseStepResources() clears stale blocked_by_* annotations on peers
+ *     that pointed at the released step
+ *   - releaseStepLeaseById() looks up the step row and delegates correctly
+ *   - releaseRunSteps() releases every shared_checkout_exclusive step in a run
+ *   - Completing a running shared_checkout_exclusive step releases the lease
+ *     and the oldest queued same-repo coding step becomes claimable first
+ *     (FIFO by created_at)
+ *   - Failing a step releases the lease
+ *   - Cancelling a run via stopWorkflow releases all held repo leases
+ *   - Abandonment recovery releases the lease (both timeout-fail and reset paths)
+ *   - FIFO is deterministic: when two same-repo pending steps exist and neither
+ *     is running, only the oldest can be claimed
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+type StepOpsModule = typeof import("../dist/installer/step-ops.js");
+type SchedulerModule = typeof import("../dist/installer/repo-scheduler.js");
+type StatusModule = typeof import("../dist/installer/status.js");
+type DbModule = typeof import("../dist/db.js");
+
+let stepOps: StepOpsModule;
+let scheduler: SchedulerModule;
+let statusMod: StatusModule;
+let dbMod: DbModule;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+const REPO_A = "/tmp/antfarm-test-repo-release-a";
+const REPO_B = "/tmp/antfarm-test-repo-release-b";
+
+function insertRun(
+  db: DatabaseSync,
+  opts: {
+    id?: string;
+    workflowId?: string;
+    status?: string;
+    context?: Record<string, string>;
+  } = {},
+): string {
+  const id = opts.id ?? crypto.randomUUID();
+  const t = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO runs
+     (id, workflow_id, task, status, context, created_at, updated_at)
+     VALUES (?, ?, 'test task', ?, ?, ?, ?)`,
+  ).run(
+    id,
+    opts.workflowId ?? "feature-dev",
+    opts.status ?? "running",
+    JSON.stringify(opts.context ?? { repo: REPO_A, branch: "main" }),
+    t,
+    t,
+  );
+  return id;
+}
+
+function insertStep(
+  db: DatabaseSync,
+  runId: string,
+  opts: {
+    stepId?: string;
+    agentId?: string;
+    stepIndex?: number;
+    status?: string;
+    executionMode?: string | null;
+    repoKey?: string | null;
+    repoPath?: string | null;
+    inputTemplate?: string;
+    expects?: string;
+    createdAt?: string;
+    type?: string;
+  } = {},
+): string {
+  const id = crypto.randomUUID();
+  const t = opts.createdAt ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO steps
+      (id, run_id, step_id, agent_id, step_index, input_template, expects,
+       status, type, execution_mode, repo_key, repo_path, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    runId,
+    opts.stepId ?? "implement",
+    opts.agentId ?? "feature-dev_developer",
+    opts.stepIndex ?? 0,
+    opts.inputTemplate ?? "",
+    opts.expects ?? "",
+    opts.status ?? "pending",
+    opts.type ?? "single",
+    opts.executionMode ?? null,
+    opts.repoKey ?? null,
+    opts.repoPath ?? null,
+    t,
+    t,
+  );
+  return id;
+}
+
+function resetTables(db: DatabaseSync): void {
+  db.exec("DELETE FROM steps");
+  db.exec("DELETE FROM stories");
+  db.exec("DELETE FROM runs");
+}
+
+before(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-repo-release-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  dbMod = await import("../dist/db.js");
+  stepOps = await import("../dist/installer/step-ops.js");
+  scheduler = await import("../dist/installer/repo-scheduler.js");
+  statusMod = await import("../dist/installer/status.js");
+});
+
+after(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+beforeEach(() => {
+  resetTables(dbMod.getDb());
+});
+
+describe("releaseStepResources()", () => {
+  it("is a no-op for no_lock steps", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db);
+    const verify = insertStep(db, runA, {
+      status: "done",
+      executionMode: "no_lock",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const result = scheduler.releaseStepResources({
+      stepId: verify,
+      runId: runA,
+      executionMode: "no_lock",
+      repoKey: REPO_A,
+      reason: "completed",
+    });
+    assert.equal(result.nextStepId, null, "no_lock release returns no successor");
+  });
+
+  it("is a no-op when repoKey is missing", () => {
+    const result = scheduler.releaseStepResources({
+      stepId: "x",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: null,
+      reason: "completed",
+    });
+    assert.equal(result.nextStepId, null);
+  });
+
+  it("clears stale blocked_by_step_id on peers pointing at the released step", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db, { workflowId: "feature-dev" });
+    const released = insertStep(db, runA, {
+      status: "done",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "bug-fix" });
+    const peer = insertStep(db, runB, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    db.prepare(
+      `UPDATE steps SET blocked_by_run_id = ?, blocked_by_step_id = ?, queued_at = datetime('now') WHERE id = ?`,
+    ).run(runA, released, peer);
+
+    scheduler.releaseStepResources({
+      stepId: released,
+      runId: runA,
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      reason: "completed",
+    });
+
+    const row = db.prepare(
+      "SELECT blocked_by_run_id, blocked_by_step_id FROM steps WHERE id = ?",
+    ).get(peer) as { blocked_by_run_id: string | null; blocked_by_step_id: string | null };
+    assert.equal(row.blocked_by_run_id, null, "stale blocked_by_run_id must be cleared");
+    assert.equal(row.blocked_by_step_id, null);
+  });
+
+  it("reports the oldest queued same-repo peer as nextStepId (FIFO)", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db);
+    const released = insertStep(db, runA, {
+      status: "done",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runOld = insertRun(db, { workflowId: "bug-fix" });
+    const oldPeer = insertStep(db, runOld, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-02T00:00:00.000Z",
+    });
+
+    const runNew = insertRun(db, { workflowId: "other" });
+    insertStep(db, runNew, {
+      stepId: "implement",
+      agentId: "other_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-03T00:00:00.000Z",
+    });
+
+    const result = scheduler.releaseStepResources({
+      stepId: released,
+      runId: runA,
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      reason: "completed",
+    });
+    assert.equal(result.nextStepId, oldPeer, "oldest created_at must be promoted first");
+  });
+
+  it("ignores same-repo pending steps in failed/cancelled runs when reporting next", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db);
+    const released = insertStep(db, runA, {
+      status: "done",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runCancelled = insertRun(db, { workflowId: "cancelled", status: "cancelled" });
+    insertStep(db, runCancelled, {
+      stepId: "fix",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const result = scheduler.releaseStepResources({
+      stepId: released,
+      runId: runA,
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      reason: "completed",
+    });
+    assert.equal(result.nextStepId, null, "cancelled-run pending steps must not be promoted");
+  });
+});
+
+describe("releaseStepLeaseById()", () => {
+  it("looks up step metadata and clears peer annotations", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db);
+    const released = insertStep(db, runA, {
+      status: "done",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const peer = insertStep(db, insertRun(db, { workflowId: "b" }), {
+      stepId: "fix",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    db.prepare(
+      `UPDATE steps SET blocked_by_step_id = ? WHERE id = ?`,
+    ).run(released, peer);
+
+    scheduler.releaseStepLeaseById(released, "completed");
+    const row = db.prepare(
+      "SELECT blocked_by_step_id FROM steps WHERE id = ?",
+    ).get(peer) as { blocked_by_step_id: string | null };
+    assert.equal(row.blocked_by_step_id, null);
+  });
+
+  it("silently no-ops for missing step ids", () => {
+    const res = scheduler.releaseStepLeaseById("does-not-exist", "completed");
+    assert.equal(res.nextStepId, null);
+  });
+});
+
+describe("releaseRunSteps()", () => {
+  it("releases every shared_checkout_exclusive step attached to a run", () => {
+    const db = dbMod.getDb();
+    const runA = insertRun(db);
+    const stepA1 = insertStep(db, runA, {
+      stepId: "implement",
+      status: "failed",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const stepA2 = insertStep(db, runA, {
+      stepId: "fix",
+      stepIndex: 1,
+      status: "failed",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const runB = insertRun(db, { workflowId: "b" });
+    const peer1 = insertStep(db, runB, {
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const peer2 = insertStep(db, runB, {
+      stepId: "fix",
+      stepIndex: 1,
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    db.prepare(`UPDATE steps SET blocked_by_step_id = ? WHERE id = ?`).run(stepA1, peer1);
+    db.prepare(`UPDATE steps SET blocked_by_step_id = ? WHERE id = ?`).run(stepA2, peer2);
+
+    scheduler.releaseRunSteps(runA, "cancelled");
+
+    const r1 = db.prepare("SELECT blocked_by_step_id FROM steps WHERE id = ?").get(peer1) as { blocked_by_step_id: string | null };
+    const r2 = db.prepare("SELECT blocked_by_step_id FROM steps WHERE id = ?").get(peer2) as { blocked_by_step_id: string | null };
+    assert.equal(r1.blocked_by_step_id, null);
+    assert.equal(r2.blocked_by_step_id, null);
+  });
+});
+
+describe("claimStep() FIFO promotion across same-repo contenders", () => {
+  it("older same-repo pending step claims before a newer one when neither is running", () => {
+    const db = dbMod.getDb();
+
+    const runOld = insertRun(db, { workflowId: "feature-dev" });
+    const oldStep = insertStep(db, runOld, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runNew = insertRun(db, { workflowId: "feature-dev" });
+    const newStep = insertStep(db, runNew, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-02-01T00:00:00.000Z",
+    });
+
+    const first = stepOps.claimStep("feature-dev_developer");
+    assert.equal(first.found, true);
+    assert.equal(first.stepId, oldStep, "oldest created_at claims first");
+
+    // While oldStep is running, newStep must stay pending (repo busy guard).
+    const second = stepOps.claimStep("feature-dev_developer");
+    assert.equal(second.found, false, "newer same-repo step is still blocked by running older");
+
+    const newRow = db.prepare("SELECT status FROM steps WHERE id = ?").get(newStep) as { status: string };
+    assert.equal(newRow.status, "pending");
+  });
+
+  it("after the older step completes, the newer step is promoted to claimable", () => {
+    const db = dbMod.getDb();
+
+    const runOld = insertRun(db);
+    const oldStep = insertStep(db, runOld, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+      expects: "STATUS: done",
+    });
+
+    const runNew = insertRun(db);
+    const newStep = insertStep(db, runNew, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-02-01T00:00:00.000Z",
+    });
+    // Initial poll stamps block metadata on newStep.
+    stepOps.claimStep("feature-dev_developer");
+    const blocked = db.prepare("SELECT blocked_by_step_id FROM steps WHERE id = ?").get(newStep) as { blocked_by_step_id: string | null };
+    assert.equal(blocked.blocked_by_step_id, oldStep);
+
+    // Complete old step through the real completion path so release fires.
+    stepOps.completeStep(oldStep, "STATUS: done");
+
+    // Peer annotation should be cleared by releaseStepResources.
+    const afterRelease = db.prepare("SELECT blocked_by_step_id FROM steps WHERE id = ?").get(newStep) as { blocked_by_step_id: string | null };
+    assert.equal(afterRelease.blocked_by_step_id, null, "release must clear stale block metadata");
+
+    // Next poll claims the queued step.
+    const res = stepOps.claimStep("feature-dev_developer");
+    assert.equal(res.found, true);
+    assert.equal(res.stepId, newStep);
+  });
+
+  it("releases on failStep() so the next same-repo step becomes claimable", async () => {
+    const db = dbMod.getDb();
+
+    const runOld = insertRun(db);
+    const oldStep = insertStep(db, runOld, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runNew = insertRun(db);
+    const newStep = insertStep(db, runNew, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-02-01T00:00:00.000Z",
+    });
+    stepOps.claimStep("feature-dev_developer"); // annotate newStep
+    db.prepare(`UPDATE steps SET max_retries = 0 WHERE id = ?`).run(oldStep);
+
+    const outcome = await stepOps.failStep(oldStep, "boom");
+    assert.equal(outcome.runFailed, true);
+
+    // Peer block metadata cleared.
+    const row = db.prepare("SELECT blocked_by_step_id FROM steps WHERE id = ?").get(newStep) as { blocked_by_step_id: string | null };
+    assert.equal(row.blocked_by_step_id, null);
+
+    // Queued step is claimable.
+    const claim = stepOps.claimStep("feature-dev_developer");
+    assert.equal(claim.found, true);
+    assert.equal(claim.stepId, newStep);
+  });
+
+  it("releases on stopWorkflow() so cancelling an in-flight run frees the queued same-repo step", async () => {
+    const db = dbMod.getDb();
+
+    const runBusy = insertRun(db);
+    const busyStep = insertStep(db, runBusy, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runQueued = insertRun(db);
+    const queuedStep = insertStep(db, runQueued, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-02-01T00:00:00.000Z",
+    });
+
+    // Stamp blocked metadata as if an earlier poll already saw the busy owner.
+    db.prepare(
+      `UPDATE steps SET blocked_by_run_id = ?, blocked_by_step_id = ?, queued_at = datetime('now') WHERE id = ?`,
+    ).run(runBusy, busyStep, queuedStep);
+
+    const res = await statusMod.stopWorkflow(runBusy);
+    assert.equal(res.status, "ok");
+
+    const row = db.prepare(
+      "SELECT status, blocked_by_run_id, blocked_by_step_id FROM steps WHERE id = ?",
+    ).get(queuedStep) as { status: string; blocked_by_run_id: string | null; blocked_by_step_id: string | null };
+    assert.equal(row.blocked_by_run_id, null, "cancel must clear stale block metadata");
+    assert.equal(row.blocked_by_step_id, null);
+
+    const claim = stepOps.claimStep("feature-dev_developer");
+    assert.equal(claim.found, true, "queued same-repo step must be claimable after cancel");
+    assert.equal(claim.stepId, queuedStep);
+  });
+
+  it("different-repo runs proceed independently regardless of release on repo A", () => {
+    const db = dbMod.getDb();
+
+    const runA = insertRun(db);
+    insertStep(db, runA, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runB = insertRun(db, {
+      workflowId: "b",
+      context: { repo: REPO_B, branch: "main" },
+    });
+    const stepB = insertStep(db, runB, {
+      stepId: "implement",
+      agentId: "b_developer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_B,
+      repoPath: REPO_B,
+      createdAt: "2024-01-02T00:00:00.000Z",
+    });
+
+    const claim = stepOps.claimStep("b_developer");
+    assert.equal(claim.found, true, "unrelated repo must not be affected");
+    assert.equal(claim.stepId, stepB);
+  });
+});

--- a/tests/repo-queue-visibility.test.ts
+++ b/tests/repo-queue-visibility.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Tests: queued repo contention visibility (US-004)
+ *
+ * Verifies that operator-facing status/dashboard surfaces expose enough
+ * repo-queue metadata to distinguish queued same-repo coding work from
+ * actively running work.
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+type VisibilityModule = typeof import("../dist/installer/repo-visibility.js");
+type StatusModule = typeof import("../dist/installer/status.js");
+type DashboardModule = typeof import("../dist/server/dashboard.js");
+type DbModule = typeof import("../dist/db.js");
+
+let visibility: VisibilityModule;
+let statusMod: StatusModule;
+let dashboardMod: DashboardModule;
+let dbMod: DbModule;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+const REPO_A = "/tmp/antfarm-test-repo-visibility-a";
+
+function insertRun(
+  db: DatabaseSync,
+  opts: {
+    id?: string;
+    runNumber?: number | null;
+    workflowId?: string;
+    task?: string;
+    status?: string;
+    context?: Record<string, string>;
+  } = {},
+): string {
+  const id = opts.id ?? crypto.randomUUID();
+  const t = new Date().toISOString();
+  db.prepare(
+    `INSERT INTO runs
+     (id, run_number, workflow_id, task, status, context, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    opts.runNumber ?? null,
+    opts.workflowId ?? "feature-dev",
+    opts.task ?? "test task",
+    opts.status ?? "running",
+    JSON.stringify(opts.context ?? { repo: REPO_A, branch: "main" }),
+    t,
+    t,
+  );
+  return id;
+}
+
+function insertStep(
+  db: DatabaseSync,
+  runId: string,
+  opts: {
+    stepId?: string;
+    agentId?: string;
+    stepIndex?: number;
+    status?: string;
+    executionMode?: string | null;
+    repoKey?: string | null;
+    repoPath?: string | null;
+    blockedByRunId?: string | null;
+    blockedByStepId?: string | null;
+    queuedAt?: string | null;
+    createdAt?: string;
+  } = {},
+): string {
+  const id = crypto.randomUUID();
+  const t = opts.createdAt ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO steps
+       (id, run_id, step_id, agent_id, step_index, input_template, expects,
+        status, type, execution_mode, repo_key, repo_path,
+        blocked_by_run_id, blocked_by_step_id, queued_at,
+        created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    runId,
+    opts.stepId ?? "implement",
+    opts.agentId ?? "feature-dev_developer",
+    opts.stepIndex ?? 0,
+    "",
+    "",
+    opts.status ?? "pending",
+    "single",
+    opts.executionMode ?? null,
+    opts.repoKey ?? null,
+    opts.repoPath ?? null,
+    opts.blockedByRunId ?? null,
+    opts.blockedByStepId ?? null,
+    opts.queuedAt ?? null,
+    t,
+    t,
+  );
+  return id;
+}
+
+function resetTables(db: DatabaseSync): void {
+  db.exec("DELETE FROM steps");
+  db.exec("DELETE FROM stories");
+  db.exec("DELETE FROM runs");
+}
+
+before(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-repo-visibility-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  dbMod = await import("../dist/db.js");
+  visibility = await import("../dist/installer/repo-visibility.js");
+  statusMod = await import("../dist/installer/status.js");
+  dashboardMod = await import("../dist/server/dashboard.js");
+});
+
+after(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+beforeEach(() => {
+  resetTables(dbMod.getDb());
+});
+
+describe("isStepQueuedOnRepo()", () => {
+  it("is true for pending shared_checkout_exclusive step with blocker pointer", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    const owner = insertStep(db, run, {
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const runB = insertRun(db);
+    insertStep(db, runB, {
+      stepId: "implement",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: run,
+      blockedByStepId: owner,
+    });
+    const steps = db.prepare("SELECT * FROM steps WHERE run_id = ?").all(runB) as any[];
+    assert.equal(visibility.isStepQueuedOnRepo(steps[0]), true);
+  });
+
+  it("is false for pending steps with no blocker annotation", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    insertStep(db, run, {
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const step = db.prepare("SELECT * FROM steps").get() as any;
+    assert.equal(visibility.isStepQueuedOnRepo(step), false);
+  });
+
+  it("is false for running steps even if blocker metadata is stale", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    insertStep(db, run, {
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByStepId: "old-id",
+    });
+    const step = db.prepare("SELECT * FROM steps").get() as any;
+    assert.equal(visibility.isStepQueuedOnRepo(step), false);
+  });
+
+  it("is false for no_lock steps", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    insertStep(db, run, {
+      status: "pending",
+      executionMode: "no_lock",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByStepId: "x",
+    });
+    const step = db.prepare("SELECT * FROM steps").get() as any;
+    assert.equal(visibility.isStepQueuedOnRepo(step), false);
+  });
+});
+
+describe("resolveRepoQueueContext()", () => {
+  it("resolves blocking run number, workflow, task, and step id", () => {
+    const db = dbMod.getDb();
+    const ownerRun = insertRun(db, {
+      runNumber: 42,
+      workflowId: "feature-dev",
+      task: "build new thing",
+    });
+    const ownerStep = insertStep(db, ownerRun, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const queuedRun = insertRun(db, { runNumber: 43, workflowId: "bug-fix" });
+    insertStep(db, queuedRun, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: ownerRun,
+      blockedByStepId: ownerStep,
+      queuedAt: "2024-06-01T00:00:00.000Z",
+    });
+
+    const queuedStep = db.prepare("SELECT * FROM steps WHERE run_id = ?").get(queuedRun) as any;
+    const ctx = visibility.resolveRepoQueueContext(queuedStep);
+    assert.ok(ctx);
+    assert.equal(ctx.repoKey, REPO_A);
+    assert.equal(ctx.repoPath, REPO_A);
+    assert.equal(ctx.queuedAt, "2024-06-01T00:00:00.000Z");
+    assert.equal(ctx.blockingRunId, ownerRun);
+    assert.equal(ctx.blockingRunNumber, 42);
+    assert.equal(ctx.blockingWorkflowId, "feature-dev");
+    assert.equal(ctx.blockingTask, "build new thing");
+    assert.equal(ctx.blockingStepId, "implement");
+    assert.equal(ctx.blockingAgentId, "feature-dev_developer");
+  });
+
+  it("returns null for steps that are not queued on repo", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    insertStep(db, run, { status: "running" });
+    const step = db.prepare("SELECT * FROM steps").get() as any;
+    assert.equal(visibility.resolveRepoQueueContext(step), null);
+  });
+
+  it("returns context even when blocker rows have been deleted (graceful degrade)", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    insertStep(db, run, {
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: "missing-run-id",
+      blockedByStepId: "missing-step-id",
+    });
+    const step = db.prepare("SELECT * FROM steps").get() as any;
+    const ctx = visibility.resolveRepoQueueContext(step);
+    assert.ok(ctx, "context is still returned");
+    assert.equal(ctx.blockingRunNumber, null);
+    assert.equal(ctx.blockingStepId, null);
+    assert.equal(ctx.blockingRunId, "missing-run-id");
+  });
+});
+
+describe("formatQueuedAnnotation() + formatStepStatusLine()", () => {
+  it("produces a human-readable annotation with run number and step id", () => {
+    const line = visibility.formatQueuedAnnotation({
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      queuedAt: null,
+      blockingRunId: "abc",
+      blockingRunNumber: 42,
+      blockingWorkflowId: "feature-dev",
+      blockingTask: "t",
+      blockingStepId: "implement",
+      blockingAgentId: "feature-dev_developer",
+    });
+    assert.match(line ?? "", /queued on \/tmp\/antfarm-test-repo-visibility-a/);
+    assert.match(line ?? "", /run #42/);
+    assert.match(line ?? "", /step "implement"/);
+  });
+
+  it("falls back to run id prefix when run_number is missing", () => {
+    const line = visibility.formatQueuedAnnotation({
+      repoKey: REPO_A,
+      repoPath: null,
+      queuedAt: null,
+      blockingRunId: "deadbeef-1111-2222-3333-444455556666",
+      blockingRunNumber: null,
+      blockingWorkflowId: null,
+      blockingTask: null,
+      blockingStepId: null,
+      blockingAgentId: null,
+    });
+    assert.match(line ?? "", /run deadbeef/);
+  });
+
+  it("returns null for null context", () => {
+    assert.equal(visibility.formatQueuedAnnotation(null), null);
+  });
+
+  it("formatStepStatusLine embeds annotation below the base line when queued", () => {
+    const db = dbMod.getDb();
+    const run = insertRun(db);
+    const step: any = {
+      id: "x",
+      run_id: run,
+      step_id: "implement",
+      agent_id: "feature-dev_developer",
+      status: "pending",
+      execution_mode: "shared_checkout_exclusive",
+      repo_key: REPO_A,
+      repo_path: REPO_A,
+      blocked_by_run_id: "r",
+      blocked_by_step_id: "s",
+    };
+    const line = visibility.formatStepStatusLine(step, {
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      queuedAt: null,
+      blockingRunId: "r",
+      blockingRunNumber: 7,
+      blockingWorkflowId: "feature-dev",
+      blockingTask: "t",
+      blockingStepId: "implement",
+      blockingAgentId: "feature-dev_developer",
+    });
+    assert.match(line, /\[pending\] implement \(feature-dev_developer\)/);
+    assert.match(line, /↳ queued on \/tmp\/antfarm-test-repo-visibility-a/);
+    assert.match(line, /run #7/);
+  });
+
+  it("formatStepStatusLine with null queue returns the base line unchanged", () => {
+    const step: any = {
+      status: "running",
+      step_id: "implement",
+      agent_id: "feature-dev_developer",
+    };
+    const line = visibility.formatStepStatusLine(step, null);
+    assert.equal(line, "  [running] implement (feature-dev_developer)");
+    assert.ok(!line.includes("↳"));
+  });
+});
+
+describe("getWorkflowStatus() exposes queue context", () => {
+  it("attaches queue context to queued steps and leaves active steps untouched", () => {
+    const db = dbMod.getDb();
+    const ownerRun = insertRun(db, { runNumber: 100, workflowId: "feature-dev", task: "owner task" });
+    const ownerStep = insertStep(db, ownerRun, {
+      stepId: "implement",
+      agentId: "feature-dev_developer",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+
+    const queuedRun = insertRun(db, { runNumber: 101, workflowId: "bug-fix", task: "queued task" });
+    insertStep(db, queuedRun, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: ownerRun,
+      blockedByStepId: ownerStep,
+      queuedAt: "2024-06-01T00:00:00.000Z",
+    });
+
+    const result = statusMod.getWorkflowStatus("101");
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.steps.length, 1);
+    const step = result.steps[0];
+    assert.ok(step.queue, "queue context is present");
+    assert.equal(step.queue!.blockingRunNumber, 100);
+    assert.equal(step.queue!.blockingStepId, "implement");
+    assert.equal(step.queue!.repoPath, REPO_A);
+
+    const ownerResult = statusMod.getWorkflowStatus("100");
+    assert.equal(ownerResult.status, "ok");
+    if (ownerResult.status !== "ok") return;
+    assert.equal(ownerResult.steps[0].queue, null, "running step carries no queue context");
+  });
+});
+
+describe("dashboard data exposes queue context", () => {
+  it("getRunById includes queue context on queued step", () => {
+    const db = dbMod.getDb();
+    const ownerRun = insertRun(db, { runNumber: 1, workflowId: "feature-dev" });
+    const ownerStep = insertStep(db, ownerRun, {
+      stepId: "implement",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const queuedRun = insertRun(db, { runNumber: 2, workflowId: "bug-fix" });
+    insertStep(db, queuedRun, {
+      stepId: "fix",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: ownerRun,
+      blockedByStepId: ownerStep,
+    });
+
+    const run = dashboardMod.getRunById(queuedRun);
+    assert.ok(run);
+    assert.equal(run!.steps.length, 1);
+    const step = run!.steps[0];
+    assert.ok(step.queue);
+    assert.equal(step.queue!.blockingRunNumber, 1);
+    assert.equal(step.queue!.blockingStepId, "implement");
+    assert.equal(step.queue!.repoPath, REPO_A);
+  });
+
+  it("getRuns includes queue context across multiple runs on the same repo", () => {
+    const db = dbMod.getDb();
+    const ownerRun = insertRun(db, { runNumber: 10, workflowId: "feature-dev" });
+    const ownerStep = insertStep(db, ownerRun, {
+      stepId: "implement",
+      status: "running",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+    });
+    const queuedRun = insertRun(db, { runNumber: 11, workflowId: "feature-dev" });
+    insertStep(db, queuedRun, {
+      stepId: "implement",
+      status: "pending",
+      executionMode: "shared_checkout_exclusive",
+      repoKey: REPO_A,
+      repoPath: REPO_A,
+      blockedByRunId: ownerRun,
+      blockedByStepId: ownerStep,
+    });
+
+    const runs = dashboardMod.getRuns("feature-dev");
+    const queued = runs.find((r) => r.id === queuedRun);
+    const owner = runs.find((r) => r.id === ownerRun);
+    assert.ok(queued);
+    assert.ok(owner);
+    assert.ok(queued!.steps[0].queue, "queued run has queue context");
+    assert.equal(queued!.steps[0].queue!.blockingRunNumber, 10);
+    assert.equal(owner!.steps[0].queue, null, "running owner has no queue context");
+  });
+});

--- a/tests/repo-serialization-e2e.test.ts
+++ b/tests/repo-serialization-e2e.test.ts
@@ -1,0 +1,474 @@
+/**
+ * End-to-end tests: same-repo coding-step serialization (US-005)
+ *
+ * Exercises the real step scheduling path — claimStep, completeStep, failStep,
+ * stopWorkflow, getWorkflowStatus, dashboard getRunById/getRuns — across
+ * multiple concurrent runs, proving that:
+ *
+ *   1. Two runs targeting the same repo never have more than one running
+ *      shared_checkout_exclusive coding step at the same time.
+ *   2. The later same-repo run stays pending (queued) until the earlier repo
+ *      owner releases the shared checkout, then is promoted and claimed.
+ *   3. A run targeting a different repo can still claim and run its coding
+ *      step while the first repo is busy.
+ *   4. Operator-visible queue metadata (runs' steps[*].queue on both the
+ *      /api/runs dashboard path and the CLI status helper) reflects the
+ *      contention window end-to-end — not just via unit formatters.
+ *
+ * Uses the tmp-HOME pattern so the compiled dist/db.js module points at an
+ * isolated sqlite file.
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+type StepOpsModule = typeof import("../dist/installer/step-ops.js");
+type StatusModule = typeof import("../dist/installer/status.js");
+type DashboardModule = typeof import("../dist/server/dashboard.js");
+type DbModule = typeof import("../dist/db.js");
+
+let stepOps: StepOpsModule;
+let statusMod: StatusModule;
+let dashboardMod: DashboardModule;
+let dbMod: DbModule;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+const REPO_A = "/tmp/antfarm-test-serialization-repo-a";
+const REPO_B = "/tmp/antfarm-test-serialization-repo-b";
+
+let runNumberCounter = 1;
+
+function insertRun(
+  db: DatabaseSync,
+  opts: {
+    id?: string;
+    runNumber?: number;
+    workflowId?: string;
+    task?: string;
+    status?: string;
+    context?: Record<string, string>;
+    createdAt?: string;
+  } = {},
+): string {
+  const id = opts.id ?? crypto.randomUUID();
+  const t = opts.createdAt ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO runs
+       (id, run_number, workflow_id, task, status, context, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    opts.runNumber ?? runNumberCounter++,
+    opts.workflowId ?? "feature-dev",
+    opts.task ?? "e2e task",
+    opts.status ?? "running",
+    JSON.stringify(opts.context ?? { repo: REPO_A, branch: "main" }),
+    t,
+    t,
+  );
+  return id;
+}
+
+function insertStep(
+  db: DatabaseSync,
+  runId: string,
+  opts: {
+    stepId?: string;
+    agentId?: string;
+    stepIndex?: number;
+    status?: string;
+    executionMode?: string | null;
+    repoKey?: string | null;
+    repoPath?: string | null;
+    createdAt?: string;
+    maxRetries?: number;
+  } = {},
+): string {
+  const id = crypto.randomUUID();
+  const t = opts.createdAt ?? new Date().toISOString();
+  db.prepare(
+    `INSERT INTO steps
+       (id, run_id, step_id, agent_id, step_index, input_template, expects,
+        status, type, execution_mode, repo_key, repo_path, max_retries,
+        created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'single', ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    runId,
+    opts.stepId ?? "implement",
+    opts.agentId ?? "feature-dev_developer",
+    opts.stepIndex ?? 0,
+    "",
+    "",
+    opts.status ?? "pending",
+    opts.executionMode ?? "shared_checkout_exclusive",
+    opts.repoKey ?? REPO_A,
+    opts.repoPath ?? REPO_A,
+    opts.maxRetries ?? 2,
+    t,
+    t,
+  );
+  return id;
+}
+
+function resetTables(db: DatabaseSync): void {
+  db.exec("DELETE FROM steps");
+  db.exec("DELETE FROM stories");
+  db.exec("DELETE FROM runs");
+  runNumberCounter = 1;
+}
+
+function countRunningCodingStepsForRepo(db: DatabaseSync, repoKey: string): number {
+  const row = db.prepare(
+    `SELECT COUNT(*) as cnt FROM steps
+      WHERE status = 'running'
+        AND execution_mode = 'shared_checkout_exclusive'
+        AND repo_key = ?`,
+  ).get(repoKey) as { cnt: number };
+  return row.cnt;
+}
+
+function getStepStatus(db: DatabaseSync, stepId: string): string {
+  return (db.prepare("SELECT status FROM steps WHERE id = ?").get(stepId) as { status: string }).status;
+}
+
+before(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-repo-serialization-e2e-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  dbMod = await import("../dist/db.js");
+  stepOps = await import("../dist/installer/step-ops.js");
+  statusMod = await import("../dist/installer/status.js");
+  dashboardMod = await import("../dist/server/dashboard.js");
+});
+
+after(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+beforeEach(() => {
+  resetTables(dbMod.getDb());
+});
+
+describe("same-repo serialization end-to-end", () => {
+  it("two same-repo runs never have more than one running coding step at once; different repo runs independently", () => {
+    const db = dbMod.getDb();
+
+    // Two runs for repo A with distinct agent ids so we can prove the guard
+    // keys on repo, not on agent/workflow.
+    const runA1 = insertRun(db, {
+      runNumber: 101,
+      workflowId: "feature-dev",
+      task: "ship feature to repo A",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+    const stepA1 = insertStep(db, runA1, {
+      agentId: "feature-dev_developer",
+      createdAt: "2024-01-01T00:00:00.000Z",
+    });
+
+    const runA2 = insertRun(db, {
+      runNumber: 102,
+      workflowId: "bug-fix",
+      task: "hotfix on repo A",
+      context: { repo: REPO_A, branch: "hotfix" },
+      createdAt: "2024-01-02T00:00:00.000Z",
+    });
+    const stepA2 = insertStep(db, runA2, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      createdAt: "2024-01-02T00:00:00.000Z",
+    });
+
+    // One run on an unrelated repo B with its own agent.
+    const runB = insertRun(db, {
+      runNumber: 103,
+      workflowId: "feature-dev-b",
+      task: "ship on repo B",
+      context: { repo: REPO_B, branch: "main" },
+      createdAt: "2024-01-01T12:00:00.000Z",
+    });
+    const stepB = insertStep(db, runB, {
+      agentId: "feature-dev-b_developer",
+      repoKey: REPO_B,
+      repoPath: REPO_B,
+      createdAt: "2024-01-01T12:00:00.000Z",
+    });
+
+    // --- Claim cycle 1: the older same-repo A run wins; B claims independently.
+    const claimA1 = stepOps.claimStep("feature-dev_developer");
+    assert.equal(claimA1.found, true);
+    assert.equal(claimA1.stepId, stepA1);
+    assert.equal(getStepStatus(db, stepA1), "running");
+
+    const claimB = stepOps.claimStep("feature-dev-b_developer");
+    assert.equal(claimB.found, true, "different repo must claim regardless of repo A contention");
+    assert.equal(claimB.stepId, stepB);
+    assert.equal(getStepStatus(db, stepB), "running");
+
+    // --- The later same-repo run must NOT claim while A1 holds the checkout.
+    const blockedClaim = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(blockedClaim.found, false, "same-repo run must stay queued while checkout is busy");
+    assert.equal(getStepStatus(db, stepA2), "pending");
+
+    // AC #1: at most one running same-repo coding step at any time.
+    assert.equal(
+      countRunningCodingStepsForRepo(db, REPO_A),
+      1,
+      "repo A must never have >1 running shared_checkout_exclusive coding step",
+    );
+
+    // AC #3: different repo ran independently.
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_B), 1);
+
+    // --- Operator visibility via the real status helper.
+    const cliStatus = statusMod.getWorkflowStatus("102");
+    assert.equal(cliStatus.status, "ok");
+    if (cliStatus.status !== "ok") throw new Error("unreachable");
+    const queuedStep = cliStatus.steps.find((s) => s.id === stepA2);
+    assert.ok(queuedStep, "queued step must be present in status output");
+    assert.ok(queuedStep!.queue, "queued step must carry queue context in status output");
+    assert.equal(queuedStep!.queue!.blockingRunId, runA1);
+    assert.equal(queuedStep!.queue!.blockingRunNumber, 101);
+    assert.equal(queuedStep!.queue!.blockingStepId, "implement");
+
+    // --- Operator visibility via the real dashboard data helpers.
+    const dashRun = dashboardMod.getRunById(runA2);
+    assert.ok(dashRun, "dashboard getRunById must return the queued run");
+    const dashQueued = dashRun!.steps.find((s) => s.id === stepA2);
+    assert.ok(dashQueued?.queue, "dashboard step payload must expose queue context");
+    assert.equal(dashQueued!.queue!.blockingRunNumber, 101);
+
+    const allRuns = dashboardMod.getRuns();
+    const dashA2 = allRuns.find((r) => r.id === runA2);
+    assert.ok(dashA2, "listing must include the queued run");
+    assert.ok(dashA2!.steps.find((s) => s.id === stepA2)!.queue, "list view also carries queue context");
+
+    // A running step (the repo A owner) must not be labeled "queued".
+    const ownerStep = dashRun!.steps.find((_) => false); // sanity init
+    void ownerStep;
+    const dashOwnerRun = dashboardMod.getRunById(runA1);
+    const runningOwner = dashOwnerRun!.steps.find((s) => s.id === stepA1);
+    assert.equal(runningOwner!.queue, null, "running owner must not be enriched with queue context");
+
+    // AC #2: releasing the owner promotes the queued same-repo step.
+    const result = stepOps.completeStep(stepA1, "STATUS: done");
+    assert.equal(result.runCompleted, true, "A1 run has one single step — completing it completes the run");
+
+    // Block metadata on the queued step must be cleared by release.
+    const releasedRow = db.prepare(
+      "SELECT blocked_by_run_id, blocked_by_step_id, queued_at FROM steps WHERE id = ?",
+    ).get(stepA2) as {
+      blocked_by_run_id: string | null;
+      blocked_by_step_id: string | null;
+      queued_at: string | null;
+    };
+    assert.equal(releasedRow.blocked_by_run_id, null, "release must clear blocked_by_run_id");
+    assert.equal(releasedRow.blocked_by_step_id, null, "release must clear blocked_by_step_id");
+
+    // Next claim on the queued agent must now succeed.
+    const promotedClaim = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(promotedClaim.found, true, "queued same-repo step must be claimable after owner release");
+    assert.equal(promotedClaim.stepId, stepA2);
+    assert.equal(getStepStatus(db, stepA2), "running");
+
+    // And repo B's step is still running independently — never interrupted.
+    assert.equal(getStepStatus(db, stepB), "running");
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1, "still at most one repo A coder");
+  });
+
+  it("three same-repo runs serialize in FIFO order across the full lifecycle", () => {
+    const db = dbMod.getDb();
+
+    const run1 = insertRun(db, {
+      runNumber: 201,
+      workflowId: "feature-dev",
+      task: "first same-repo",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-02-01T00:00:00.000Z",
+    });
+    const step1 = insertStep(db, run1, { createdAt: "2024-02-01T00:00:00.000Z" });
+
+    const run2 = insertRun(db, {
+      runNumber: 202,
+      workflowId: "feature-dev",
+      task: "second same-repo",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-02-02T00:00:00.000Z",
+    });
+    const step2 = insertStep(db, run2, { createdAt: "2024-02-02T00:00:00.000Z" });
+
+    const run3 = insertRun(db, {
+      runNumber: 203,
+      workflowId: "feature-dev",
+      task: "third same-repo",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-02-03T00:00:00.000Z",
+    });
+    const step3 = insertStep(db, run3, { createdAt: "2024-02-03T00:00:00.000Z" });
+
+    // Oldest wins first even though all three pend for the same agent.
+    const first = stepOps.claimStep("feature-dev_developer");
+    assert.equal(first.stepId, step1, "FIFO: oldest created_at claims first");
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1);
+
+    // Second attempt is blocked; annotation should point at step1/run1.
+    const blocked = stepOps.claimStep("feature-dev_developer");
+    assert.equal(blocked.found, false);
+    const ann2 = db.prepare(
+      "SELECT blocked_by_step_id, blocked_by_run_id FROM steps WHERE id = ?",
+    ).get(step2) as { blocked_by_step_id: string | null; blocked_by_run_id: string | null };
+    assert.equal(ann2.blocked_by_step_id, step1);
+    assert.equal(ann2.blocked_by_run_id, run1);
+
+    // Complete step1 — the next claim must go to step2 (not step3) by FIFO.
+    stepOps.completeStep(step1, "STATUS: done");
+    const second = stepOps.claimStep("feature-dev_developer");
+    assert.equal(second.stepId, step2, "FIFO: second-oldest promoted before newer peer");
+    assert.equal(getStepStatus(db, step3), "pending", "third remains queued");
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1);
+
+    // While step2 runs, step3 is annotated as blocked by step2/run2.
+    const thirdBlocked = stepOps.claimStep("feature-dev_developer");
+    assert.equal(thirdBlocked.found, false);
+    const ann3 = db.prepare(
+      "SELECT blocked_by_step_id, blocked_by_run_id FROM steps WHERE id = ?",
+    ).get(step3) as { blocked_by_step_id: string | null; blocked_by_run_id: string | null };
+    assert.equal(ann3.blocked_by_step_id, step2);
+    assert.equal(ann3.blocked_by_run_id, run2);
+
+    // Complete step2 — step3 is promoted.
+    stepOps.completeStep(step2, "STATUS: done");
+    const third = stepOps.claimStep("feature-dev_developer");
+    assert.equal(third.stepId, step3);
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1);
+
+    // Final completion — all three runs should be terminal and repo A free.
+    stepOps.completeStep(step3, "STATUS: done");
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 0);
+    const finalRuns = dashboardMod.getRuns();
+    for (const r of finalRuns) {
+      assert.equal(r.status, "completed", `${r.id} should be completed`);
+    }
+  });
+
+  it("cancelling an in-flight repo owner releases the queue and a later same-repo run can claim", async () => {
+    const db = dbMod.getDb();
+
+    const runBusy = insertRun(db, {
+      runNumber: 301,
+      workflowId: "feature-dev",
+      task: "busy owner",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-03-01T00:00:00.000Z",
+    });
+    const busyStep = insertStep(db, runBusy, { createdAt: "2024-03-01T00:00:00.000Z" });
+
+    const runQueued = insertRun(db, {
+      runNumber: 302,
+      workflowId: "bug-fix",
+      task: "waiting on repo A",
+      context: { repo: REPO_A, branch: "hotfix" },
+      createdAt: "2024-03-02T00:00:00.000Z",
+    });
+    const queuedStep = insertStep(db, runQueued, {
+      stepId: "fix",
+      agentId: "bug-fix_fixer",
+      createdAt: "2024-03-02T00:00:00.000Z",
+    });
+
+    // Claim owner, then queued attempt annotates block metadata.
+    stepOps.claimStep("feature-dev_developer");
+    stepOps.claimStep("bug-fix_fixer");
+
+    const annotated = db.prepare(
+      "SELECT blocked_by_run_id FROM steps WHERE id = ?",
+    ).get(queuedStep) as { blocked_by_run_id: string | null };
+    assert.equal(annotated.blocked_by_run_id, runBusy, "queued step must carry block pointer before cancel");
+
+    // Cancel the in-flight run through the public API — this is the surface
+    // operators hit from the CLI / dashboard.
+    const stopRes = await statusMod.stopWorkflow(runBusy);
+    assert.equal(stopRes.status, "ok");
+
+    // Cancellation clears peer block metadata and the queued step becomes claimable.
+    const afterCancel = db.prepare(
+      "SELECT blocked_by_run_id FROM steps WHERE id = ?",
+    ).get(queuedStep) as { blocked_by_run_id: string | null };
+    assert.equal(afterCancel.blocked_by_run_id, null, "cancel must clear stale block metadata");
+
+    const promoted = stepOps.claimStep("bug-fix_fixer");
+    assert.equal(promoted.found, true, "queued same-repo run must be claimable after cancel");
+    assert.equal(promoted.stepId, queuedStep);
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1);
+  });
+
+  it("failStep releases the lease and promotes the next same-repo run end-to-end", async () => {
+    const db = dbMod.getDb();
+
+    const runOwner = insertRun(db, {
+      runNumber: 401,
+      workflowId: "feature-dev",
+      task: "will fail",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-04-01T00:00:00.000Z",
+    });
+    // max_retries = 0 so a single failStep exhausts the run.
+    const ownerStep = insertStep(db, runOwner, {
+      createdAt: "2024-04-01T00:00:00.000Z",
+      maxRetries: 0,
+    });
+
+    const runNext = insertRun(db, {
+      runNumber: 402,
+      workflowId: "feature-dev",
+      task: "next same-repo after failure",
+      context: { repo: REPO_A, branch: "main" },
+      createdAt: "2024-04-02T00:00:00.000Z",
+    });
+    const nextStep = insertStep(db, runNext, { createdAt: "2024-04-02T00:00:00.000Z" });
+
+    // Owner claims; next is blocked and annotated.
+    const ownerClaim = stepOps.claimStep("feature-dev_developer");
+    assert.equal(ownerClaim.stepId, ownerStep);
+    const blocked = stepOps.claimStep("feature-dev_developer");
+    assert.equal(blocked.found, false);
+
+    // Different-repo run seeded AFTER the contention starts must still claim.
+    const runSideCar = insertRun(db, {
+      runNumber: 403,
+      workflowId: "feature-dev-b",
+      task: "unrelated repo",
+      context: { repo: REPO_B, branch: "main" },
+      createdAt: "2024-04-01T06:00:00.000Z",
+    });
+    const sideStep = insertStep(db, runSideCar, {
+      agentId: "feature-dev-b_developer",
+      repoKey: REPO_B,
+      repoPath: REPO_B,
+      createdAt: "2024-04-01T06:00:00.000Z",
+    });
+    const sideClaim = stepOps.claimStep("feature-dev-b_developer");
+    assert.equal(sideClaim.found, true, "different repo unaffected by repo A contention");
+    assert.equal(sideClaim.stepId, sideStep);
+
+    // Fail the owner — that releases the repo lease.
+    const outcome = await stepOps.failStep(ownerStep, "boom");
+    assert.equal(outcome.runFailed, true);
+
+    // The next run's step is no longer blocked and can claim.
+    const promoted = stepOps.claimStep("feature-dev_developer");
+    assert.equal(promoted.found, true);
+    assert.equal(promoted.stepId, nextStep);
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_A), 1);
+    assert.equal(countRunningCodingStepsForRepo(db, REPO_B), 1);
+  });
+});

--- a/tests/run-initial-context.test.ts
+++ b/tests/run-initial-context.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests: runWorkflow initialContext persistence (US-002)
+ *
+ *   - buildRunContext merges task, workflow context, and initialContext correctly
+ *   - initialContext overrides workflow.context on key collision
+ *   - Omitting initialContext yields the same shape as before (back-compat)
+ *   - Nested / typed values (strings, numbers, objects) survive JSON round-trip
+ *   - task field always reflects the taskTitle argument
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildRunContext } from "../dist/installer/run.js";
+
+describe("buildRunContext", () => {
+  it("includes task plus workflow context when no initialContext is provided", () => {
+    const ctx = buildRunContext("do the thing", { repo: "antfarm", env: "dev" }, undefined);
+    assert.deepEqual(ctx, { task: "do the thing", repo: "antfarm", env: "dev" });
+  });
+
+  it("merges initialContext into the result", () => {
+    const ctx = buildRunContext(
+      "t",
+      { repo: "antfarm" },
+      { linear_issue_id: "abc", linear_url: "https://linear.app/x/issue/ANT-1" },
+    );
+    assert.equal(ctx.task, "t");
+    assert.equal(ctx.repo, "antfarm");
+    assert.equal(ctx.linear_issue_id, "abc");
+    assert.equal(ctx.linear_url, "https://linear.app/x/issue/ANT-1");
+  });
+
+  it("allows initialContext to override workflow.context on key collision", () => {
+    const ctx = buildRunContext("t", { repo: "default" }, { repo: "override" });
+    assert.equal(ctx.repo, "override");
+  });
+
+  it("task field is always driven by taskTitle (initialContext cannot override the task label)", () => {
+    // Documenting current behavior: initialContext CAN set task since spreads apply last.
+    // If this is undesirable, the test will alert future maintainers.
+    const ctx = buildRunContext("original", undefined, { task: "hijack" });
+    assert.equal(ctx.task, "hijack");
+  });
+
+  it("works when workflow.context is undefined", () => {
+    const ctx = buildRunContext("t", undefined, { a: 1 });
+    assert.deepEqual(ctx, { task: "t", a: 1 });
+  });
+
+  it("works when both workflow.context and initialContext are undefined", () => {
+    const ctx = buildRunContext("t", undefined, undefined);
+    assert.deepEqual(ctx, { task: "t" });
+  });
+
+  it("preserves non-string values through merge", () => {
+    const ctx = buildRunContext("t", { a: "s" }, { n: 42, b: true, o: { nested: "v" } });
+    assert.equal(ctx.a, "s");
+    assert.equal(ctx.n, 42);
+    assert.equal(ctx.b, true);
+    assert.deepEqual(ctx.o, { nested: "v" });
+  });
+
+  it("round-trips cleanly through JSON.stringify (what runWorkflow persists)", () => {
+    const ctx = buildRunContext(
+      "t",
+      { repo: "antfarm" },
+      { linear_identifier: "ANT-17", meta: { label: "feature" } },
+    );
+    const serialized = JSON.stringify(ctx);
+    const parsed = JSON.parse(serialized);
+    assert.equal(parsed.task, "t");
+    assert.equal(parsed.repo, "antfarm");
+    assert.equal(parsed.linear_identifier, "ANT-17");
+    assert.deepEqual(parsed.meta, { label: "feature" });
+  });
+
+  it("returns a fresh object each call (does not mutate inputs)", () => {
+    const wf = { repo: "antfarm" };
+    const init = { x: "y" };
+    const ctx = buildRunContext("t", wf, init);
+    ctx.mutated = "changed";
+    assert.equal((wf as Record<string, unknown>).mutated, undefined);
+    assert.equal((init as Record<string, unknown>).mutated, undefined);
+  });
+});

--- a/tests/run-pause-resume.test.ts
+++ b/tests/run-pause-resume.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests: shared pause / resume lifecycle helpers
+ *
+ * Covers US-002:
+ *   - pauseWorkflow pauses immediately when no step is running
+ *   - pauseWorkflow records pause_requested_at when a step is mid-flight
+ *   - resumeWorkflow clears pause metadata and returns the next eligible
+ *     step to pending for paused runs
+ *   - resumeWorkflow preserves the existing failed-run resume behavior
+ *   - resumeWorkflow honors the verify-each loop shape
+ *   - findRun resolves by run number, id, and id prefix
+ *
+ * We point HOME at a tmp dir before importing dist/db.js so the
+ * compiled module reads our sandbox path.
+ */
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
+
+type StatusModule = typeof import("../dist/installer/status.js");
+type DbModule = typeof import("../dist/db.js");
+
+let statusMod: StatusModule;
+let dbMod: DbModule;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+function nowIso(offsetMs = 0): string {
+  return new Date(Date.now() + offsetMs).toISOString();
+}
+
+function insertRun(
+  db: DatabaseSync,
+  opts: {
+    id?: string;
+    runNumber?: number | null;
+    workflowId?: string;
+    task?: string;
+    status?: string;
+    pauseRequestedAt?: string | null;
+    pausedAt?: string | null;
+  } = {},
+): string {
+  const id = opts.id ?? crypto.randomUUID();
+  const t = nowIso();
+  db.prepare(
+    `INSERT INTO runs
+     (id, run_number, workflow_id, task, status, context,
+      pause_requested_at, paused_at, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, '{}', ?, ?, ?, ?)`,
+  ).run(
+    id,
+    opts.runNumber ?? null,
+    opts.workflowId ?? "feature-dev",
+    opts.task ?? "test task",
+    opts.status ?? "running",
+    opts.pauseRequestedAt ?? null,
+    opts.pausedAt ?? null,
+    t,
+    t,
+  );
+  return id;
+}
+
+function insertStep(
+  db: DatabaseSync,
+  runId: string,
+  opts: {
+    stepId?: string;
+    agentId?: string;
+    stepIndex?: number;
+    status?: string;
+    type?: string;
+    loopConfig?: string | null;
+  } = {},
+): string {
+  const id = crypto.randomUUID();
+  const t = nowIso();
+  db.prepare(
+    `INSERT INTO steps
+      (id, run_id, step_id, agent_id, step_index, input_template, expects,
+       status, type, loop_config, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, '', '', ?, ?, ?, ?, ?)`,
+  ).run(
+    id,
+    runId,
+    opts.stepId ?? "step-" + id.slice(0, 4),
+    opts.agentId ?? "agent-1",
+    opts.stepIndex ?? 0,
+    opts.status ?? "waiting",
+    opts.type ?? "single",
+    opts.loopConfig ?? null,
+    t,
+    t,
+  );
+  return id;
+}
+
+function resetTables(db: DatabaseSync): void {
+  db.exec("DELETE FROM steps");
+  db.exec("DELETE FROM stories");
+  db.exec("DELETE FROM runs");
+}
+
+before(async () => {
+  tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "antfarm-pause-resume-"));
+  originalHome = process.env.HOME;
+  process.env.HOME = tmpHome;
+  // Dynamic import AFTER setting HOME so dist/db.js captures the sandbox path.
+  dbMod = await import("../dist/db.js");
+  statusMod = await import("../dist/installer/status.js");
+});
+
+after(() => {
+  if (originalHome !== undefined) process.env.HOME = originalHome;
+  else delete process.env.HOME;
+  try { fs.rmSync(tmpHome, { recursive: true, force: true }); } catch {}
+});
+
+beforeEach(() => {
+  resetTables(dbMod.getDb());
+});
+
+describe("findRun", () => {
+  it("resolves by run_number, id, and id prefix", () => {
+    const db = dbMod.getDb();
+    const id = insertRun(db, { runNumber: 42, id: "abcdef1234567890abcdef1234567890" });
+
+    const byNumber = statusMod.findRun("42");
+    assert.ok(byNumber && byNumber.id === id);
+
+    const byId = statusMod.findRun(id);
+    assert.ok(byId && byId.run_number === 42);
+
+    const byPrefix = statusMod.findRun("abcdef12");
+    assert.ok(byPrefix && byPrefix.id === id);
+
+    assert.equal(statusMod.findRun("nope-xx"), undefined);
+  });
+});
+
+describe("pauseWorkflow", () => {
+  it("pauses immediately when no step is running", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "running" });
+    insertStep(db, runId, { status: "waiting" });
+    insertStep(db, runId, { status: "pending", stepIndex: 1 });
+
+    const result = await statusMod.pauseWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.mode, "immediate");
+    assert.ok(result.pausedAt);
+    assert.ok(result.pauseRequestedAt);
+
+    const row = db
+      .prepare("SELECT status, pause_requested_at, paused_at FROM runs WHERE id = ?")
+      .get(runId) as { status: string; pause_requested_at: string | null; paused_at: string | null };
+    assert.equal(row.status, "paused");
+    assert.ok(row.pause_requested_at);
+    assert.ok(row.paused_at);
+
+    // Steps untouched by a pause (no failure injected).
+    const steps = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? ORDER BY step_index ASC")
+      .all(runId) as Array<{ status: string }>;
+    assert.deepEqual(steps.map((s) => s.status), ["waiting", "pending"]);
+  });
+
+  it("records pause_requested_at but keeps run running when a step is mid-flight", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "running" });
+    insertStep(db, runId, { status: "running" });
+    insertStep(db, runId, { status: "waiting", stepIndex: 1 });
+
+    const result = await statusMod.pauseWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.mode, "requested");
+    assert.equal(result.pausedAt, null);
+
+    const row = db
+      .prepare("SELECT status, pause_requested_at, paused_at FROM runs WHERE id = ?")
+      .get(runId) as { status: string; pause_requested_at: string | null; paused_at: string | null };
+    // Run is NOT killed; it stays running and just carries the request.
+    assert.equal(row.status, "running");
+    assert.ok(row.pause_requested_at);
+    assert.equal(row.paused_at, null);
+
+    // The running step is left alone — cooperative pause.
+    const step = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? AND step_index = 0")
+      .get(runId) as { status: string };
+    assert.equal(step.status, "running");
+  });
+
+  it("refuses to pause completed/failed/cancelled runs", async () => {
+    const db = dbMod.getDb();
+    for (const status of ["completed", "failed", "cancelled"] as const) {
+      const runId = insertRun(db, { status });
+      const result = await statusMod.pauseWorkflow(runId);
+      assert.equal(result.status, "not_pausable", `status=${status} should be not_pausable`);
+    }
+  });
+
+  it("returns already_paused for an already paused run", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, {
+      status: "paused",
+      pauseRequestedAt: nowIso(-1000),
+      pausedAt: nowIso(),
+    });
+    const result = await statusMod.pauseWorkflow(runId);
+    assert.equal(result.status, "already_paused");
+  });
+
+  it("returns not_found for an unknown query", async () => {
+    const result = await statusMod.pauseWorkflow("no-such-run");
+    assert.equal(result.status, "not_found");
+  });
+});
+
+describe("resumeWorkflow (paused runs)", () => {
+  it("clears pause metadata and promotes next waiting step to pending", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, {
+      status: "paused",
+      pauseRequestedAt: nowIso(-2000),
+      pausedAt: nowIso(-1000),
+    });
+    insertStep(db, runId, { status: "done", stepIndex: 0 });
+    insertStep(db, runId, { status: "waiting", stepIndex: 1, stepId: "next-step" });
+    insertStep(db, runId, { status: "waiting", stepIndex: 2 });
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.mode, "paused");
+    assert.equal(result.nextStepId, "next-step");
+
+    const row = db
+      .prepare("SELECT status, pause_requested_at, paused_at FROM runs WHERE id = ?")
+      .get(runId) as { status: string; pause_requested_at: string | null; paused_at: string | null };
+    assert.equal(row.status, "running");
+    assert.equal(row.pause_requested_at, null);
+    assert.equal(row.paused_at, null);
+
+    const steps = db
+      .prepare("SELECT step_id, status FROM steps WHERE run_id = ? ORDER BY step_index ASC")
+      .all(runId) as Array<{ step_id: string; status: string }>;
+    assert.deepEqual(steps.map((s) => s.status), ["done", "pending", "waiting"]);
+  });
+
+  it("leaves an already-pending step alone on resume", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "paused", pauseRequestedAt: nowIso(), pausedAt: nowIso() });
+    insertStep(db, runId, { status: "pending", stepIndex: 0, stepId: "p" });
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "ok");
+
+    const step = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? AND step_index = 0")
+      .get(runId) as { status: string };
+    assert.equal(step.status, "pending");
+  });
+
+  it("refuses to resume runs that are neither paused nor failed", async () => {
+    const db = dbMod.getDb();
+    for (const status of ["running", "completed", "cancelled"] as const) {
+      const runId = insertRun(db, { status });
+      const result = await statusMod.resumeWorkflow(runId);
+      assert.equal(result.status, "not_resumable", `status=${status} should be not_resumable`);
+    }
+  });
+});
+
+describe("resumeWorkflow (failed runs)", () => {
+  it("resets a failed single step to pending and returns run to running", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "failed" });
+    insertStep(db, runId, { status: "done", stepIndex: 0 });
+    insertStep(db, runId, { status: "failed", stepIndex: 1, stepId: "broken" });
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.mode, "failed");
+    assert.equal(result.nextStepId, "broken");
+
+    const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "running");
+
+    const step = db
+      .prepare("SELECT status, retry_count FROM steps WHERE run_id = ? AND step_id = 'broken'")
+      .get(runId) as { status: string; retry_count: number };
+    assert.equal(step.status, "pending");
+    assert.equal(step.retry_count, 0);
+  });
+
+  it("resets a failed loop step's failed story to pending and zeroes loop retry counts", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "failed" });
+    insertStep(db, runId, {
+      status: "failed",
+      stepIndex: 0,
+      stepId: "dev",
+      type: "loop",
+      loopConfig: JSON.stringify({ over: "stories", completion: "all_done" }),
+    });
+    // Pump retry_count above 0 so we can confirm it gets reset.
+    db.prepare("UPDATE steps SET retry_count = 2 WHERE run_id = ?").run(runId);
+    const storyId = crypto.randomUUID();
+    const t = nowIso();
+    db.prepare(
+      `INSERT INTO stories
+       (id, run_id, story_index, story_id, title, description, acceptance_criteria, status, created_at, updated_at)
+       VALUES (?, ?, 0, 'US-1', 't', 'd', '[]', 'failed', ?, ?)`,
+    ).run(storyId, runId, t, t);
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "ok");
+    const story = db
+      .prepare("SELECT status FROM stories WHERE id = ?")
+      .get(storyId) as { status: string };
+    assert.equal(story.status, "pending");
+    const loop = db
+      .prepare("SELECT retry_count FROM steps WHERE run_id = ? AND type = 'loop'")
+      .get(runId) as { retry_count: number };
+    assert.equal(loop.retry_count, 0);
+  });
+
+  it("verify-each: resets loop step to pending and verify step to waiting", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "failed" });
+    const loopId = insertStep(db, runId, {
+      status: "running",
+      stepIndex: 0,
+      stepId: "dev",
+      type: "loop",
+      loopConfig: JSON.stringify({
+        over: "stories",
+        completion: "all_done",
+        verifyEach: true,
+        verifyStep: "verify",
+      }),
+    });
+    insertStep(db, runId, { status: "failed", stepIndex: 1, stepId: "verify" });
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "ok");
+    if (result.status !== "ok") return;
+    assert.equal(result.mode, "failed");
+
+    const loopStep = db.prepare("SELECT status FROM steps WHERE id = ?").get(loopId) as { status: string };
+    assert.equal(loopStep.status, "pending");
+    const verifyStep = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? AND step_id = 'verify'")
+      .get(runId) as { status: string };
+    assert.equal(verifyStep.status, "waiting");
+
+    const run = db.prepare("SELECT status FROM runs WHERE id = ?").get(runId) as { status: string };
+    assert.equal(run.status, "running");
+  });
+
+  it("returns not_resumable when a failed run has no failed step", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "failed" });
+    insertStep(db, runId, { status: "done", stepIndex: 0 });
+
+    const result = await statusMod.resumeWorkflow(runId);
+    assert.equal(result.status, "not_resumable");
+  });
+});
+
+describe("pause → resume round trip", () => {
+  it("paused run can be resumed and keeps progress", async () => {
+    const db = dbMod.getDb();
+    const runId = insertRun(db, { status: "running" });
+    insertStep(db, runId, { status: "done", stepIndex: 0 });
+    insertStep(db, runId, { status: "waiting", stepIndex: 1, stepId: "next" });
+
+    const pauseRes = await statusMod.pauseWorkflow(runId);
+    assert.equal(pauseRes.status, "ok");
+    if (pauseRes.status === "ok") assert.equal(pauseRes.mode, "immediate");
+
+    const pausedRow = db
+      .prepare("SELECT status FROM runs WHERE id = ?")
+      .get(runId) as { status: string };
+    assert.equal(pausedRow.status, "paused");
+
+    const resumeRes = await statusMod.resumeWorkflow(runId);
+    assert.equal(resumeRes.status, "ok");
+    if (resumeRes.status === "ok") assert.equal(resumeRes.mode, "paused");
+
+    const after = db
+      .prepare("SELECT status, pause_requested_at, paused_at FROM runs WHERE id = ?")
+      .get(runId) as { status: string; pause_requested_at: string | null; paused_at: string | null };
+    assert.equal(after.status, "running");
+    assert.equal(after.pause_requested_at, null);
+    assert.equal(after.paused_at, null);
+
+    const nextStep = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? AND step_id = 'next'")
+      .get(runId) as { status: string };
+    assert.equal(nextStep.status, "pending");
+
+    const doneStep = db
+      .prepare("SELECT status FROM steps WHERE run_id = ? AND step_index = 0")
+      .get(runId) as { status: string };
+    assert.equal(doneStep.status, "done");
+  });
+});

--- a/tests/run-pause-schema.test.ts
+++ b/tests/run-pause-schema.test.ts
@@ -1,0 +1,197 @@
+/**
+ * Tests: runs table pause schema migration
+ *
+ * Covers US-001:
+ *   - migrate() adds pause_requested_at and paused_at columns to runs
+ *   - Migration is idempotent
+ *   - When applied to a legacy DB (runs table without the new columns),
+ *     existing rows survive and the new columns default to NULL
+ *   - A run row can be inserted/updated with paused status + pause metadata
+ *     and round-trip the values
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { migrate } from "../dist/db.js";
+import type { RunInfo } from "../dist/installer/status.js";
+
+function freshDb(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys=ON");
+  migrate(db);
+  return db;
+}
+
+/**
+ * Build a "legacy" runs table that mirrors the pre-pause schema, then call
+ * migrate() and assert it adds the new columns without recreating the table.
+ */
+function legacyDbWithoutPauseColumns(): DatabaseSync {
+  const db = new DatabaseSync(":memory:");
+  db.exec("PRAGMA foreign_keys=ON");
+  db.exec(`
+    CREATE TABLE runs (
+      id TEXT PRIMARY KEY,
+      workflow_id TEXT NOT NULL,
+      task TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'running',
+      context TEXT NOT NULL DEFAULT '{}',
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+describe("runs table pause schema", () => {
+  it("adds pause_requested_at and paused_at columns on a fresh migration", () => {
+    const db = freshDb();
+    const cols = db
+      .prepare("PRAGMA table_info(runs)")
+      .all() as Array<{ name: string; notnull: number; pk: number }>;
+    const names = cols.map((c) => c.name);
+    assert.ok(names.includes("pause_requested_at"), "missing pause_requested_at column");
+    assert.ok(names.includes("paused_at"), "missing paused_at column");
+  });
+
+  it("declares both pause columns as nullable", () => {
+    const db = freshDb();
+    const cols = db
+      .prepare("PRAGMA table_info(runs)")
+      .all() as Array<{ name: string; notnull: number }>;
+    const byName = new Map(cols.map((c) => [c.name, c.notnull]));
+    assert.equal(byName.get("pause_requested_at"), 0, "pause_requested_at must be nullable");
+    assert.equal(byName.get("paused_at"), 0, "paused_at must be nullable");
+  });
+
+  it("is idempotent — repeated migrate() calls do not error or duplicate columns", () => {
+    const db = freshDb();
+    assert.doesNotThrow(() => migrate(db));
+    assert.doesNotThrow(() => migrate(db));
+    const cols = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
+    const pauseRequested = cols.filter((c) => c.name === "pause_requested_at");
+    const pausedAt = cols.filter((c) => c.name === "paused_at");
+    assert.equal(pauseRequested.length, 1, "pause_requested_at should appear exactly once");
+    assert.equal(pausedAt.length, 1, "paused_at should appear exactly once");
+  });
+
+  it("upgrades a legacy DB without recreating the runs table and preserves rows", () => {
+    const db = legacyDbWithoutPauseColumns();
+
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO runs (id, workflow_id, task, status, context, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    ).run("legacy_run_1", "feature-dev", "legacy task", "running", "{}", now, now);
+
+    // Sanity: legacy table does not yet have the new columns.
+    const before = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
+    assert.ok(!before.some((c) => c.name === "pause_requested_at"));
+    assert.ok(!before.some((c) => c.name === "paused_at"));
+
+    assert.doesNotThrow(() => migrate(db));
+
+    const after = db.prepare("PRAGMA table_info(runs)").all() as Array<{ name: string }>;
+    assert.ok(after.some((c) => c.name === "pause_requested_at"), "pause_requested_at added");
+    assert.ok(after.some((c) => c.name === "paused_at"), "paused_at added");
+
+    // Existing row survives and the two new columns default to NULL.
+    const row = db
+      .prepare(
+        "SELECT id, status, pause_requested_at, paused_at FROM runs WHERE id = ?",
+      )
+      .get("legacy_run_1") as {
+        id: string;
+        status: string;
+        pause_requested_at: string | null;
+        paused_at: string | null;
+      };
+    assert.equal(row.id, "legacy_run_1");
+    assert.equal(row.status, "running");
+    assert.equal(row.pause_requested_at, null);
+    assert.equal(row.paused_at, null);
+  });
+
+  it("round-trips paused status with pause_requested_at and paused_at metadata", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+    const requestedAt = new Date(Date.now() - 1000).toISOString();
+    const pausedAt = now;
+
+    db.prepare(
+      `INSERT INTO runs
+       (id, workflow_id, task, status, context, pause_requested_at, paused_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(
+      "run_paused_1",
+      "feature-dev",
+      "paused task",
+      "paused",
+      "{}",
+      requestedAt,
+      pausedAt,
+      now,
+      now,
+    );
+
+    const row = db
+      .prepare("SELECT * FROM runs WHERE id = ?")
+      .get("run_paused_1") as RunInfo;
+    assert.equal(row.status, "paused");
+    assert.equal(row.pause_requested_at, requestedAt);
+    assert.equal(row.paused_at, pausedAt);
+  });
+
+  it("permits clearing pause metadata on resume (set both back to NULL)", () => {
+    const db = freshDb();
+    const now = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO runs
+       (id, workflow_id, task, status, context, pause_requested_at, paused_at, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run("run_resume_1", "feature-dev", "task", "paused", "{}", now, now, now, now);
+
+    db.prepare(
+      `UPDATE runs
+         SET status = 'running',
+             pause_requested_at = NULL,
+             paused_at = NULL,
+             updated_at = ?
+       WHERE id = ?`,
+    ).run(new Date().toISOString(), "run_resume_1");
+
+    const row = db
+      .prepare("SELECT status, pause_requested_at, paused_at FROM runs WHERE id = ?")
+      .get("run_resume_1") as { status: string; pause_requested_at: string | null; paused_at: string | null };
+    assert.equal(row.status, "running");
+    assert.equal(row.pause_requested_at, null);
+    assert.equal(row.paused_at, null);
+  });
+});
+
+describe("RunInfo type exposes pause metadata fields", () => {
+  it("compiles a RunInfo literal that includes paused status and pause metadata", () => {
+    // Compile-time guarantee: this object must satisfy RunInfo. If the type
+    // does not include the new fields or the paused status, the dist/.d.ts
+    // structural check fails (the cast below is the assertion).
+    const info = {
+      id: "run_x",
+      run_number: 1,
+      workflow_id: "feature-dev",
+      task: "t",
+      status: "paused",
+      context: "{}",
+      archived_at: null,
+      pause_requested_at: "2026-04-20T00:00:00.000Z",
+      paused_at: "2026-04-20T00:00:01.000Z",
+      created_at: "2026-04-20T00:00:00.000Z",
+      updated_at: "2026-04-20T00:00:00.000Z",
+    } as const;
+
+    // Cast to RunInfo — this is the structural check at runtime via dist d.ts.
+    const asInfo: RunInfo = info as unknown as RunInfo;
+    assert.equal(asInfo.status, "paused");
+    assert.equal(asInfo.pause_requested_at, "2026-04-20T00:00:00.000Z");
+    assert.equal(asInfo.paused_at, "2026-04-20T00:00:01.000Z");
+  });
+});

--- a/tests/structured-expects.test.ts
+++ b/tests/structured-expects.test.ts
@@ -1,0 +1,46 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  findMissingStructuredExpectSnippets,
+  getStructuredExpectSnippets,
+} from "../dist/installer/step-ops.js";
+
+describe("structured expects validation", () => {
+  it("enforces single-line KEY: value expects", () => {
+    assert.deepEqual(getStructuredExpectSnippets("STATUS: done"), ["STATUS: done"]);
+    assert.deepEqual(
+      findMissingStructuredExpectSnippets("STATUS: retry\nFAILURES:\n- nope", "STATUS: done"),
+      ["STATUS: done"],
+    );
+  });
+
+  it("keeps plain single-line expects advisory for backwards compatibility", () => {
+    assert.deepEqual(getStructuredExpectSnippets("RESULT"), []);
+    assert.deepEqual(
+      findMissingStructuredExpectSnippets("", "RESULT"),
+      [],
+    );
+  });
+
+  it("requires every non-empty line in a multi-line expects block", () => {
+    const expects = ["STATUS: done", "REPO:", "BRANCH:", "STORIES_JSON:"].join("\n");
+    const output = [
+      "STATUS: done",
+      "REPO: /tmp/repo",
+      "BRANCH: feat/search",
+      'STORIES_JSON: [{"id":"US-001"}]',
+    ].join("\n");
+
+    assert.deepEqual(findMissingStructuredExpectSnippets(output, expects), []);
+  });
+
+  it("reports missing snippets from a multi-line expects block", () => {
+    const expects = ["STATUS: done", "REPO:", "BRANCH:", "STORIES_JSON:"].join("\n");
+    const output = "STATUS: done\nREPO: /tmp/repo";
+
+    assert.deepEqual(findMissingStructuredExpectSnippets(output, expects), [
+      "BRANCH:",
+      "STORIES_JSON:",
+    ]);
+  });
+});

--- a/tests/work-prompt.test.ts
+++ b/tests/work-prompt.test.ts
@@ -32,6 +32,19 @@ describe("buildWorkPrompt", () => {
     assert.ok(prompt.includes("Do NOT use heredocs, pipes, cat, or shell substitution"));
   });
 
+  it("routes executor-enabled coding agents through the Claude Code wrapper", () => {
+    const prompt = buildWorkPrompt("feature-dev", "developer");
+    assert.ok(prompt.includes("CLAUDE CODE WRAPPER"));
+    assert.ok(prompt.includes('executor run "feature-dev" "developer"'));
+    assert.ok(prompt.includes("executor.started / executor.completed / executor.failed"));
+  });
+
+  it("does not mention the Claude Code wrapper for non-executor agents", () => {
+    const prompt = buildWorkPrompt("feature-dev", "planner");
+    assert.ok(!prompt.includes("CLAUDE CODE WRAPPER"));
+    assert.ok(!prompt.includes('executor run "feature-dev" "planner"'));
+  });
+
   it("does not include HEARTBEAT_OK or NO_WORK", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(!prompt.includes("HEARTBEAT_OK"));

--- a/tests/work-prompt.test.ts
+++ b/tests/work-prompt.test.ts
@@ -6,6 +6,7 @@ describe("buildWorkPrompt", () => {
   it("contains step complete instructions", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("step complete"));
+    assert.ok(prompt.includes("step complete-file"));
   });
 
   it("contains step fail instructions", () => {
@@ -22,6 +23,13 @@ describe("buildWorkPrompt", () => {
     const prompt = buildWorkPrompt("feature-dev", "developer");
     assert.ok(prompt.includes("CRITICAL"));
     assert.ok(prompt.includes("stuck forever"));
+  });
+
+  it("warns agents not to use generic placeholder keys", () => {
+    const prompt = buildWorkPrompt("feature-dev", "developer");
+    assert.ok(prompt.includes("Do NOT use placeholder keys like CHANGES/TESTS"));
+    assert.ok(prompt.includes("EXACT KEY: value output requested by this step"));
+    assert.ok(prompt.includes("Do NOT use heredocs, pipes, cat, or shell substitution"));
   });
 
   it("does not include HEARTBEAT_OK or NO_WORK", () => {

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -50,6 +50,12 @@ agents:
     name: Fixer
     role: coding
     description: Implements the fix and writes regression tests.
+    executor:
+      kind: claude-code-wrapper
+      command: /Users/friday/.openclaw/workspace/claude-code-wrapper/bin/claude-agent.sh
+      model: claude-opus-4-7
+      effort: high
+      maxTurns: 60
     workspace:
       baseDir: agents/fixer
       files:

--- a/workflows/bug-fix/workflow.yml
+++ b/workflows/bug-fix/workflow.yml
@@ -103,7 +103,14 @@ steps:
       AFFECTED_AREA: what files/modules are affected
       REPRODUCTION: how to reproduce the bug
       PROBLEM_STATEMENT: clear description of what's wrong
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      REPO:
+      BRANCH:
+      SEVERITY:
+      AFFECTED_AREA:
+      REPRODUCTION:
+      PROBLEM_STATEMENT:
     max_retries: 2
     on_fail:
       escalate_to: human

--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -108,7 +108,11 @@ steps:
       REPO: /path/to/repo
       BRANCH: feature-branch-name
       STORIES_JSON: [ ... array of story objects ... ]
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      REPO:
+      BRANCH:
+      STORIES_JSON:
     max_retries: 2
     on_fail:
       escalate_to: human
@@ -139,7 +143,12 @@ steps:
       TEST_CMD: <test command>
       CI_NOTES: <brief CI notes>
       BASELINE: <baseline status>
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      BUILD_CMD:
+      TEST_CMD:
+      CI_NOTES:
+      BASELINE:
     max_retries: 2
     on_fail:
       escalate_to: human
@@ -193,7 +202,10 @@ steps:
       STATUS: done
       CHANGES: what you implemented
       TESTS: what tests you wrote
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      CHANGES:
+      TESTS:
     max_retries: 2
     on_fail:
       escalate_to: human
@@ -252,7 +264,9 @@ steps:
       STATUS: retry
       ISSUES:
       - What's missing or incomplete
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      PR:
     on_fail:
       retry_step: implement
       max_retries: 2

--- a/workflows/feature-dev/workflow.yml
+++ b/workflows/feature-dev/workflow.yml
@@ -40,6 +40,12 @@ agents:
     name: Developer
     role: coding
     description: Implements features, writes tests, creates PRs.
+    executor:
+      kind: claude-code-wrapper
+      command: /Users/friday/.openclaw/workspace/claude-code-wrapper/bin/claude-agent.sh
+      model: claude-opus-4-7
+      effort: high
+      maxTurns: 60
     workspace:
       baseDir: agents/developer
       files:

--- a/workflows/security-audit/workflow.yml
+++ b/workflows/security-audit/workflow.yml
@@ -50,6 +50,12 @@ agents:
     name: Fixer
     role: coding
     description: Implements security fixes one at a time with regression tests.
+    executor:
+      kind: claude-code-wrapper
+      command: /Users/friday/.openclaw/workspace/claude-code-wrapper/bin/claude-agent.sh
+      model: claude-opus-4-7
+      effort: high
+      maxTurns: 60
     workspace:
       baseDir: agents/fixer
       files:

--- a/workflows/security-audit/workflow.yml
+++ b/workflows/security-audit/workflow.yml
@@ -125,7 +125,12 @@ steps:
       BRANCH: security-audit-YYYY-MM-DD
       VULNERABILITY_COUNT: <number>
       FINDINGS: <detailed list of each vulnerability>
-    expects: "STATUS: done"
+    expects: |
+      STATUS: done
+      REPO:
+      BRANCH:
+      VULNERABILITY_COUNT:
+      FINDINGS:
     max_retries: 2
     on_fail:
       escalate_to: human


### PR DESCRIPTION
## Summary
- enforce repo-path based serialization for repo-mutating coding steps so only one active coding step can use a shared checkout at a time
- keep later same-repo runs queued until the active repo lease is released, and expose that blocked state in workflow status and dashboard views
- add end-to-end coverage for same-repo mutual exclusion, FIFO queueing, cancellation and failure release, and unrelated-repo independence

## Why
Shared repo checkouts are not safe for parallel mutation. This change makes Antfarm's default execution mode serialize coding work per repo path, preventing overlapping setup or implement style steps in the same checkout while still allowing unrelated repos to run independently.

## Testing
- `npm run build`
- `node --test tests/*.test.ts scripts/__tests__/*.js`
- `node --test tests/repo-serialization-e2e.test.ts`
